### PR TITLE
design: bump hero subtitle to text-xl font-medium (#35)

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -26,7 +26,7 @@ export default async function Home() {
         <h1 className="font-mono text-4xl font-semibold tracking-tight text-text-primary lowercase [text-wrap:balance]">
           detached-node
         </h1>
-        <p className="mt-4 max-w-xl text-lg leading-8 text-text-secondary">
+        <p className="mt-4 max-w-xl text-xl font-medium leading-8 text-text-secondary">
           a diagnostic analysis of AI-assisted software engineering
         </p>
       </section>


### PR DESCRIPTION
## Summary

- Hero subtitle `<p>` steps from `text-lg` (18px) to `text-xl` (20px) and gains `font-medium` (500).
- Reads as thesis rather than caption; leaves the h1's `font-semibold` in visual hierarchy ahead.
- Italic explicitly rejected as too stylized for a short declarative subtitle. Color token unchanged.

## Files

- `src/app/(frontend)/page.tsx` — 1 class swap + 1 class added

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)