### PR TITLE
Skip hidden images in FadeReveal load wait (fixes ~3s LCP regression)

### DIFF
--- a/src/components/FadeReveal.tsx
+++ b/src/components/FadeReveal.tsx
@@ -52,6 +52,16 @@ export function FadeReveal({ children }: { children: ReactNode }) {
     };
 
     images.forEach((img) => {
+      // Hidden images (display:none, visibility:hidden) with loading="lazy"
+      // never fire load events — the browser correctly skips fetching them.
+      // Treat them as ready so we don't stall the reveal waiting on a load
+      // that will never happen (e.g. the inactive-theme variant in a stacked
+      // light/dark hero pair).
+      const cs = window.getComputedStyle(img);
+      if (cs.display === 'none' || cs.visibility === 'hidden') {
+        check();
+        return;
+      }
       if (img.complete) {
         check();
       } else {

--- a/tests/unit/components/FadeReveal.test.tsx
+++ b/tests/unit/components/FadeReveal.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import { FadeReveal } from "@/components/FadeReveal";
+
+/**
+ * FadeReveal holds children at opacity:0 until every <img> inside has
+ * resolved, then swaps to the `glitch-reveal` class. A hidden image
+ * (display:none) with loading="lazy" will never fire a load event because
+ * the browser skips the fetch — FadeReveal must treat those as already
+ * resolved, otherwise it stalls until the 3s safety timeout and the page
+ * feels broken.
+ */
+describe("FadeReveal", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function getRevealClass(container: HTMLElement): Promise<string> {
+    // Let the post-mount useEffect flush.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    return container.firstElementChild?.className ?? "";
+  }
+
+  it("reveals immediately when there are no images", async () => {
+    const { container } = render(
+      <FadeReveal>
+        <p>content</p>
+      </FadeReveal>,
+    );
+
+    const cls = await getRevealClass(container);
+    expect(cls).toContain("glitch-reveal");
+  });
+
+  it("reveals immediately when every image is already complete", async () => {
+    const { container } = render(
+      <FadeReveal>
+        <img alt="a" />
+      </FadeReveal>,
+    );
+
+    // jsdom reports complete=true for <img> with no src by default
+    const cls = await getRevealClass(container);
+    expect(cls).toContain("glitch-reveal");
+  });
+
+  it("skips images hidden via display:none instead of waiting on them", async () => {
+    // A `display:none` image with loading="lazy" never fires `load` — the
+    // browser correctly skips the fetch. Before the fix, FadeReveal stalled
+    // on this case until the 3s timeout. Regression test isolates the
+    // hidden image alone; if it's not skipped, `ready` stays false.
+    const { container } = render(
+      <FadeReveal>
+        <img
+          alt="hidden"
+          loading="lazy"
+          style={{ display: "none" }}
+          src="/never-fetched.png"
+        />
+      </FadeReveal>,
+    );
+
+    const cls = await getRevealClass(container);
+    expect(cls).toContain("glitch-reveal");
+  });
+
+  it("renders children at opacity:0 initially", () => {
+    const { container } = render(
+      <FadeReveal>
+        <div>content</div>
+      </FadeReveal>,
+    );
+
+    // Inspect before any timers run.
+    expect(container.firstElementChild?.className ?? "").toContain(
+      "opacity-0",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

After PR #54 landed the theme-aware hero pair, post detail pages started taking ~3 seconds to reveal. `FadeReveal` holds content at `opacity-0` until every `<img>` inside resolves, with a 3000 ms safety timeout.

The new `ThemeAwareHero` renders two stacked images — one visible, one `display: none`. The hidden image has `loading=\"lazy\"` + `display: none`, so the browser correctly never fetches it. But `img.complete` stays `false`, so `FadeReveal` waits on a `load` event that never fires and hits its 3 s timeout on every render.

Measured on prod (`/posts/rethinking-systems-in-the-agentic-age`, warm edge cache):
- TTFB: 39 ms
- FCP: 112 ms
- Chrome LCP: **3,335 ms** (render delay 3,253 ms = 3 s timeout + 200 ms glitch-in + 150 ms delay)

So the whole render-delay budget was FadeReveal waiting on an image the browser will never load.

## Fix

In `useEffect`, treat CSS-hidden images (`display: none` or `visibility: hidden`) as already resolved so the reveal fires as soon as the visible variant finishes loading.

```tsx
const cs = window.getComputedStyle(img);
if (cs.display === 'none' || cs.visibility === 'hidden') {
  check();
  return;
}
```

This is the minimum change — no animation timing adjustments, no new CSS, no changes to `ThemeAwareHero`.

## Tests

Added `tests/unit/components/FadeReveal.test.tsx`:
- Reveals immediately with no images.
- Reveals immediately when every image is complete.
- **Skips a `display: none` + `loading=\"lazy\"` image** (regression test for this exact bug).
- Renders at `opacity-0` initially.

`pnpm test:unit`: 149/149 ✅ (4 new). `pnpm lint`: 0 errors. `pnpm exec tsc --noEmit`: clean.

## Out of scope

- The hero image source optimization (PNG → WebP) is a separate operational change, not needed for this fix — it's an additional win on cold-cache transcode but unrelated to the `FadeReveal` stall.
- Vercel Build Command / `NOT NULL` follow-up migration / `tmp/hero-pics/` cleanup — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)