### PR TITLE
design: tint hero hyphen with accent purple (#33)

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -24,7 +24,7 @@ export default async function Home() {
     <div className="flex flex-col gap-16">
       <section>
         <h1 className="font-mono text-4xl font-semibold tracking-tight text-text-primary lowercase [text-wrap:balance]">
-          detached-node
+          detached<span className="text-accent">-</span>node
         </h1>
         <p className="mt-4 max-w-xl text-lg leading-8 text-text-secondary">
           a diagnostic analysis of AI-assisted software engineering


### PR DESCRIPTION
## Summary

- Wraps the `-` in the hero h1 `detached-node` with a `<span className="text-accent">` so it renders in the same accent purple as the d-n logo hyphen.
- Visual rhyme: the stamp (`d-n`) and its expansion (`detached-node`) now read as related wordmarks rather than two unrelated marks.

## Files

- `src/app/(frontend)/page.tsx` — 1 line changed

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)