### PR TITLE
perf: keep one Cloud Run instance warm (min-instances=1)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
           service: detached-node
           image: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/tech-blog/app:${{ github.sha }}
           region: ${{ vars.GCP_REGION }}
-          flags: '--allow-unauthenticated --min-instances=0 --max-instances=3 --cpu=1 --memory=512Mi --port=8080 --timeout=60s'
+          flags: '--allow-unauthenticated --min-instances=1 --max-instances=3 --cpu=1 --memory=512Mi --port=8080 --timeout=60s'
           env_vars: |
             NODE_ENV=production
             NEXT_PUBLIC_SERVER_URL=${{ vars.NEXT_PUBLIC_SERVER_URL }}


### PR DESCRIPTION
## Summary
Hard-reload TTFB on detached-node.dev is ~2.7s — Cloud Run scales to zero between visits and each refresh pays the cold-start cost (Node + Next.js + Payload + Supabase TLS handshake). PR #100 fixes the image cache MISS (~500ms) but that's only 16% of the slowness — the HTML document itself is what takes 2.7s cold.

\`min-instances=1\` keeps one container continuously alive, so first-byte drops to ~150ms.

## Tradeoff
~\$5-7/mo vs. \$0. Cheap enough to be worth snappy TTFB on every visit for a hobby blog you actually browse.

## Test plan
- [x] Flag syntax valid
- [ ] After deploy: hard-reload TTFB should be ~150ms instead of ~2.7s

🤖 Generated with [Claude Code](https://claude.com/claude-code)