### PR TITLE
feat: enforce NOT NULL on posts.featured_image_{light,dark}_id (#58)

### DIFF
--- a/migrations/20260422_022813_featured_image_not_null.ts
+++ b/migrations/20260422_022813_featured_image_not_null.ts
@@ -1,0 +1,43 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Database Migration: Enforce NOT NULL on posts.featured_image_light_id
+ * and featured_image_dark_id.
+ *
+ * The theme-aware hero migration (20260421_205422) intentionally added
+ * both columns as nullable to allow a migration-first-then-seed deploy
+ * sequence. The seed (scripts/seed-theme-hero.ts) has run and both
+ * published posts are populated. Payload already enforces required: true
+ * at the app layer (src/collections/Posts.ts); this migration closes
+ * the DB-level gap for defense in depth.
+ *
+ * Prerequisite: no rows in `posts` may have either column NULL when
+ * this runs. Verified pre-merge via:
+ *   SELECT COUNT(*) FROM posts WHERE featured_image_light_id IS NULL
+ *                                  OR featured_image_dark_id IS NULL;
+ * (Expected: 0.)
+ *
+ * Down migration: drop the NOT NULL constraint on both columns.
+ */
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "posts"
+      ALTER COLUMN "featured_image_light_id" SET NOT NULL;
+  `)
+  await db.execute(sql`
+    ALTER TABLE "posts"
+      ALTER COLUMN "featured_image_dark_id" SET NOT NULL;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "posts"
+      ALTER COLUMN "featured_image_light_id" DROP NOT NULL;
+  `)
+  await db.execute(sql`
+    ALTER TABLE "posts"
+      ALTER COLUMN "featured_image_dark_id" DROP NOT NULL;
+  `)
+}

--- a/migrations/index.ts
+++ b/migrations/index.ts
@@ -2,6 +2,7 @@ import * as migration_20260213_071339_add_composite_indexes from './20260213_071
 import * as migration_20260213_072000_add_composite_indexes from './20260213_072000_add_composite_indexes';
 import * as migration_20260213_074055_mark_initial_schema_complete from './20260213_074055_mark_initial_schema_complete';
 import * as migration_20260421_205422_theme_aware_hero_images from './20260421_205422_theme_aware_hero_images';
+import * as migration_20260422_022813_featured_image_not_null from './20260422_022813_featured_image_not_null';
 
 export const migrations = [
   {
@@ -23,5 +24,10 @@ export const migrations = [
     up: migration_20260421_205422_theme_aware_hero_images.up,
     down: migration_20260421_205422_theme_aware_hero_images.down,
     name: '20260421_205422_theme_aware_hero_images',
+  },
+  {
+    up: migration_20260422_022813_featured_image_not_null.up,
+    down: migration_20260422_022813_featured_image_not_null.down,
+    name: '20260422_022813_featured_image_not_null',
   },
 ];


### PR DESCRIPTION
## Summary

- New migration `migrations/20260422_022813_featured_image_not_null.ts` — runs `ALTER COLUMN … SET NOT NULL` on both `posts.featured_image_light_id` and `posts.featured_image_dark_id`.
- Registered in `migrations/index.ts`.
- Down migration reverses with `DROP NOT NULL` on both columns.

## Why

Migration `20260421_205422_theme_aware_hero_images` added these columns as nullable to allow migration-before-seed deploy ordering. The seed has run; both published posts on prod are populated. This migration closes the gap between Payload's app-layer `required: true` and the DB schema.

## Pre-merge verification (production DB)

```sql
SELECT COUNT(*) FROM posts
WHERE featured_image_light_id IS NULL
   OR featured_image_dark_id IS NULL;
-- → 0
```

Spot check:
```
id=3  slug=rethinking-systems-in-the-agentic-age  light=8  dark=2
id=4  slug=what-tickets-and-prs-are-actually-for  light=9  dark=10
```

## Test plan

- [ ] Merge (Mergify)
- [ ] Vercel deploy runs `pnpm build:production` → `payload migrate` → migration applies (enabled by #57)
- [ ] Supabase: `\d+ posts` shows both columns NOT NULL
- [ ] Site remains up; no regression in admin or public render

## Safety

- Payload's migrate runner wraps each migration in a transaction — if either `SET NOT NULL` fails, both roll back (via `killTransaction`).
- `SET NOT NULL` on an already-NOT-NULL column is a silent no-op in Postgres (idempotent re-run).

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)