### PR TITLE
ci: run pnpm build:production on every Vercel deploy (#57)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "buildCommand": "pnpm build:production",
   "functions": {
     "src/app/(payload)/api/**/*": {
       "maxDuration": 60


### PR DESCRIPTION
## Summary

- Adds `buildCommand: "pnpm build:production"` to `vercel.json`, so every deploy runs `pnpm payload migrate && pnpm build` instead of the default `next build`.
- Encodes the setting in version control rather than the Vercel dashboard — survives project transfers, revertable via `git revert`, visible in PRs.
- `vercel.json` takes precedence over dashboard settings.

## Why

PR #54 shipped a schema migration that never ran on deploy because the default Vercel build command skips `pnpm payload migrate`. On 2026-04-21 this caused the `featuredImage` column to be out of sync with code, temporarily hiding posts on prod until migrations were run out-of-band. Forcing migration into the build command makes the contract automatic.

## Test plan

- [ ] Merge this PR
- [ ] Observe next Vercel production deploy log — expect `payload migrate` output before `next build`
- [ ] Confirm site remains up (no-op migration since #54's migration already ran out-of-band)

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)