### PR TITLE
feat(cms): revalidate ISR paths on post change

### DIFF
--- a/src/collections/Posts.ts
+++ b/src/collections/Posts.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig } from 'payload'
 import { createSlugHook } from '@/lib/slug'
 import { publishedOrAuthenticated } from '@/lib/access-control'
+import { revalidateAfterChange, revalidateAfterDelete } from '@/lib/revalidate-post'
 
 export const Posts: CollectionConfig = {
   slug: 'posts',
@@ -14,6 +15,10 @@ export const Posts: CollectionConfig = {
     create: ({ req: { user } }) => !!user,
     update: ({ req: { user } }) => !!user,
     delete: ({ req: { user } }) => !!user,
+  },
+  hooks: {
+    afterChange: [revalidateAfterChange],
+    afterDelete: [revalidateAfterDelete],
   },
   fields: [
     {

--- a/src/lib/revalidate-post.ts
+++ b/src/lib/revalidate-post.ts
@@ -2,7 +2,7 @@ import { revalidatePath } from 'next/cache'
 import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'payload'
 
 const paths = (slug?: string | null) => {
-  const out = ['/', '/posts']
+  const out = ['/', '/posts', '/sitemap.xml', '/feed.xml']
   if (slug) out.push(`/posts/${slug}`)
   return out
 }

--- a/src/lib/revalidate-post.ts
+++ b/src/lib/revalidate-post.ts
@@ -1,0 +1,23 @@
+import { revalidatePath } from 'next/cache'
+import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'payload'
+
+const paths = (slug?: string | null) => {
+  const out = ['/', '/posts']
+  if (slug) out.push(`/posts/${slug}`)
+  return out
+}
+
+export const revalidateAfterChange: CollectionAfterChangeHook = ({ doc, previousDoc }) => {
+  const targets = new Set<string>()
+  for (const p of paths(doc?.slug)) targets.add(p)
+  if (previousDoc?.slug && previousDoc.slug !== doc?.slug) {
+    targets.add(`/posts/${previousDoc.slug}`)
+  }
+  for (const p of targets) revalidatePath(p)
+  return doc
+}
+
+export const revalidateAfterDelete: CollectionAfterDeleteHook = ({ doc }) => {
+  for (const p of paths(doc?.slug)) revalidatePath(p)
+  return doc
+}

--- a/src/lib/revalidate-post.ts
+++ b/src/lib/revalidate-post.ts
@@ -7,17 +7,29 @@ const paths = (slug?: string | null) => {
   return out
 }
 
+// Safe revalidate: no-op when invoked outside a Next.js request context
+// (e.g. seed scripts, `payload migrate`, Local API CLI). In those contexts
+// `revalidatePath` throws "Invariant: static generation store missing" — we
+// have no ISR cache to invalidate there, so silently skipping is correct.
+const safeRevalidate = (path: string) => {
+  try {
+    revalidatePath(path)
+  } catch {
+    // outside request scope; nothing to invalidate
+  }
+}
+
 export const revalidateAfterChange: CollectionAfterChangeHook = ({ doc, previousDoc }) => {
   const targets = new Set<string>()
   for (const p of paths(doc?.slug)) targets.add(p)
   if (previousDoc?.slug && previousDoc.slug !== doc?.slug) {
     targets.add(`/posts/${previousDoc.slug}`)
   }
-  for (const p of targets) revalidatePath(p)
+  for (const p of targets) safeRevalidate(p)
   return doc
 }
 
 export const revalidateAfterDelete: CollectionAfterDeleteHook = ({ doc }) => {
-  for (const p of paths(doc?.slug)) revalidatePath(p)
+  for (const p of paths(doc?.slug)) safeRevalidate(p)
   return doc
 }


### PR DESCRIPTION
## Summary

Adds `afterChange` + `afterDelete` hooks on the Posts collection that call `revalidatePath` for `/`, `/posts`, and `/posts/[slug]`. Publishing a post now makes it visible on the frontend within one request, instead of requiring a manual Cloud Run revision bump or waiting for the 30–60 min ISR stale-time to expire.

## Context

Publishing **Subagent Orchestration Workflow** (post id 5) today exposed a gap: the post rendered correctly at `/posts/subagent-orchestration-workflow`, but `/` and `/posts` served cached HTML that didn't include it. The only remedies before this PR were:

1. Wait out the `s-maxage` TTL (30 min for `/`, 60 min for `/posts`).
2. Bump a no-op env var on Cloud Run to force a new revision with an empty in-container ISR cache.

Neither is acceptable as a workflow.

## Changes

- New `src/lib/revalidate-post.ts` exports `revalidateAfterChange` and `revalidateAfterDelete` hooks. Both use `revalidatePath` from `next/cache`. On slug change, the previous slug's page is also invalidated.
- `src/collections/Posts.ts` registers the two hooks.

## Acceptance

- `pnpm exec tsc --noEmit`: 0 errors
- `pnpm lint`: 0 errors on changed files

## Follow-ups (not in this PR)

- Remove the two `CACHE_BUST` env vars I added to the Cloud Run service (`detached-node-00014-mbb` and `-00015-6b2` revisions). They were operational workarounds; once this merges and a fresh deploy runs, they can go.