### PR TITLE
chore: verify envguard Preview build (throwaway)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ See `CONTENT_MODEL.md` for the full schema specification.
 ## License
 
 All rights reserved.
+


### PR DESCRIPTION
## Diagrams

N/A — single-line trailing-newline change; no code behavior or UI affected.

## Summary

- Throwaway PR to trigger a fresh Vercel Preview build post-#76 merge, so we can capture the new loud-fail error shape (`Missing required environment variables: [DATABASE_URL] ...`) in the build logs.
- Will be closed without merging once the log is captured.

## Screenshots

N/A — not UI.

## Test plan

- [x] Preview build triggered (the whole point)
- [ ] Preview build log contains the new error format (captured by the automation that opened this)
- [ ] PR closed without merging afterward

## Plan reference

Related to #73 (closed) — PR #76's validator. Verification step.