### PR TITLE
Rebrand home page: d-n logo, detached-node hero

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -77,7 +77,7 @@ export default function FrontendLayout({
   return (
     <html lang="en" className={`${crimsonPro.variable} ${jetbrainsMono.variable}`} suppressHydrationWarning>
       <head>
-        <link rel="alternate" type="application/rss+xml" title="Detached Node" href={`${siteUrl}/feed.xml`} />
+        <link rel="alternate" type="application/rss+xml" title="detached-node" href={`${siteUrl}/feed.xml`} />
       </head>
       <body className="min-h-screen antialiased bg-background text-text-primary">
         <a
@@ -92,8 +92,8 @@ export default function FrontendLayout({
           <TextureOverlay />
           <div className="site-frame mx-auto my-4 flex min-h-[calc(100vh-2rem)] max-w-5xl flex-col rounded-sm border border-border sm:my-6 sm:min-h-[calc(100vh-3rem)]">
             <header className="flex items-center justify-between border-b border-border px-4 py-3 sm:px-6">
-              <Link href="/" className="font-mono text-lg font-semibold tracking-tight text-accent focus-ring">
-                Detached Node
+              <Link href="/" className="font-mono text-lg font-semibold tracking-tight text-accent lowercase focus-ring">
+                d-n
               </Link>
               <div className="flex items-center gap-4">
                 <nav className="flex flex-wrap items-center gap-4 text-sm font-mono tracking-[0.04em] text-text-secondary sm:gap-6" aria-label="Main navigation">

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { Card } from "@/components/Card";
-import { Button } from "@/components/Button";
 import { FadeReveal } from "@/components/FadeReveal";
 import { SchemaScript } from "@/components/SchemaScript";
 import { generateWebSiteSchema, generatePersonSchema } from "@/lib/schema";
@@ -23,24 +22,13 @@ export default async function Home() {
     <FadeReveal>
     <SchemaScript schema={[generateWebSiteSchema(), generatePersonSchema()]} />
     <div className="flex flex-col gap-16">
-      <section className="hero-glow rounded-sm border border-border bg-surface p-8">
-        <h1 className="font-mono text-4xl font-semibold tracking-tight text-text-primary [text-wrap:balance]">
-          Thoughts on autonomous systems and the agents that run them.
+      <section>
+        <h1 className="font-mono text-4xl font-semibold tracking-tight text-text-primary lowercase [text-wrap:balance]">
+          detached-node
         </h1>
-        <p className="text-zinc-500 dark:text-zinc-400 font-mono text-sm mt-2">
-          Exploring failure modes of AI-assisted development.
-        </p>
         <p className="mt-4 max-w-xl text-lg leading-8 text-text-secondary">
-          Exploring agentic AI workflows, tool use, and the philosophy of machine intelligence.
+          a diagnostic analysis of AI-assisted software engineering
         </p>
-        <div className="mt-6 flex flex-wrap gap-4">
-          <Button href="/posts" asChild>
-            Browse the archive
-          </Button>
-          <Button href="/about" variant="secondary" asChild>
-            About this project
-          </Button>
-        </div>
       </section>
 
       <section>

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -2,7 +2,7 @@ import { getPublishedPosts } from "@/lib/queries/posts";
 import { siteUrl } from "@/lib/site-config";
 import type { Post } from "@/payload-types";
 
-const SITE_TITLE = "Detached Node";
+const SITE_TITLE = "detached-node";
 const SITE_DESCRIPTION =
   "Exploring modern agentic AI workflows, autonomous systems, and the philosophy of machine intelligence.";
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -86,7 +86,7 @@ export function StatusBar() {
           <span>{'//'}</span>
           <span className="inline-flex">{digits}</span>
         </div>
-        <span className="shrink-0 text-text-tertiary">&copy; DETACHED NODE</span>
+        <span className="shrink-0 text-text-tertiary">&copy; DETACHED-NODE</span>
       </div>
     </footer>
   );

--- a/src/lib/schema/collection-page.ts
+++ b/src/lib/schema/collection-page.ts
@@ -25,7 +25,7 @@ export function generateCollectionPageSchema(): CollectionPageSchema {
     // @id uses #collection fragment to distinguish this entity from
     // the bare /posts URL which is just a navigation path
     "@id": `${SITE_CONFIG.url}/posts#collection`,
-    name: "Posts — Detached Node",
+    name: "Posts — detached-node",
     description:
       "Writing on agentic AI workflows, autonomous systems, and machine intelligence.",
     url: `${SITE_CONFIG.url}/posts`,

--- a/src/lib/schema/config.ts
+++ b/src/lib/schema/config.ts
@@ -15,7 +15,7 @@
 const siteUrl =
   process.env.NEXT_PUBLIC_SERVER_URL || "https://detached-node.dev";
 
-const siteName = "Detached Node";
+const siteName = "detached-node";
 
 const siteDescription =
   "Exploring modern agentic AI workflows, autonomous systems, and the philosophy of machine intelligence.";

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -9,7 +9,7 @@
 export const siteUrl: string =
   process.env.NEXT_PUBLIC_SERVER_URL || "https://detached-node.dev";
 
-export const siteName = "Detached Node";
+export const siteName = "detached-node";
 
 export const siteDescription =
   "Exploring modern agentic AI workflows, autonomous systems, and the philosophy of machine intelligence.";

--- a/tests/e2e/fixtures/page-objects/home.page.ts
+++ b/tests/e2e/fixtures/page-objects/home.page.ts
@@ -6,9 +6,6 @@ import { Page, Locator } from '@playwright/test'
 export class HomePage {
   readonly page: Page
   readonly heroTitle: Locator
-  readonly heroSubtitle: Locator
-  readonly browsePostsButton: Locator
-  readonly aboutButton: Locator
   readonly featuredPostsSection: Locator
   readonly featuredPostsHeading: Locator
   readonly featuredPostCards: Locator
@@ -17,10 +14,7 @@ export class HomePage {
   constructor(page: Page) {
     this.page = page
     this.navigation = page.locator('nav')
-    this.heroTitle = page.getByRole('heading', { name: /autonomous systems/i })
-    this.heroSubtitle = page.locator('section').first().getByText(/agentic AI workflows/i)
-    this.browsePostsButton = page.getByRole('link', { name: /browse the archive/i })
-    this.aboutButton = page.getByRole('link', { name: /about this project/i })
+    this.heroTitle = page.getByRole('heading', { name: /detached-node/i })
     this.featuredPostsHeading = page.getByRole('heading', { name: /featured posts/i })
     this.featuredPostsSection = page.locator('section').last()
     this.featuredPostCards = page.locator('section').last().locator('a[href^="/posts/"]')
@@ -33,16 +27,6 @@ export class HomePage {
 
   async getFeaturedPostCount() {
     return await this.featuredPostCards.count()
-  }
-
-  async clickBrowsePosts() {
-    await this.browsePostsButton.click()
-    await this.page.waitForURL(/\/posts$/)
-  }
-
-  async clickAbout() {
-    await this.aboutButton.click()
-    await this.page.waitForURL(/\/about$/)
   }
 
   async getFeaturedPostTitles() {

--- a/tests/e2e/public/header-navigation.spec.ts
+++ b/tests/e2e/public/header-navigation.spec.ts
@@ -14,7 +14,7 @@ test.describe('Header Navigation', () => {
   test('should navigate to homepage when clicking logo', async ({ postsPage }) => {
     await postsPage.goto()
 
-    const logo = postsPage.page.getByRole('link', { name: /^Detached Node$/i })
+    const logo = postsPage.page.getByRole('link', { name: /^d-n$/i })
     await expectVisible(logo)
 
     await logo.click()

--- a/tests/e2e/public/homepage-hero.spec.ts
+++ b/tests/e2e/public/homepage-hero.spec.ts
@@ -1,58 +1,25 @@
 import { test } from '../fixtures'
-import { expectVisible, expectUrl, expectTitle } from '../helpers'
+import { expectVisible, expectTitle } from '../helpers'
 
 /**
  * E2E tests for homepage hero section (CON-36)
- * Tests verify that the hero section renders correctly and CTAs navigate properly
+ * Tests verify that the hero section renders correctly.
  */
 
 test.describe('Homepage Hero Section', () => {
-  test('should load homepage without errors and display all hero elements', async ({ homePage }) => {
+  test('should load homepage without errors and display hero elements', async ({ homePage }) => {
     await homePage.goto()
 
-    // Verify page title
-    await expectTitle(homePage.page, /Detached Node/)
-
-    // Verify main heading is visible
+    await expectTitle(homePage.page, /detached-node/)
     await expectVisible(homePage.heroTitle)
-
-    // Verify both CTA buttons are visible
-    await expectVisible(homePage.browsePostsButton)
-    await expectVisible(homePage.aboutButton)
   })
 
-  test('should navigate to /posts when clicking "Browse posts" button', async ({ homePage }) => {
-    await homePage.goto()
-
-    // Click the "Browse posts" CTA
-    await homePage.clickBrowsePosts()
-
-    // Verify navigation to posts page
-    await expectUrl(homePage.page, /\/posts$/)
-  })
-
-  test('should navigate to /about when clicking "About the project" button', async ({ homePage }) => {
-    await homePage.goto()
-
-    // Click the "About the project" CTA
-    await homePage.clickAbout()
-
-    // Verify navigation to about page
-    await expectUrl(homePage.page, /\/about$/)
-  })
-
-  test('should display responsive layout on mobile viewport', async ({ homePage }) => {
-    // Set mobile viewport
+  test('should display hero on mobile viewport', async ({ homePage }) => {
     await homePage.page.setViewportSize({ width: 375, height: 667 })
-
     await homePage.goto()
 
-    // Verify hero section is still visible and accessible on mobile
     await expectVisible(homePage.heroTitle)
-    await expectVisible(homePage.browsePostsButton)
-    await expectVisible(homePage.aboutButton)
 
-    // Verify buttons are stacked properly (checking they're visible is enough)
     const heroSection = homePage.page.locator('section').first()
     await expectVisible(heroSection)
   })

--- a/tests/e2e/public/page-metadata.spec.ts
+++ b/tests/e2e/public/page-metadata.spec.ts
@@ -14,7 +14,7 @@ test.describe('Page Metadata and SEO', () => {
   test('should have correct homepage title and description', async ({ homePage }) => {
     await homePage.goto()
 
-    await expectTitle(homePage.page, /Detached Node/)
+    await expectTitle(homePage.page, /detached-node/)
 
     const metaDescription = await homePage.page
       .locator('meta[name="description"]')
@@ -27,20 +27,20 @@ test.describe('Page Metadata and SEO', () => {
   test('should have correct posts listing page title', async ({ postsPage }) => {
     await postsPage.goto()
 
-    await expectTitle(postsPage.page, 'Posts | Detached Node')
+    await expectTitle(postsPage.page, 'Posts | detached-node')
   })
 
   test('should have dynamic title for post detail page', async ({ postDetailPage }) => {
     await postDetailPage.goto('architecture-of-agent-systems')
 
     await expectTitle(postDetailPage.page, /The Architecture of Agent Systems/)
-    await expectTitle(postDetailPage.page, /Detached Node/)
+    await expectTitle(postDetailPage.page, /detached-node/)
   })
 
   test('should have correct about page title', async ({ aboutPage }) => {
     await aboutPage.goto()
 
     await expectTitle(aboutPage.page, /About/)
-    await expectTitle(aboutPage.page, /Detached Node/)
+    await expectTitle(aboutPage.page, /detached-node/)
   })
 })


### PR DESCRIPTION
## Summary

Compact the brand mark in the nav to `d-n`; expand it into `detached-node` as the home-page hero. Strip the hero's card chrome and the CTA buttons so the page reads as a publication rather than a product page. Subtitle states the thesis directly: *a diagnostic analysis of AI-assisted software engineering*.

The abbreviation ↔ expansion pairing mirrors how engineering notation works — the short form is what you use, the long form is what you define — and reinforces the editorial stance (outsider-within, detachment-as-method).

### Before / after

- **Logo (nav):** `Detached Node` → `d-n`
- **Hero h1:** aspirational headline in a bordered card → `detached-node` (lowercase mono, unframed)
- **Hero chrome:** `hero-glow rounded-sm border bg-surface p-8` → removed
- **Hero CTAs:** "Browse the archive" / "About this project" → removed (nav is sufficient)
- **Status bar footer:** `© DETACHED NODE` → `© DETACHED-NODE`

### Metadata alignment

All site-identity surfaces unified to `detached-node`:
- `siteName` in `src/lib/site-config.ts` (drives `<title>`, OG cards, meta description template)
- `SITE_TITLE` in `src/app/feed.xml/route.ts` (RSS channel title)
- RSS autodiscovery `<link title>` in layout
- `siteName` + `CollectionPage.name` in schema library (JSON-LD)

Deliberately **not** touched: prose references to "Detached Node" in README/CLAUDE.md/seed scripts. Mid-sentence proper-noun capitalization reads more naturally than a forced `detached-node` find-replace in editorial copy.

### Tests

- `header-navigation.spec.ts`: logo pattern updated to `/^d-n$/i`
- `page-metadata.spec.ts`: 5 title assertions updated to `detached-node`
- `homepage-hero.spec.ts`: removed obsolete button-visibility and click-navigation tests (buttons no longer exist); focus the file on hero content + responsive layout

### Follow-ups filed as separate issues

Design review of the rebranded page surfaced four polish items, all tracked separately — not in scope here:

- #32 — Mobile status bar collision (bug)
- #33 — Tint hero hyphens purple for logo↔hero visual rhyme
- #34 — Drop Field Report card chrome
- #35 — Bump hero subtitle weight

## Test plan

- [ ] Home page renders `d-n` in nav + `detached-node` in hero (light + dark)
- [ ] Browser tab title reads `detached-node`
- [ ] RSS feed at `/feed.xml` uses `detached-node` as channel title
- [ ] Status bar footer reads `© DETACHED-NODE`
- [ ] Nav links still work (Home / Posts / About)
- [ ] E2E suite passes on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)