### PR TITLE
fix: add addRandomSuffix to vercelBlobStorage (#52)

### DIFF
--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -57,6 +57,7 @@ export default buildConfig({
       collections: { media: true },
       token: process.env.BLOB_READ_WRITE_TOKEN,
       clientUploads: true, // Bypasses 4.5MB serverless limit
+      addRandomSuffix: true,
     }),
   ],
   sharp,


### PR DESCRIPTION
## Summary

- Sets `addRandomSuffix: true` on the `vercelBlobStorage` plugin config in `src/payload.config.ts`.
- Prevents 400s when uploading a Media entry whose source filename collides with an existing blob pathname.
- Existing Media records are untouched — only new uploads get a short random suffix.

## Why

Re-uploading `what-tickets-and-prs-are-actually-for-dark.webp` through the admin UI during the #50 fix returned a 400 from Vercel Blob. Workaround was renaming locally to `-v2.webp`, which is brittle: accidental collisions are easy and the admin surfaces no helpful error. The SDK-native `addRandomSuffix` flag is the cleanest fix.

The `url` field on each Media doc is persisted at upload time, so downstream rendering (Next/Image, ISR, RSS/sitemap, OG tags) resolves correctly regardless of pathname shape. Old records keep their unsuffixed URLs.

Rejected the `beforeChange` hook alternative per the issue's explicit scope note — ~15 LOC and a race surface for no meaningful gain on a single-author blog.

## Test plan

- [ ] Merge PR
- [ ] Re-upload a Media entry with a colliding filename through the admin → expect success (not 400)
- [ ] Confirm public pages for existing posts still render (existing blob URLs unchanged)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)