### PR TITLE
feat: preserve hero-tooling scripts, gitignore tmp/ (#60)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ scripts/.tmp-seed-images/
 /creative-output/
 /launch-plan/
 /docs/brainstorms/
+
+# Transient workspaces
+tmp/

--- a/scripts/convert-hero-webp.ts
+++ b/scripts/convert-hero-webp.ts
@@ -1,0 +1,27 @@
+/**
+ * Converts PNG hero images in `tmp/hero-pics/` to WebP at quality 85
+ * using sharp. Produces ~15× size reduction for the hero-pair workflow.
+ *
+ * Run this BEFORE `pnpm tsx scripts/seed-theme-hero.ts` when onboarding
+ * a new hero pair: drop PNGs in `tmp/hero-pics/`, run this, then run seed.
+ *
+ * The `tmp/hero-pics/` directory is gitignored — source PNGs stay local.
+ */
+import sharp from 'sharp'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const dir = path.resolve(__dirname, '..', 'tmp', 'hero-pics')
+const files = fs.readdirSync(dir).filter((f) => f.endsWith('.png'))
+
+for (const f of files) {
+  const src = path.join(dir, f)
+  const dst = path.join(dir, f.replace(/\.png$/, '.webp'))
+  const before = fs.statSync(src).size
+  await sharp(src).webp({ quality: 85 }).toFile(dst)
+  const after = fs.statSync(dst).size
+  const pct = Math.round(100 * (1 - after / before))
+  console.log(`${f.padEnd(55)} ${Math.round(before / 1024)} KB → ${Math.round(after / 1024)} KB  (-${pct}%)`)
+}

--- a/scripts/seed-theme-hero.ts
+++ b/scripts/seed-theme-hero.ts
@@ -2,12 +2,22 @@
  * Seeds (or updates) theme-aware hero image pairs for posts.
  *
  * Reads light + dark WebP files from `tmp/hero-pics/`, uploads via
- * Payload's local API to the Media collection, and links to the post
- * by slug. Idempotent: re-running with existing filenames updates the
- * bytes in place.
+ * Payload's local API to the Media collection, and links the resulting
+ * media IDs to the matching posts via `featuredImageLight` /
+ * `featuredImageDark`. Idempotent: media uploads are upserted by
+ * filename and post updates always overwrite both variant fields, so
+ * re-running refreshes bytes in place. Old media rows are NOT deleted
+ * automatically — remove them via the admin if cleanup is desired.
+ *
+ * Run: `pnpm tsx scripts/seed-theme-hero.ts`
  *
  * Run `pnpm tsx scripts/convert-hero-webp.ts` FIRST if you only have
  * PNG source assets.
+ *
+ * Requires `DATABASE_URL`, `PAYLOAD_SECRET`, and (for prod uploads to
+ * Vercel Blob) `BLOB_READ_WRITE_TOKEN` in `.env.local`.
+ *
+ * After a successful run, delete `tmp/hero-pics/`.
  */
 import 'dotenv/config'
 import dotenv from 'dotenv'

--- a/scripts/seed-theme-hero.ts
+++ b/scripts/seed-theme-hero.ts
@@ -1,22 +1,13 @@
 /**
- * Seed script: theme-aware hero images for the two currently-published posts.
+ * Seeds (or updates) theme-aware hero image pairs for posts.
  *
- * Run with: pnpm tsx scripts/seed-theme-hero.ts
+ * Reads light + dark WebP files from `tmp/hero-pics/`, uploads via
+ * Payload's local API to the Media collection, and links to the post
+ * by slug. Idempotent: re-running with existing filenames updates the
+ * bytes in place.
  *
- * Uploads four source images from tmp/hero-pics/ (light + dark for each of
- * "rethinking-systems-in-the-agentic-age" and "what-tickets-and-prs-are-actually-for"),
- * then links the resulting media IDs to the matching posts via the new
- * featuredImageLight / featuredImageDark fields.
- *
- * Safe to run more than once: media uploads are upserted by filename, and the
- * post update is idempotent (we always overwrite both variant fields with the
- * freshest upload IDs). Old media rows are NOT deleted — delete manually in
- * the admin if cleanup is desired.
- *
- * Requires DATABASE_URL, PAYLOAD_SECRET, and (for prod uploads to Vercel Blob)
- * BLOB_READ_WRITE_TOKEN in .env.local.
- *
- * After a successful run, delete tmp/hero-pics/.
+ * Run `pnpm tsx scripts/convert-hero-webp.ts` FIRST if you only have
+ * PNG source assets.
  */
 import 'dotenv/config'
 import dotenv from 'dotenv'
@@ -47,16 +38,16 @@ const POSTS: PostAssets[] = [
     slug: 'rethinking-systems-in-the-agentic-age',
     title: 'Rethinking Systems in the Agentic Age',
     files: {
-      light: 'rethinking-systems-in-the-agentic-age-light.png',
-      dark: 'rethinking-systems-in-the-agentic-age-dark.png',
+      light: 'rethinking-systems-in-the-agentic-age-light.webp',
+      dark: 'rethinking-systems-in-the-agentic-age-dark.webp',
     },
   },
   {
     slug: 'what-tickets-and-prs-are-actually-for',
     title: 'What Tickets and PRs Are Actually For',
     files: {
-      light: 'what-tickets-and-prs-are-actually-for-light.png',
-      dark: 'what-tickets-and-prs-are-actually-for-dark.png',
+      light: 'what-tickets-and-prs-are-actually-for-light.webp',
+      dark: 'what-tickets-and-prs-are-actually-for-dark.webp',
     },
   },
 ]


### PR DESCRIPTION
## Summary

- **New:** `scripts/convert-hero-webp.ts` (19-line sharp utility converting PNG hero assets to WebP at quality 85 — the 15× size reduction that unblocked the 2026-04-21 prod recovery).
- **Updated:** `scripts/seed-theme-hero.ts` now references `.webp` filenames (four string literals, previously `.png`) and the docstring covers required env vars + cleanup reminder.
- **Gitignore:** `tmp/` added so the source PNG/WebP assets these scripts consume never accidentally commit.

## Why

Both scripts previously only lived in a local worktree (`feat-theme-aware-hero`) that will be cleaned up at some point. Rebuilding them from scratch would cost the next author 30–60 minutes and a repeat of the PNG-too-large transcoding trap. Landing them on main preserves the reusable path.

Chose Option A from the issue (two scripts, minimal diff) over Option B (single script wrapping both). A is ship-ready in one pass; B is a future refactor.

## Invocation order

```bash
# 1. Drop PNGs in tmp/hero-pics/
# 2. Convert to WebP
pnpm tsx scripts/convert-hero-webp.ts
# 3. Seed / update posts
pnpm tsx scripts/seed-theme-hero.ts
# 4. Delete tmp/hero-pics/ manually
```

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)