### PR TITLE
feat: wire RichText converter for mermaid block (issue #104 T3)

### DIFF
--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -16,6 +16,10 @@ import { isValidSlug } from "@/lib/types/branded";
 import { isMediaObject } from "@/lib/types/media";
 import { FadeReveal } from "@/components/FadeReveal";
 import { siteUrl, ogDefaultImage } from "@/lib/site-config";
+import { MermaidDiagram } from "@/components/MermaidDiagram";
+import type { SerializedBlockNode } from "@payloadcms/richtext-lexical";
+
+type MermaidBlockFields = { blockType: 'mermaid'; code: string };
 
 // ISR: Revalidate every hour - post content changes infrequently
 export const revalidate = 3600;
@@ -151,7 +155,17 @@ export default async function PostPage({ params }: PostPageProps) {
 
         <TextGlitch>
           <section className="prose dark:prose-invert max-w-none">
-            <RichText data={post.body as SerializedEditorState} />
+            <RichText
+              data={post.body as SerializedEditorState}
+              converters={({ defaultConverters }) => ({
+                ...defaultConverters,
+                blocks: {
+                  mermaid: ({ node }: { node: SerializedBlockNode }) => (
+                    <MermaidDiagram source={(node.fields as unknown as MermaidBlockFields).code} />
+                  ),
+                },
+              })}
+            />
           </section>
         </TextGlitch>
       </PageLayout>


### PR DESCRIPTION
## Summary

Connects the post page's `<RichText>` component to `<MermaidDiagram>` by adding a `converters` prop that intercepts the `mermaid` block slug and renders the diagram component with the stored source code. All other node types pass through unchanged via the `...defaultConverters` spread.

## Changes

- `src/app/(frontend)/posts/[slug]/page.tsx`: added `MermaidDiagram` import, `MermaidBlockFields` type alias, and `converters` prop on the `<RichText>` element.

## Acceptance checks run locally

- `pnpm exec tsc --noEmit`: pass (pre-existing `mermaid` module types error in T2's component is unchanged)
- `pnpm lint`: pass (0 errors, 18 pre-existing warnings, none from changed file)
- `pnpm test:unit`: pass (160/160)
- `pnpm build`: env-var blocked only (`NEXT_PUBLIC_SERVER_URL` required at build time; TS compilation succeeded before the env check)

Closes part of #104 (T3)