### PR TITLE
chore: disable Vercel Preview deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
   "buildCommand": "pnpm build:production",
+  "git": {
+    "deploymentEnabled": {
+      "**": false,
+      "main": true
+    }
+  },
   "functions": {
     "src/app/(payload)/api/**/*": {
       "maxDuration": 60


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    push["Push to branch"] --> gate{vercel.json<br/>git.deploymentEnabled}
    gate -->|main| prod["Production deploy"]
    gate -->|any other branch| skip["No deploy, no commit status"]
    prod --> pr["✓ green on PRs<br/>(Vercel check simply absent)"]
    skip --> pr
```

## Summary

- Preview builds required a DB to run `payload migrate`; paying $9.68/mo for a Supabase branch to power PR previews nobody looks at wasn't worth it.
- `git.deploymentEnabled` with minimatch `{"**": false, "main": true}` tells Vercel to deploy only `main` pushes (Production); non-main branches trigger nothing.
- Side effect: no Vercel commit status is posted on PRs → no red X → no noise in the checks list → branch protection's \`requiresDeployments\` can safely be re-enabled (just remove `"Preview"` from `requiredDeploymentEnvironments` since it will never fire).

## Screenshots

N/A — not UI.

## Test plan

- [x] `vercel.json` minimatch config per [Vercel git-configuration docs](https://vercel.com/docs/project-configuration/git-configuration)
- [ ] This PR itself should produce NO Vercel check (first verifying that the config-in-branch takes effect on the PR that introduces it)
- [ ] After merge: next PR opened on a feature branch should produce NO Vercel check whatsoever
- [ ] Production deploy of `main` post-merge still runs

## Plan reference

Follows #76 (validator landed). Preview gone at Vercel layer; validator stays as infrastructure for any future required env vars.