### PR TITLE
fix(scripts): guard seed:test against production databases

### DIFF
--- a/scripts/seed-test-db.ts
+++ b/scripts/seed-test-db.ts
@@ -13,7 +13,31 @@ import { createRichText, createRichTextMulti, createRichTextWithMermaid } from '
 // Load environment variables from .env.local FIRST
 dotenv.config({ path: '.env.local' })
 
+function assertNonProductionDatabase(): void {
+  const raw = process.env.DATABASE_URL
+  if (!raw) throw new Error('DATABASE_URL is not set')
+
+  let host: string
+  try {
+    host = new URL(raw).hostname
+  } catch {
+    throw new Error('DATABASE_URL is not a valid URL')
+  }
+
+  const allowed = /^(localhost|127\.0\.0\.1|::1)$/.test(host) || /(^|[-.])test([-.]|$)/.test(host)
+  if (!allowed) {
+    throw new Error(
+      `seed-test-db refuses to run against host ${host}. This script deletes every row ` +
+        `from listings/posts/pages/media/tags/users. Point DATABASE_URL at a local or test-tier ` +
+        `database (hostname must be localhost/127.0.0.1/::1 or contain a "test" segment), or set ` +
+        `I_KNOW_THIS_IS_NOT_PROD=1 to override.`,
+    )
+  }
+}
+
 async function seedTestDatabase() {
+  if (process.env.I_KNOW_THIS_IS_NOT_PROD !== '1') assertNonProductionDatabase()
+
   console.log('🌱 Starting test database seed...')
 
   // Dynamic import to ensure env vars are loaded first


### PR DESCRIPTION
## Summary

Adds a hostname guard to `scripts/seed-test-db.ts`. The script calls `payload.delete({ collection, where: {} })` on six collections (listings, posts, pages, media, tags, users) with no filter — running it against a production hostname wipes the entire database. The guard allows only `localhost` / `127.0.0.1` / `::1` / hosts containing a `test` segment, or an explicit `I_KNOW_THIS_IS_NOT_PROD=1` override.

## Incident

On 2026-04-24 ~05:20 UTC, a worktreed subagent in this session symlinked `.env.local` into its worktree and ran `pnpm seed:test`. Because `.env.local`'s `DATABASE_URL` points at the Supabase production pooler, the seed wiped and re-seeded production.

**Restored** via the Supabase daily backup taken 2026-04-23 14:54 UTC (≈14.5 hours pre-wipe). Verified: 2 real posts + admin user are back.

## CI compatibility

CI's E2E workflow runs `pnpm seed:test` against `postgres://…@localhost:5432/test_db` — hostname `localhost`, allowed by the guard.

## Changes

- `scripts/seed-test-db.ts`: add `assertNonProductionDatabase()` gate at top of `seedTestDatabase()`.
- `tests/e2e/public/mermaid-debug.spec.ts`: remove (scratch debug file left in worktree by T5 subagent).

## Acceptance checks

- `pnpm exec tsc --noEmit`: 0 errors
- `pnpm lint`: 0 errors on changed files