### PR TITLE
fix(ui): FadeReveal no longer blocks on image load

### DIFF
--- a/src/components/FadeReveal.tsx
+++ b/src/components/FadeReveal.tsx
@@ -1,92 +1,42 @@
 'use client';
 
-import { useRef, useState, useEffect, type ReactNode, type CSSProperties } from 'react';
+import { useState, useEffect, type ReactNode, type CSSProperties } from 'react';
 
-/** Random float in range [min, max], rounded to 1 decimal */
 function rand(min: number, max: number) {
   return Math.round((min + Math.random() * (max - min)) * 10) / 10;
 }
 
 /**
- * Holds content invisible until all images within have loaded,
- * then reveals everything with the glitch-in animation.
- *
- * Randomizes jitter, opacity midpoint, and duration so each
- * reveal feels slightly different — like unstable signal lock.
+ * Wraps children with a glitch-in animation on mount. Does not wait
+ * for images — image loading is handled by next/image independently.
  */
 export function FadeReveal({ children }: { children: ReactNode }) {
-  const ref = useRef<HTMLDivElement>(null);
-  const [ready, setReady] = useState(false);
-  const [vars, setVars] = useState<CSSProperties>({});
+  const [state, setState] = useState<{ ready: boolean; vars: CSSProperties }>({
+    ready: false,
+    vars: {},
+  });
 
   useEffect(() => {
-    // Generate random values client-side only to avoid hydration mismatch
-    setVars({
-      '--gr-jitter-1': `${rand(0.5, 1.2)}px`,
-      '--gr-jitter-2': `${rand(-0.8, -0.3)}px`,
-      '--gr-jitter-3': `${rand(0.1, 0.5)}px`,
-      '--gr-mid-opacity': `${rand(0.5, 0.75)}`,
-      animationDuration: `${rand(350, 500)}ms`,
-    } as CSSProperties);
-
-    const el = ref.current;
-    if (!el) {
-      setReady(true);
-      return;
-    }
-
-    const images = el.querySelectorAll('img');
-
-    // No images — reveal immediately
-    if (images.length === 0) {
-      setReady(true);
-      return;
-    }
-
-    let loaded = 0;
-    const total = images.length;
-
-    const check = () => {
-      loaded++;
-      if (loaded >= total) setReady(true);
-    };
-
-    images.forEach((img) => {
-      // Hidden images (display:none, visibility:hidden) with loading="lazy"
-      // never fire load events — the browser correctly skips fetching them.
-      // Treat them as ready so we don't stall the reveal waiting on a load
-      // that will never happen (e.g. the inactive-theme variant in a stacked
-      // light/dark hero pair).
-      const cs = window.getComputedStyle(img);
-      if (cs.display === 'none' || cs.visibility === 'hidden') {
-        check();
-        return;
-      }
-      if (img.complete) {
-        check();
-      } else {
-        img.addEventListener('load', check, { once: true });
-        img.addEventListener('error', check, { once: true });
-      }
+    // Mount-time animation: we want the initial render to paint
+    // opacity-0, then the effect flips ready so the next render
+    // applies glitch-reveal. The cascading render is the point.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setState({
+      ready: true,
+      vars: {
+        '--gr-jitter-1': `${rand(0.5, 1.2)}px`,
+        '--gr-jitter-2': `${rand(-0.8, -0.3)}px`,
+        '--gr-jitter-3': `${rand(0.1, 0.5)}px`,
+        '--gr-mid-opacity': `${rand(0.5, 0.75)}`,
+        animationDuration: `${rand(350, 500)}ms`,
+      } as CSSProperties,
     });
-
-    // Don't wait forever — reveal after 3s regardless
-    const timeout = setTimeout(() => setReady(true), 3000);
-
-    return () => {
-      clearTimeout(timeout);
-      images.forEach((img) => {
-        img.removeEventListener('load', check);
-        img.removeEventListener('error', check);
-      });
-    };
   }, []);
 
   return (
     <div
-      ref={ref}
-      className={`opacity-0 ${ready ? 'glitch-reveal' : ''}`}
-      style={vars}
+      className={`opacity-0 ${state.ready ? 'glitch-reveal' : ''}`}
+      style={state.vars}
     >
       {children}
     </div>

--- a/tests/unit/components/FadeReveal.test.tsx
+++ b/tests/unit/components/FadeReveal.test.tsx
@@ -2,14 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, act } from "@testing-library/react";
 import { FadeReveal } from "@/components/FadeReveal";
 
-/**
- * FadeReveal holds children at opacity:0 until every <img> inside has
- * resolved, then swaps to the `glitch-reveal` class. A hidden image
- * (display:none) with loading="lazy" will never fire a load event because
- * the browser skips the fetch — FadeReveal must treat those as already
- * resolved, otherwise it stalls until the 3s safety timeout and the page
- * feels broken.
- */
 describe("FadeReveal", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -20,49 +12,16 @@ describe("FadeReveal", () => {
   });
 
   async function getRevealClass(container: HTMLElement): Promise<string> {
-    // Let the post-mount useEffect flush.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
     return container.firstElementChild?.className ?? "";
   }
 
-  it("reveals immediately when there are no images", async () => {
+  it("reveals on mount without waiting for images", async () => {
     const { container } = render(
       <FadeReveal>
-        <p>content</p>
-      </FadeReveal>,
-    );
-
-    const cls = await getRevealClass(container);
-    expect(cls).toContain("glitch-reveal");
-  });
-
-  it("reveals immediately when every image is already complete", async () => {
-    const { container } = render(
-      <FadeReveal>
-        <img alt="a" />
-      </FadeReveal>,
-    );
-
-    // jsdom reports complete=true for <img> with no src by default
-    const cls = await getRevealClass(container);
-    expect(cls).toContain("glitch-reveal");
-  });
-
-  it("skips images hidden via display:none instead of waiting on them", async () => {
-    // A `display:none` image with loading="lazy" never fires `load` — the
-    // browser correctly skips the fetch. Before the fix, FadeReveal stalled
-    // on this case until the 3s timeout. Regression test isolates the
-    // hidden image alone; if it's not skipped, `ready` stays false.
-    const { container } = render(
-      <FadeReveal>
-        <img
-          alt="hidden"
-          loading="lazy"
-          style={{ display: "none" }}
-          src="/never-fetched.png"
-        />
+        <img alt="a" src="/slow.png" />
       </FadeReveal>,
     );
 
@@ -77,7 +36,6 @@ describe("FadeReveal", () => {
       </FadeReveal>,
     );
 
-    // Inspect before any timers run.
     expect(container.firstElementChild?.className ?? "").toContain(
       "opacity-0",
     );


### PR DESCRIPTION
## Summary
FadeReveal wrapped the entire post page and held it at opacity:0 until every img fired a load event (or 3s timeout). Even with HTML arriving in ~150ms, the page stayed invisible until the hero image loaded — hero latency bottlenecked *text* render.

Image loading is handled by next/image independently. FadeReveal's job is the glitch-in animation; it doesn't need to gate visibility on image readiness.

Change: reveal on mount (one effect tick), drop all image-load listeners.

## Test plan
- [x] Unit tests pass (160/160)
- [ ] Post pages show text+chrome immediately, hero fades in when it arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)