### PR TITLE
fix(env): fail loudly on missing required env vars; document Preview environment

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -11,6 +11,7 @@ concurrency:
 env:
   DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
   PAYLOAD_SECRET: ci-build-secret-not-real
+  NEXT_PUBLIC_SERVER_URL: http://localhost:3000
 
 jobs:
   analyze:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,6 +13,7 @@ concurrency:
 env:
   DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
   PAYLOAD_SECRET: ci-build-secret-not-real
+  NEXT_PUBLIC_SERVER_URL: http://localhost:3000
 
 jobs:
   build:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,6 +22,7 @@ concurrency:
 env:
   DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
   PAYLOAD_SECRET: test-secret-for-ci-environment-only
+  NEXT_PUBLIC_SERVER_URL: http://localhost:3000
   NODE_ENV: test
 
 jobs:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -87,6 +87,46 @@ NEXT_PUBLIC_SERVER_URL="http://localhost:3000"
 
 **Never commit `.env.local` to git.** It's already in `.gitignore`.
 
+### Preview Environment
+
+Vercel scopes environment variables per environment (Production, Preview, Development). A variable set only in Production is **undefined during Preview builds**, which breaks every PR's preview deployment. See [issue #73](https://github.com/julianken/detached-node/issues/73) for the incident this section prevents.
+
+The following variables must be set in Vercel's **Preview** scope (in addition to Production):
+
+```bash
+# Payload CMS secret — MUST differ from Production (token-signing isolation)
+# Generate with: openssl rand -base64 32
+PAYLOAD_SECRET="preview-only-secret-min-32-chars"
+
+# Server URL — safe to reuse the Production canonical, or use a per-deployment URL
+NEXT_PUBLIC_SERVER_URL="https://detached-node.vercel.app"
+
+# Database — TODO: provision a dedicated Preview Postgres.
+# Do NOT point Preview at the Production DB: `payload migrate` runs on every
+# Preview build and would mutate production data.
+DATABASE_URL="postgres://..."
+```
+
+Vercel env vars are not inherited across scopes — Production and Preview are independent name-value maps.
+
+**Setting them via CLI**:
+
+```bash
+vercel env add PAYLOAD_SECRET preview
+# paste a fresh secret; do NOT reuse Production's
+vercel env add NEXT_PUBLIC_SERVER_URL preview
+vercel env add DATABASE_URL preview
+```
+
+**Verifying**:
+
+```bash
+vercel env ls | grep -E "PAYLOAD_SECRET|DATABASE_URL|NEXT_PUBLIC_SERVER_URL"
+# Expect each row to list "Preview" in its environments column
+```
+
+Missing any of these in Preview produces the error `Missing required environment variables: [...]` at build time (see `src/lib/env/required-env.ts`).
+
 ## Deployment Workflow
 
 ### Automatic Deployments
@@ -454,6 +494,7 @@ git push origin main
 - **Missing dependencies**: Add missing package to `package.json`, commit, push
 - **Migration failure**: Fix migration file, create new migration if needed
 - **Environment variable missing**: Add to Vercel project settings → Environment Variables
+- **`Missing required environment variables: [...]`**: The env-preflight validator caught one or more vars unset for this environment. If Production passes but Preview fails, it's almost certainly per-environment scope — see [Preview Environment](#preview-environment). Diagnose: `vercel env ls | grep -E "PAYLOAD_SECRET|DATABASE_URL|NEXT_PUBLIC_SERVER_URL"`
 
 **Verification**:
 
@@ -905,7 +946,7 @@ async headers() {
 
 ---
 
-**Document Version**: 1.0
-**Last Updated**: 2026-02-13
+**Document Version**: 1.1
+**Last Updated**: 2026-04-22
 **Maintained By**: Backend Development Agent
 **Linear Issue**: CON-113

--- a/src/lib/env/required-env.ts
+++ b/src/lib/env/required-env.ts
@@ -1,0 +1,44 @@
+/**
+ * Strict environment-variable validator.
+ *
+ * Use this to fail fast — with a readable, actionable error — whenever a
+ * module depends on env vars that must be set. The previous pattern
+ * (`process.env.FOO || ''`) silently substitutes an empty string, which
+ * surfaces as a confusing downstream failure (e.g. Postgres refusing an
+ * empty connection string, Payload rejecting an empty secret).
+ *
+ * Deployment context: Vercel scopes some vars (e.g. `PAYLOAD_SECRET`) per
+ * environment. A Production-only secret breaks Preview deploys; we want the
+ * error to name every missing var at once and identify the phase, so the
+ * fix is a single trip to the dashboard.
+ */
+
+function phaseFromEnv(): string {
+  return process.env.NEXT_PHASE ?? process.env.VERCEL_ENV ?? 'runtime'
+}
+
+export function assertRequiredEnv<const T extends readonly string[]>(
+  names: T,
+  opts?: { phase?: string },
+): { readonly [K in T[number]]: string } {
+  const missing: string[] = []
+  const values: Record<string, string> = {}
+
+  for (const name of names) {
+    const raw = process.env[name]
+    if (raw === undefined || raw === '') {
+      missing.push(name)
+    } else {
+      values[name] = raw
+    }
+  }
+
+  if (missing.length > 0) {
+    const phase = opts?.phase ?? phaseFromEnv()
+    throw new Error(
+      `Missing required environment variables: [${missing.join(', ')}] (phase: ${phase}). See docs/deployment.md#preview-environment.`,
+    )
+  }
+
+  return Object.freeze(values) as { readonly [K in T[number]]: string }
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -12,12 +12,19 @@ import { Pages } from './collections/Pages'
 import { Tags } from './collections/Tags'
 import { Posts } from './collections/Posts'
 import { Listings } from './collections/Listings'
+import { assertRequiredEnv } from './lib/env/required-env'
+
+const env = assertRequiredEnv([
+  'PAYLOAD_SECRET',
+  'DATABASE_URL',
+  'NEXT_PUBLIC_SERVER_URL',
+] as const)
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 export default buildConfig({
-  serverURL: process.env.NEXT_PUBLIC_SERVER_URL || '',
+  serverURL: env.NEXT_PUBLIC_SERVER_URL,
   admin: {
     user: 'users',
     importMap: {
@@ -26,15 +33,13 @@ export default buildConfig({
   },
   collections: [Users, Media, Pages, Tags, Posts, Listings],
   editor: lexicalEditor(),
-  secret: process.env.PAYLOAD_SECRET || (() => {
-    throw new Error('PAYLOAD_SECRET environment variable is required but not set')
-  })(),
+  secret: env.PAYLOAD_SECRET,
   typescript: {
     outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
   db: postgresAdapter({
     pool: {
-      connectionString: process.env.DATABASE_URL || '',
+      connectionString: env.DATABASE_URL,
     },
     // Enable schema push for initial deployment (creates tables automatically)
     // Consider disabling after initial setup and using migrations instead

--- a/tests/unit/lib/payload-config-env.test.ts
+++ b/tests/unit/lib/payload-config-env.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("payload.config env-preflight wiring", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.PAYLOAD_SECRET;
+    delete process.env.DATABASE_URL;
+    delete process.env.NEXT_PUBLIC_SERVER_URL;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    vi.resetModules();
+  });
+
+  it("fails loudly naming all three required vars when none are set", async () => {
+    let message = "";
+    try {
+      await import("@/payload.config");
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("Missing required environment variables");
+    expect(message).toContain("PAYLOAD_SECRET");
+    expect(message).toContain("DATABASE_URL");
+    expect(message).toContain("NEXT_PUBLIC_SERVER_URL");
+  });
+});
+
+describe("required-env error docs pointer", () => {
+  it("points at a heading that exists in docs/deployment.md", () => {
+    const docs = readFileSync(
+      join(process.cwd(), "docs/deployment.md"),
+      "utf8"
+    );
+    // The H3 slug GitHub generates from this line is #preview-environment,
+    // which the validator's error message hard-codes. A rename here rots the
+    // error message silently — this test catches that.
+    expect(docs).toMatch(/^### Preview Environment\s*$/m);
+  });
+});

--- a/tests/unit/lib/required-env.test.ts
+++ b/tests/unit/lib/required-env.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { assertRequiredEnv } from "@/lib/env/required-env";
+
+describe("assertRequiredEnv", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.FOO;
+    delete process.env.BAR;
+    delete process.env.NEXT_PHASE;
+    delete process.env.VERCEL_ENV;
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("returns the values when all required vars are present", () => {
+    process.env.FOO = "x";
+    process.env.BAR = "y";
+    const result = assertRequiredEnv(["FOO", "BAR"] as const);
+    expect(result).toEqual({ FOO: "x", BAR: "y" });
+  });
+
+  it("throws when a single required var is missing", () => {
+    process.env.BAR = "y";
+    expect(() => assertRequiredEnv(["FOO", "BAR"] as const)).toThrow(/FOO/);
+  });
+
+  it("reports all missing vars in a single throw (not just the first)", () => {
+    let err: Error | undefined;
+    try {
+      assertRequiredEnv(["FOO", "BAR"] as const);
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).toBeDefined();
+    expect(err!.message).toMatch(/FOO/);
+    expect(err!.message).toMatch(/BAR/);
+  });
+
+  it("treats empty string as missing", () => {
+    process.env.FOO = "";
+    process.env.BAR = "y";
+    expect(() => assertRequiredEnv(["FOO", "BAR"] as const)).toThrow(/FOO/);
+  });
+
+  it("error message contains the literal 'Missing required environment variables' prefix", () => {
+    expect(() => assertRequiredEnv(["FOO"] as const)).toThrow(
+      /Missing required environment variables/
+    );
+  });
+
+  it("includes the current phase in the error message", () => {
+    process.env.NEXT_PHASE = "phase-production-build";
+    expect(() => assertRequiredEnv(["FOO"] as const)).toThrow(
+      /phase-production-build/
+    );
+  });
+
+  it("restores process.env between tests (sanity)", () => {
+    // FOO was deleted in beforeEach; this asserts no leak from earlier tests.
+    expect(process.env.FOO).toBeUndefined();
+    expect(process.env.BAR).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TB
    subgraph before["Before (each env-read scattered, silent defaults)"]
        direction TB
        B1["process.env.PAYLOAD_SECRET<br/>|| IIFE throw"]
        B2["process.env.DATABASE_URL<br/>|| ''   (silent)"]
        B3["process.env.NEXT_PUBLIC_SERVER_URL<br/>|| ''   (silent)"]
        B1 --> BX["buildConfig"]
        B2 --> BX
        B3 --> BX
        BX --> BY["Payload / next build"]
        BY -.->|one missing var = one cryptic throw<br/>deep in page-data collection| BFAIL["Vercel Preview FAIL"]
    end

    subgraph after["After (single module-load preflight)"]
        direction TB
        A1["assertRequiredEnv(['PAYLOAD_SECRET',<br/>'DATABASE_URL',<br/>'NEXT_PUBLIC_SERVER_URL'] as const)"]
        A1 -->|all present| AOK["frozen env object,<br/>typed as Record<K, string>"]
        A1 -.->|any missing| AERR["ONE Error naming ALL<br/>missing vars + phase +<br/>docs pointer"]
        AOK --> AX["buildConfig"]
        AX --> AY["Payload / next build"]
    end

    before --> after
```

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant CI as CI/Vercel
    participant Cfg as payload.config.ts
    participant Env as required-env.ts

    Dev->>CI: push PR
    CI->>Cfg: import at build time
    Cfg->>Env: assertRequiredEnv([3 vars] as const)
    alt all present
        Env-->>Cfg: Object.freeze({ PAYLOAD_SECRET, DATABASE_URL, NEXT_PUBLIC_SERVER_URL })
        Cfg-->>CI: buildConfig(...)
    else any missing
        Env-->>CI: throw Error("Missing required environment variables: [FOO, BAR] (phase: phase-production-build). See docs/deployment.md#preview-environment.")
    end
```

## Summary

- **Why:** Every PR's Vercel Preview build dies during `pnpm payload migrate` with `Error: PAYLOAD_SECRET environment variable is required but not set` because the var is scoped only to the Production environment in Vercel. Two sibling reads in the same file (`NEXT_PUBLIC_SERVER_URL`, `DATABASE_URL`) silently defaulted to `''` — time-bombs waiting to surface as cryptic Payload/Postgres errors once PAYLOAD_SECRET was fixed.
- **What:** New reusable validator `src/lib/env/required-env.ts` that collects **all** missing vars in a single `Error` (not stopping at the first). Wired into `src/payload.config.ts`, replacing the ad-hoc IIFE throw and the two `|| ''` silent defaults. 7 unit tests. Error message points to a new `### Preview Environment` docs section that documents the per-environment scoping quirk and the post-merge `vercel env add` steps.
- **Scope note:** this PR does NOT set the secret in Vercel Preview — that's a one-time dashboard/CLI action tracked in #73 and explicitly called out in the docs as a post-merge step.

## Screenshots

N/A — not UI.

## Test plan

- [x] `pnpm test:unit` — green (156 tests, +7 new for the validator)
- [x] `pnpm exec tsc --noEmit` — clean, zero errors
- [x] `pnpm exec eslint` on changed files — zero warnings/errors
- [x] Negative test: `env -i NEXT_PHASE=phase-production-build pnpm exec tsx -e "import('./src/payload.config.ts')"` — throws one error naming all three missing vars, includes phase, includes docs pointer
- [x] CI workflows (`ci-build`, `bundle-size`, `e2e-tests`) now export `NEXT_PUBLIC_SERVER_URL` so the validator passes in CI
- [ ] (Post-merge) Workstream A — `vercel env add PAYLOAD_SECRET preview` with a fresh `openssl rand -base64 32` secret (different from Production); also `NEXT_PUBLIC_SERVER_URL` and a dedicated Preview `DATABASE_URL`; verify with `vercel env ls`
- [ ] (Post-merge) Open a throwaway PR to confirm Preview build completes `pnpm payload migrate` successfully; stream via Vercel MCP `get_deployment_build_logs`

## Plan reference

Closes #73 · See `docs/deployment.md#preview-environment`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)