### PR TITLE
Add CodeQL security scanning and Lighthouse CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - '*.config.*'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - name: Run CodeQL analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,36 @@
+name: Lighthouse CI
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  lighthouse:
+    name: Lighthouse Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Lighthouse
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: |
+            https://detached-node.vercel.app/
+            https://detached-node.vercel.app/posts
+            https://detached-node.vercel.app/about
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+
+      - name: Format results
+        if: always()
+        run: |
+          echo "## Lighthouse Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Audited URLs:" >> $GITHUB_STEP_SUMMARY
+          echo "- https://detached-node.vercel.app/" >> $GITHUB_STEP_SUMMARY
+          echo "- https://detached-node.vercel.app/posts" >> $GITHUB_STEP_SUMMARY
+          echo "- https://detached-node.vercel.app/about" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Full results uploaded as artifacts." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- **CodeQL workflow** (`codeql.yml`): Runs GitHub's CodeQL static analysis for JavaScript/TypeScript on every PR touching `src/` or config files, plus a weekly Monday schedule. Surfaces security vulnerabilities and code quality issues in the Security tab.
- **Lighthouse CI workflow** (`lighthouse.yml`): Runs weekly Lighthouse audits against the production site (homepage, posts listing, about page). Uploads results as artifacts and posts a summary to the workflow run.

## Test plan

- [ ] Verify CodeQL workflow triggers on `workflow_dispatch`
- [ ] Verify Lighthouse workflow triggers on `workflow_dispatch`
- [ ] Confirm CodeQL results appear in the repository Security tab
- [ ] Confirm Lighthouse artifacts are uploaded after a run

🤖 Generated with [Claude Code](https://claude.com/claude-code)