### PR TITLE
test: add Playwright E2E smoke for mermaid block (issue #104 T5)

### DIFF
--- a/scripts/seed-test-db.ts
+++ b/scripts/seed-test-db.ts
@@ -333,7 +333,7 @@ async function seedTestDatabase() {
       ),
       tags: [agenticAiTag.id],
       status: 'published',
-      publishedAt: new Date('2026-01-30').toISOString(),
+      publishedAt: new Date('2022-01-01').toISOString(),
       featured: false,
     },
   })

--- a/scripts/seed-test-db.ts
+++ b/scripts/seed-test-db.ts
@@ -8,7 +8,7 @@
 import dotenv from 'dotenv'
 import fs from 'fs'
 import path from 'path'
-import { createRichText, createRichTextMulti } from '../src/lib/rich-text.js'
+import { createRichText, createRichTextMulti, createRichTextWithMermaid } from '../src/lib/rich-text.js'
 
 // Load environment variables from .env.local FIRST
 dotenv.config({ path: '.env.local' })
@@ -315,7 +315,30 @@ async function seedTestDatabase() {
     },
   })
 
-  console.log('✓ Created 6 posts')
+  // Post 7: Published post containing a mermaid block — used by E2E mermaid tests
+  await payload.create({
+    collection: 'posts',
+    data: {
+      title: 'Mermaid Diagram Test Post',
+      slug: 'mermaid-diagram-test-post',
+      type: 'essay',
+      summary: 'A test post containing a mermaid sequence diagram for E2E testing.',
+      // Reuse first media item so required image fields are satisfied
+      featuredImageLight: mediaItems[0].id,
+      featuredImageDark: mediaItems[0].id,
+      body: createRichTextWithMermaid(
+        'sequenceDiagram\n  User->>Server: Request\n  Server-->>User: Response',
+        // Stable UUID so the block id is predictable across seed runs
+        '00000000-0000-0000-0000-000000000001',
+      ),
+      tags: [agenticAiTag.id],
+      status: 'published',
+      publishedAt: new Date('2026-01-30').toISOString(),
+      featured: false,
+    },
+  })
+
+  console.log('✓ Created 7 posts (including mermaid test post)')
 
   // 5. Create About page
   console.log('📄 Creating About page...')
@@ -401,7 +424,7 @@ async function seedTestDatabase() {
   console.log('  • 1 test admin user (test@example.com / testpassword123)')
   console.log('  • 3 tags (Agentic AI, Workflows, Philosophy)')
   console.log('  • 4 media items')
-  console.log('  • 6 posts (3 featured+published, 1 published, 1 draft, 1 archived)')
+  console.log('  • 7 posts (3 featured+published, 2 published, 1 draft, 1 archived, 1 mermaid test)')
   console.log('  • 1 page (About)')
   console.log('  • 1 listing (Featured Essays)')
 

--- a/scripts/seed-test-db.ts
+++ b/scripts/seed-test-db.ts
@@ -333,6 +333,7 @@ async function seedTestDatabase() {
       ),
       tags: [agenticAiTag.id],
       status: 'published',
+      // do not add a pre-2022 seed without auditing posts-listing ordering asserts
       publishedAt: new Date('2022-01-01').toISOString(),
       featured: false,
     },

--- a/src/lib/rich-text.ts
+++ b/src/lib/rich-text.ts
@@ -114,6 +114,17 @@ export function createRichTextWithMermaid(
   mermaidSource: string,
   blockId: string,
 ): LexicalEditorState {
+  const emptyParagraph = (): LexicalParagraphNode => ({
+    type: "paragraph",
+    format: "",
+    indent: 0,
+    version: 1,
+    direction: "ltr",
+    children: [],
+    textStyle: "",
+    textFormat: 0,
+  });
+
   const mermaidNode: LexicalBlockNode = {
     type: "block",
     format: "",
@@ -135,7 +146,11 @@ export function createRichTextWithMermaid(
       // LexicalRootNode.children is typed as LexicalParagraphNode[], but at
       // runtime Payload accepts any valid Lexical node in the children array.
       // The cast is intentional here for seeding purposes only.
-      children: [mermaidNode] as unknown as LexicalParagraphNode[],
+      children: [
+        emptyParagraph(),
+        mermaidNode,
+        emptyParagraph(),
+      ] as unknown as LexicalParagraphNode[],
       direction: "ltr",
     },
   };

--- a/src/lib/rich-text.ts
+++ b/src/lib/rich-text.ts
@@ -87,6 +87,61 @@ export function createRichText(text: string): LexicalEditorState {
 }
 
 /**
+ * Lexical block node structure (for Payload CMS blocks feature)
+ */
+export interface LexicalBlockNode {
+  type: "block";
+  format: string;
+  version: number;
+  fields: {
+    id: string;
+    blockType: string;
+    blockName: string;
+    [key: string]: unknown;
+  };
+}
+
+/**
+ * Create a Lexical editor state containing a single mermaid block node.
+ * The block is wrapped with a leading and trailing paragraph so prose
+ * rendering has context around the diagram.
+ *
+ * @param mermaidSource - Raw mermaid diagram source (e.g. sequenceDiagram …)
+ * @param blockId - Stable UUID for the block (must be unique per post; caller
+ *   supplies it so seeds remain deterministic across runs)
+ */
+export function createRichTextWithMermaid(
+  mermaidSource: string,
+  blockId: string,
+): LexicalEditorState {
+  const mermaidNode: LexicalBlockNode = {
+    type: "block",
+    format: "",
+    version: 1,
+    fields: {
+      id: blockId,
+      blockType: "mermaid",
+      blockName: "",
+      code: mermaidSource,
+    },
+  };
+
+  return {
+    root: {
+      type: "root",
+      format: "",
+      indent: 0,
+      version: 1,
+      // LexicalRootNode.children is typed as LexicalParagraphNode[], but at
+      // runtime Payload accepts any valid Lexical node in the children array.
+      // The cast is intentional here for seeding purposes only.
+      children: [mermaidNode] as unknown as LexicalParagraphNode[],
+      direction: "ltr",
+    },
+  };
+}
+
+/**
  * Create a Lexical rich text structure with multiple paragraphs
  * Each string in the array becomes a separate paragraph
  */

--- a/tests/e2e/public/draft-access-control.spec.ts
+++ b/tests/e2e/public/draft-access-control.spec.ts
@@ -42,7 +42,7 @@ test.describe('Draft and Archived Access Control (Public)', () => {
     await postsPage.goto()
 
     const postCount = await postsPage.getPostCount()
-    expect(postCount).toBe(4)
+    expect(postCount).toBe(5)
 
     const titles = await postsPage.getPostTitles()
     expect(titles).not.toContain('Unpublished Thoughts on Emergence')
@@ -66,7 +66,7 @@ test.describe('Draft and Archived Access Control (Public)', () => {
 
     const data = await response.json()
     expect(data.docs).toBeDefined()
-    expect(data.docs.length).toBe(4)
+    expect(data.docs.length).toBe(5)
 
     const slugs = data.docs.map((post: { slug: string }) => post.slug)
     expect(slugs).not.toContain('unpublished-thoughts-emergence')

--- a/tests/e2e/public/mermaid.spec.ts
+++ b/tests/e2e/public/mermaid.spec.ts
@@ -46,10 +46,12 @@ test.describe('Mermaid block rendering', () => {
 
     const idBefore = await svg.getAttribute('id')
 
-    // The theme toggle label in light mode is "Switch to dark mode"
-    const themeToggle = postDetailPage.page.getByRole('button', {
-      name: 'Switch to dark mode',
-    })
+    // The theme toggle label in light mode is "Switch to dark mode".
+    // Scope to the page <header> (banner role) to avoid matching the
+    // second toggle rendered in the footer status-bar.
+    const themeToggle = postDetailPage.page
+      .getByRole('banner')
+      .getByRole('button', { name: 'Switch to dark mode' })
     await expect(themeToggle).toBeVisible()
     await themeToggle.click()
 

--- a/tests/e2e/public/mermaid.spec.ts
+++ b/tests/e2e/public/mermaid.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '../fixtures'
+
+/**
+ * E2E smoke tests for mermaid block rendering (issue #104 T5)
+ *
+ * Test data: the seeded "Mermaid Diagram Test Post" at
+ *   slug: mermaid-diagram-test-post
+ * contains a sequenceDiagram block with actors "User" and "Server".
+ *
+ * The mermaid render is async post-hydration, so all SVG assertions use
+ * explicit timeouts rather than fixed sleeps.
+ *
+ * Selector note: mermaid sets role="graphics-document document" (two tokens)
+ * on the <svg>, so we match with the CSS substring operator [role*="graphics-document"]
+ * and also verify the id prefix "mermaid-" to avoid matching unrelated SVGs.
+ */
+
+const MERMAID_POST_SLUG = 'mermaid-diagram-test-post'
+const SVG_TIMEOUT = 10_000
+
+// Mermaid emits role="graphics-document document" (two space-separated tokens).
+// Use [role*="graphics-document"] so both the exact and combined values match.
+const MERMAID_SVG = 'svg[id^="mermaid-"][role*="graphics-document"]'
+
+test.describe('Mermaid block rendering', () => {
+  test('renders a mermaid block as SVG on the post page', async ({ postDetailPage }) => {
+    await postDetailPage.goto(MERMAID_POST_SLUG)
+
+    const svg = postDetailPage.page.locator(MERMAID_SVG)
+
+    await expect(svg).toBeVisible({ timeout: SVG_TIMEOUT })
+
+    // The sequenceDiagram source contains "User" and "Server"; mermaid emits
+    // these as <text> nodes inside the SVG.
+    await expect(svg).toContainText('User', { timeout: SVG_TIMEOUT })
+    await expect(svg).toContainText('Server', { timeout: SVG_TIMEOUT })
+  })
+
+  test('re-renders the SVG when the theme is toggled', async ({ postDetailPage }) => {
+    await postDetailPage.goto(MERMAID_POST_SLUG)
+
+    const svg = postDetailPage.page.locator(MERMAID_SVG)
+
+    // Wait for the initial render before reading the id
+    await expect(svg).toBeVisible({ timeout: SVG_TIMEOUT })
+
+    const idBefore = await svg.getAttribute('id')
+
+    // The theme toggle label in light mode is "Switch to dark mode"
+    const themeToggle = postDetailPage.page.getByRole('button', {
+      name: 'Switch to dark mode',
+    })
+    await expect(themeToggle).toBeVisible()
+    await themeToggle.click()
+
+    // After toggling, html element should carry the "dark" class
+    await expect(postDetailPage.page.locator('html')).toHaveClass(/dark/, {
+      timeout: 5_000,
+    })
+
+    // MermaidDiagram re-renders on theme change; the new SVG gets a fresh UUID
+    // id, so waiting for it to differ from the previous id confirms re-render.
+    await expect(svg).toBeVisible({ timeout: SVG_TIMEOUT })
+    await expect
+      .poll(
+        async () => {
+          const idAfter = await svg.getAttribute('id')
+          return idAfter !== idBefore
+        },
+        { timeout: SVG_TIMEOUT },
+      )
+      .toBe(true)
+  })
+})

--- a/tests/e2e/public/posts-listing.spec.ts
+++ b/tests/e2e/public/posts-listing.spec.ts
@@ -200,7 +200,7 @@ test.describe('Posts Listing Page', () => {
       expect(titles).not.toContain('Legacy Post About Early Automation')
 
       // Verify total count
-      expect(titles).toHaveLength(4)
+      expect(titles).toHaveLength(5)
     })
   })
 })

--- a/tests/e2e/public/posts-listing.spec.ts
+++ b/tests/e2e/public/posts-listing.spec.ts
@@ -42,9 +42,9 @@ test.describe('Posts Listing Page', () => {
     test('should display published posts in reverse chronological order', async ({ postsPage }) => {
       await postsPage.goto()
 
-      // Should have exactly 4 published posts (excluding draft and archived)
+      // Should have exactly 5 published posts (excluding draft and archived)
       const postCount = await postsPage.getPostCount()
-      expect(postCount).toBe(4)
+      expect(postCount).toBe(5)
 
       // Verify posts are in reverse chronological order by publishedAt
       const titles = await postsPage.getPostTitles()
@@ -162,9 +162,9 @@ test.describe('Posts Listing Page', () => {
       const draftSummary = postsPage.page.getByText(/Early draft exploring emergent AI behaviors/)
       await expect(draftSummary).not.toBeVisible()
 
-      // Verify we only have 4 posts, not 5 (which would include the draft)
+      // Verify we only have 5 posts, not 6 (which would include the draft)
       const postCount = await postsPage.getPostCount()
-      expect(postCount).toBe(4)
+      expect(postCount).toBe(5)
     })
 
     test('should NOT display archived posts to public users', async ({ postsPage }) => {
@@ -178,9 +178,9 @@ test.describe('Posts Listing Page', () => {
       const archivedSummary = postsPage.page.getByText(/Historical analysis of early automation techniques from the pre-AI era/)
       await expect(archivedSummary).not.toBeVisible()
 
-      // Verify we only have 4 posts, not 5 or 6
+      // Verify we only have 5 posts, not 6 or 7
       const postCount = await postsPage.getPostCount()
-      expect(postCount).toBe(4)
+      expect(postCount).toBe(5)
     })
 
     test('should only display published posts (comprehensive check)', async ({ postsPage }) => {


### PR DESCRIPTION
## Summary

- Adds `tests/e2e/public/mermaid.spec.ts` with two Playwright E2E test cases guarding mermaid block rendering against regressions.
- Extends `scripts/seed-test-db.ts` to seed a mermaid-block post (`mermaid-diagram-test-post`) so tests have stable fixture data.
- Adds `createRichTextWithMermaid()` to `src/lib/rich-text.ts` — a seeding helper that builds a Lexical editor state containing a mermaid block node.

## Changes

| File | What changed |
|---|---|
| `src/lib/rich-text.ts` | New `createRichTextWithMermaid(source, blockId)` export + `LexicalBlockNode` interface |
| `scripts/seed-test-db.ts` | Post 7: "Mermaid Diagram Test Post" seeded with a `sequenceDiagram` block (idempotent — seed clears then reseeds) |
| `tests/e2e/public/mermaid.spec.ts` | 2 E2E tests: SVG visibility + text content; theme-toggle re-render (new SVG id + `dark` class on `<html>`) |

Data approach: **Option A** — seeded post exists before tests run. Idempotency is handled by the seed script's existing clear-first pattern.

## Test cases

1. **`renders a mermaid block as SVG on the post page`** — navigates to `/posts/mermaid-diagram-test-post`, asserts `svg[id^="mermaid-"][role*="graphics-document"]` becomes visible and contains text nodes "User" and "Server" from the `sequenceDiagram` source.

2. **`re-renders the SVG when the theme is toggled`** — captures the initial SVG id, clicks "Switch to dark mode" button, asserts `html` gains the `dark` class, then polls until the SVG id changes (confirming full re-render via `expect.poll`).

All assertions use `toBeVisible` / `toHaveClass` / `expect.poll` with explicit timeouts — no fixed sleeps.

## Acceptance checks run locally

- `pnpm exec tsc --noEmit`: **pass** (0 errors)
- `pnpm lint`: **pass** (0 errors, 18 pre-existing warnings)
- `pnpm test:e2e mermaid.spec`: pending CI (dev server not running locally in this worktree)

Closes part of #104 (T5)