### PR TITLE
fix(cd): chown .next so image cache writes persist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,14 @@ RUN pnpm payload generate:types && pnpm build
 FROM node:22-bookworm-slim AS runner
 WORKDIR /app
 ENV NODE_ENV=production PORT=8080 HOSTNAME=0.0.0.0
-COPY --from=build /app/.next/standalone ./
-COPY --from=build /app/.next/static ./.next/static
-COPY --from=build /app/public ./public
+COPY --from=build --chown=node:node /app/.next/standalone ./
+COPY --from=build --chown=node:node /app/.next/static ./.next/static
+COPY --from=build --chown=node:node /app/public ./public
+# Next.js writes the image optimization cache to .next/cache/images.
+# Pre-create and chown so the non-root `node` user can persist entries
+# across requests within a container's lifetime (x-nextjs-cache: HIT
+# instead of MISS, which avoids re-running sharp on every request).
+RUN mkdir -p ./.next/cache/images && chown -R node:node ./.next/cache
 USER node
 EXPOSE 8080
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary
Images take ~500ms per request because \`x-nextjs-cache: MISS\` on every hit. Root cause: the Dockerfile's build stage runs as root; when COPY brings \`.next\` into the runner stage, it's still root-owned; runtime switches to \`USER node\` which can't write to \`.next/cache/images\`. Next.js silently fails to persist the optimized output and re-runs sharp for every request.

Fix: \`--chown=node:node\` on the COPY lines + explicit \`mkdir -p .next/cache/images && chown -R node:node .next/cache\`. Now cache writes succeed and subsequent requests to the same warm container will be HIT (~50ms).

Cold starts (scale-to-zero first request) are still slow — that's a separate issue requiring a persistent cache handler (Redis/GCS) if we ever want to solve it without paying for min-instances=1.

## Test plan
- [x] \`chown\` is valid Dockerfile syntax
- [ ] After deploy: hit an image, reload → second request shows \`x-nextjs-cache: HIT\`
- [ ] TTFB drops from ~500ms to ~50ms on warm requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)