### PR TITLE
Upgrade pnpm/action-setup from v4 to v6

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 9.15.9
+          standalone: true
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -36,9 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 9.15.9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 9.15.9
+          standalone: true
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -37,9 +37,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 9.15.9
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 9.15.9
+          standalone: true
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -36,6 +37,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 9.15.9
+          standalone: true
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,9 +17,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 9.15.9
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -33,9 +33,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 9.15.9
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 9.15.9
+          standalone: true
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -17,9 +17,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 9.15.9
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -57,9 +57,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 9.15.9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -130,9 +130,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 9.15.9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -60,6 +60,7 @@ jobs:
         uses: pnpm/action-setup@v6
         with:
           version: 9.15.9
+          standalone: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -133,6 +134,7 @@ jobs:
         uses: pnpm/action-setup@v6
         with:
           version: 9.15.9
+          standalone: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "detached-node",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
   "type": "module",
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Summary
- Bumps `pnpm/action-setup` from v4 to v6 in all CI workflows
- Pins pnpm to `9.15.9` (matching local dev environment)
- Adds `packageManager` field to `package.json` for tooling compatibility

Replaces Dependabot PR #6 which accumulated merge artifacts that corrupted GitHub's test-merge lockfile ref.

## Test plan
- [ ] All CI checks pass (lint, typecheck, vitest, build, e2e, bundle, codeql)
- [ ] pnpm version in CI matches 9.15.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)