### PR TITLE
refactor: OptimizedImage props as discriminated union on fill (#59)

### DIFF
--- a/src/components/OptimizedImage.tsx
+++ b/src/components/OptimizedImage.tsx
@@ -1,16 +1,19 @@
 import Image from "next/image";
 
-interface OptimizedImageProps {
+interface CommonProps {
   src: string;
   alt: string;
-  width?: number;
-  height?: number;
   priority?: boolean;
   fetchPriority?: "high" | "low" | "auto";
-  fill?: boolean;
   className?: string;
   sizes?: string;
 }
+
+type OptimizedImageProps = CommonProps &
+  (
+    | { fill: true; width?: never; height?: never }
+    | { fill?: false; width: number; height: number }
+  );
 
 /**
  * Optimized image component using Next.js Image
@@ -48,20 +51,19 @@ function toRelativeSrc(src: string): string {
   return src;
 }
 
-export function OptimizedImage({
-  src,
-  alt,
-  width,
-  height,
-  priority = false,
-  fetchPriority,
-  fill = false,
-  className = "",
-  sizes,
-}: OptimizedImageProps) {
-  const dimensionProps = fill
+export function OptimizedImage(props: OptimizedImageProps) {
+  const {
+    src,
+    alt,
+    priority = false,
+    fetchPriority,
+    className = "",
+    sizes,
+  } = props;
+
+  const dimensionProps = props.fill
     ? { fill: true as const }
-    : { width: width as number, height: height as number };
+    : { width: props.width, height: props.height };
 
   return (
     <Image

--- a/tests/unit/components/OptimizedImage.type.test.tsx
+++ b/tests/unit/components/OptimizedImage.type.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { OptimizedImage } from "@/components/OptimizedImage";
+
+describe("OptimizedImage type contract", () => {
+  it("accepts fill mode without dimensions", () => {
+    const _el = <OptimizedImage fill src="/a.png" alt="alt" />;
+    expect(_el).toBeDefined();
+  });
+
+  it("accepts explicit dimensions without fill", () => {
+    const _el = <OptimizedImage src="/a.png" alt="alt" width={100} height={100} />;
+    expect(_el).toBeDefined();
+  });
+
+  it("type-level: rejects fill + explicit dimensions", () => {
+    // @ts-expect-error — fill=true disallows width/height
+    const _el = <OptimizedImage fill src="/a.png" alt="alt" width={100} height={100} />;
+    expect(_el).toBeDefined();
+  });
+
+  it("type-level: rejects neither fill nor dimensions", () => {
+    // @ts-expect-error — must provide either fill OR width+height
+    const _el = <OptimizedImage src="/a.png" alt="alt" />;
+    expect(_el).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces `interface OptimizedImageProps { width?: number; height?: number; fill?: boolean; … }` with a `CommonProps & ({ fill: true; width?: never; height?: never } | { fill?: false; width: number; height: number })` discriminated union.
- Removes the `as number` cast at the dimension site; TypeScript narrows `props.width`/`props.height` to `number` inside the `else` branch.
- Adds `tests/unit/components/OptimizedImage.type.test.tsx` with four tests, two of which use `@ts-expect-error` to assert invalid prop combinations fail at compile time.

## Why

`@julianken-bot` flagged the `as number` cast on PR #54. The pre-refactor type allowed `<OptimizedImage src="…" alt="…" />` (no `fill`, no dimensions) which `next/image` would reject at runtime. The discriminated union makes that fail at compile time.

Existing call sites (both in `src/components/ThemeAwareHero.tsx`, both using `fill`) compile unchanged.

## Test plan

- [x] `pnpm tsc --noEmit` — 0 errors
- [x] `pnpm vitest run tests/unit/components/OptimizedImage.type.test.tsx` — 4/4 passing
- [ ] Merge; smoke-test `/` and `/posts/:slug` — hero images render identically

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)