### PR TITLE
fix: remove Upstash secrets from Cloud Run deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,8 +66,6 @@ jobs:
           secrets: |
             DATABASE_URL=database-url:latest
             PAYLOAD_SECRET=payload-secret:latest
-            UPSTASH_REDIS_REST_URL=upstash-redis-url:latest
-            UPSTASH_REDIS_REST_TOKEN=upstash-redis-token:latest
             GCS_BUCKET=gcs-bucket:latest
             GCS_HMAC_ACCESS_KEY=gcs-hmac-key:latest
             GCS_HMAC_SECRET=gcs-hmac-secret:latest


### PR DESCRIPTION
## Summary
- Upstash Redis isn't set up for this project
- GCP Secret Manager rejects empty secret values (can't use placeholder)
- rate-limit.ts has a graceful in-memory fallback when UPSTASH_* env vars are absent — acceptable for a hobby blog on scale-to-zero Cloud Run

## Test plan
- [x] Deploy workflow no longer references non-existent Upstash values
- [ ] Cloud Run deploy succeeds
- [ ] Admin UI loads, rate limiting works via in-memory fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)