### PR TITLE
Switch Mergify update method to merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 queue_rules:
   - name: default
     merge_method: squash
-    update_method: rebase
+    update_method: merge
     queue_conditions:
       - "#approved-reviews-by >= 1"
       - base = main


### PR DESCRIPTION
## Summary
- Switch `update_method` from `rebase` to `merge` in `.mergify.yml`
- Rebase was causing pnpm-lock.yaml conflicts when multiple Dependabot PRs queued together
- Merge-based updates avoid lockfile conflicts; squash merge still keeps history clean

## Test plan
- [ ] Verify Mergify picks up the config change
- [ ] Queue a Dependabot PR and confirm no lockfile conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)