### PR TITLE
fix: hide status bar instrument fields below sm: breakpoint (#32)

### DIFF
--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -67,24 +67,26 @@ export function StatusBar() {
           >
             {themeLabel}
           </button>
-          <span>{'//'}</span>
-          <button
-            onClick={cycleContrast}
-            className="hover:text-accent transition-colors cursor-pointer"
-            aria-label={`Contrast: ${contrast}. Click to cycle.`}
-          >
-            CTR:{mounted ? contrast.toUpperCase() : '----'}
-          </button>
-          <span>{'//'}</span>
-          <button
-            onClick={cycleBrightness}
-            className="hover:text-accent transition-colors cursor-pointer"
-            aria-label={`Brightness: ${brightness}. Click to cycle.`}
-          >
-            BRT:{mounted ? brightness.toUpperCase() : '----'}
-          </button>
-          <span>{'//'}</span>
-          <span className="inline-flex">{digits}</span>
+          <span className="hidden sm:flex items-center gap-1">
+            <span>{'//'}</span>
+            <button
+              onClick={cycleContrast}
+              className="hover:text-accent transition-colors cursor-pointer"
+              aria-label={`Contrast: ${contrast}. Click to cycle.`}
+            >
+              CTR:{mounted ? contrast.toUpperCase() : '----'}
+            </button>
+            <span>{'//'}</span>
+            <button
+              onClick={cycleBrightness}
+              className="hover:text-accent transition-colors cursor-pointer"
+              aria-label={`Brightness: ${brightness}. Click to cycle.`}
+            >
+              BRT:{mounted ? brightness.toUpperCase() : '----'}
+            </button>
+            <span>{'//'}</span>
+            <span className="inline-flex">{digits}</span>
+          </span>
         </div>
         <span className="shrink-0 text-text-tertiary">&copy; DETACHED-NODE</span>
       </div>


### PR DESCRIPTION
## Summary

- Wraps `CTR`, `BRT`, and the epoch timestamp (plus their `//` separators) in a `<span className="hidden sm:flex items-center gap-1">` container.
- Below 640px (Tailwind `sm:`) the footer renders just `HOME // DARK` on the left and `© DETACHED-NODE` on the right — no overlap.
- At `sm:` and above the full instrument panel returns identically to before.

## Why

On 375px viewports the left-side instrument string collided with the right-side copyright, producing an unreadable footer. The status bar is part of the diagnostic chrome that sells the "instrument panel" read — mobile overlap reads as broken, not stylized.

## Test plan

- [ ] Merge
- [ ] Confirm at 375px: only `HOME // DARK © DETACHED-NODE` visible, no overlap
- [ ] Confirm at ≥640px: full instrument row renders identically to before, CTR/BRT buttons still clickable

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)