### PR TITLE
Add .npmrc to allowlist pnpm build scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+onlyBuiltDependencies[]=esbuild
+onlyBuiltDependencies[]=sharp
+onlyBuiltDependencies[]=unrs-resolver


### PR DESCRIPTION
## Summary
- Allowlist esbuild, sharp, and unrs-resolver for pnpm build scripts
- Required for pnpm/action-setup@v6 which ships stricter pnpm defaults
- Unblocks Dependabot PR #6

## Test plan
- [ ] CI passes with current pnpm (no regression)
- [ ] After merge, Dependabot PR #6 should pass CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)