### PR TITLE
Upgrade E2E test triggers and add bundle size analysis

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -9,18 +9,31 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
   PAYLOAD_SECRET: ci-build-secret-not-real
-
-permissions:
-  contents: read
-  pull-requests: write
+  NODE_ENV: production
 
 jobs:
   analyze:
     name: Analyze Bundle
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
 
@@ -35,20 +48,24 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm build
+      - name: Build and capture output
+        run: pnpm build 2>&1 | tee build-output.txt
 
-      - name: Analyze bundle size
+      - name: Report bundle size
         run: |
           echo "## Bundle Size Report" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Route Sizes" >> $GITHUB_STEP_SUMMARY
+          echo "### Route Sizes (from next build)" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          find .next -name '*.js' -path '*/pages/*' -o -name '*.js' -path '*/app/*' | head -50 | while read f; do
-            size=$(wc -c < "$f")
-            echo "$(basename $f): $(numfmt --to=iec $size)"
-          done >> $GITHUB_STEP_SUMMARY
+          sed -n '/Route (app)/,/^$/p' build-output.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Total .next size" >> $GITHUB_STEP_SUMMARY
+          echo "### Client Bundle" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          du -sh .next/static/ >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Total Build Output" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
           du -sh .next/ >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -11,7 +11,6 @@ concurrency:
 env:
   DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
   PAYLOAD_SECRET: ci-build-secret-not-real
-  NODE_ENV: production
 
 jobs:
   analyze:

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,54 @@
+name: Bundle Size
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+  PAYLOAD_SECRET: ci-build-secret-not-real
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  analyze:
+    name: Analyze Bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Analyze bundle size
+        run: |
+          echo "## Bundle Size Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Route Sizes" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          find .next -name '*.js' -path '*/pages/*' -o -name '*.js' -path '*/app/*' | head -50 | while read f; do
+            size=$(wc -c < "$f")
+            echo "$(basename $f): $(numfmt --to=iec $size)"
+          done >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Total .next size" >> $GITHUB_STEP_SUMMARY
+          du -sh .next/ >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -48,24 +48,37 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Generate Payload types
+        run: pnpm payload generate:types
+
+      - name: Run database migrations
+        run: pnpm payload migrate
+
       - name: Build and capture output
-        run: pnpm build 2>&1 | tee build-output.txt
+        run: |
+          set -o pipefail
+          pnpm build 2>&1 | tee build-output.txt
 
       - name: Report bundle size
+        if: always()
         run: |
           echo "## Bundle Size Report" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Route Sizes (from next build)" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          sed -n '/Route (app)/,/^$/p' build-output.txt >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Client Bundle" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          du -sh .next/static/ >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f build-output.txt ]; then
+            echo "### Route Sizes (from next build)" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            sed -n '/Route (app)/,/^$/p' build-output.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ -d .next/static ]; then
+            echo "### Client Bundle" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            du -sh .next/static/ >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "### Total Build Output" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          du -sh .next/ >> $GITHUB_STEP_SUMMARY
+          du -sh .next/ 2>/dev/null || echo "Build did not produce .next directory" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,12 +1,23 @@
 name: E2E Tests
 
 on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, ready_for_review]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.github/dependabot.yml'
   workflow_dispatch:
     inputs:
       test_pattern:
         description: 'Test file pattern (optional, e.g., "public/*" or leave empty for all)'
         required: false
         default: ''
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
@@ -18,6 +29,7 @@ jobs:
     name: Playwright E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft != true
 
     services:
       postgres:


### PR DESCRIPTION
## Summary
- Upgrade E2E workflow to trigger on PRs to main (opened, synchronize, ready_for_review) with paths-ignore for docs, plus concurrency control and draft-PR skip
- Add new bundle size analysis workflow that builds on PRs and reports route sizes via GitHub Step Summary
- No new dependencies or config changes required

## Test plan
- [ ] Verify E2E workflow triggers on a non-draft PR to main
- [ ] Verify E2E workflow skips draft PRs
- [ ] Verify bundle-size workflow runs and produces a step summary
- [ ] Verify concurrency cancels in-progress runs on new pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)