### PR TITLE
fix(types): shim @payloadcms/next/css for TS 6.0 compat

### DIFF
--- a/src/types/payload.d.ts
+++ b/src/types/payload.d.ts
@@ -1,0 +1,4 @@
+// Shim for Payload's CSS side-effect export. The upstream
+// `@payloadcms/next/css` export ships only a stylesheet and has no
+// `types` condition; TS 6.0 rejects such side-effect imports (TS2882).
+declare module '@payloadcms/next/css';


### PR DESCRIPTION
## Summary
- Adds `src/types/payload.d.ts` declaring the `@payloadcms/next/css` module so TS 6.0 accepts the side-effect import in `src/app/(payload)/layout.tsx`.
- Unblocks Dependabot PR #43 (`typescript 5.9.3 → 6.0.3`), which currently fails with `TS2882` on that import.
- No-op under TS 5.9 (ambient `declare module` is harmless when the import already resolves).

## Why this instead of waiting upstream
Payload's `@payloadcms/next` package.json intentionally publishes `./css` with no `types` condition — the export is a pure stylesheet (`./src/dummy.css`), not a TypeScript module. TS 6.0 tightened this case; TS 5.x let it slide. No upstream issue exists for it in payloadcms/payload, so the local shim is the pragmatic fix.

## Test plan
- [ ] Lint & Typecheck green
- [ ] Vitest green
- [ ] Next.js Build green
- [ ] After merge: comment `@dependabot rebase` on #43 and verify its TypeScript check flips green

🤖 Generated with [Claude Code](https://claude.com/claude-code)