### PR TITLE
infra: GCP billing kill-switch Cloud Function (WIP)

### DIFF
--- a/infra/budget-killswitch/README.md
+++ b/infra/budget-killswitch/README.md
@@ -24,12 +24,14 @@ gcloud projects add-iam-policy-binding detached-node \
   --role=roles/billing.projectManager
 
 # Lets the Pub/Sub push subscription invoke the underlying Cloud Run service.
+# For Gen 2 + --trigger-topic, the invoker is the Pub/Sub-managed service
+# agent, NOT the function's runtime SA.
 gcloud run services add-iam-policy-binding budget-killswitch \
   --region=us-west1 \
-  --member=serviceAccount:budget-killswitch@detached-node.iam.gserviceaccount.com \
+  --member=serviceAccount:service-474426172729@gcp-sa-pubsub.iam.gserviceaccount.com \
   --role=roles/run.invoker
 
-# Lets the Pub/Sub service agent mint OIDC tokens for that SA.
+# Lets the Pub/Sub service agent mint OIDC tokens for the function's runtime SA.
 gcloud iam service-accounts add-iam-policy-binding \
   budget-killswitch@detached-node.iam.gserviceaccount.com \
   --member=serviceAccount:service-474426172729@gcp-sa-pubsub.iam.gserviceaccount.com \
@@ -52,7 +54,7 @@ detached.
 ```
 gcloud functions deploy budget-killswitch \
   --gen2 \
-  --region=us-central1 \
+  --region=us-west1 \
   --runtime=python312 \
   --entry-point=handle_budget_alert \
   --trigger-topic=budget-alerts \

--- a/infra/budget-killswitch/README.md
+++ b/infra/budget-killswitch/README.md
@@ -1,0 +1,77 @@
+# Budget kill switch
+
+Cloud Function that detaches billing from `detached-node` when the
+monthly `blog-spend-cap` budget is hit.
+
+## Wiring
+
+- Budget `blog-spend-cap` ($50/mo) publishes to Pub/Sub topic `budget-alerts`
+  on every threshold cross. The budget's email channel warns at 60% ($30)
+  and 90% ($45).
+- Function `budget-killswitch` (2nd gen, Python 3.12) subscribes to that
+  topic and detaches billing when `costAmount >= budgetAmount`.
+- Runtime SA: `budget-killswitch@detached-node.iam.gserviceaccount.com`.
+- Region: `us-west1` (colocated with the `detached-node` Cloud Run service).
+
+### IAM bindings the deploy doesn't create
+
+Granted once, out of band from `gcloud functions deploy`:
+
+```
+# Lets the function detach billing from the project.
+gcloud projects add-iam-policy-binding detached-node \
+  --member=serviceAccount:budget-killswitch@detached-node.iam.gserviceaccount.com \
+  --role=roles/billing.projectManager
+
+# Lets the Pub/Sub push subscription invoke the underlying Cloud Run service.
+gcloud run services add-iam-policy-binding budget-killswitch \
+  --region=us-west1 \
+  --member=serviceAccount:budget-killswitch@detached-node.iam.gserviceaccount.com \
+  --role=roles/run.invoker
+
+# Lets the Pub/Sub service agent mint OIDC tokens for that SA.
+gcloud iam service-accounts add-iam-policy-binding \
+  budget-killswitch@detached-node.iam.gserviceaccount.com \
+  --member=serviceAccount:service-474426172729@gcp-sa-pubsub.iam.gserviceaccount.com \
+  --role=roles/iam.serviceAccountTokenCreator
+```
+
+## Recovery after a trigger
+
+```
+gcloud billing projects link detached-node \
+  --billing-account=011F47-AB44AC-9479DB
+```
+
+Cloud Run services scale back up on the next request. No data is lost;
+Cloud SQL / GCS / Secret Manager keep their contents while billing is
+detached.
+
+## Redeploy
+
+```
+gcloud functions deploy budget-killswitch \
+  --gen2 \
+  --region=us-central1 \
+  --runtime=python312 \
+  --entry-point=handle_budget_alert \
+  --trigger-topic=budget-alerts \
+  --service-account=budget-killswitch@detached-node.iam.gserviceaccount.com \
+  --set-env-vars=TARGET_PROJECT_ID=detached-node \
+  --source=.
+```
+
+## Test without spending $50
+
+Publish a synthetic payload to the topic:
+
+```
+gcloud pubsub topics publish budget-alerts \
+  --message='{"costAmount": 0.01, "budgetAmount": 50}' \
+  --attribute=budgetDisplayName=blog-spend-cap
+```
+
+The under-threshold branch will log and exit without touching billing.
+To dry-run the detach path, temporarily set `costAmount` above
+`budgetAmount` in the message — but only do this if you are prepared
+to re-link billing immediately.

--- a/infra/budget-killswitch/main.py
+++ b/infra/budget-killswitch/main.py
@@ -2,29 +2,32 @@
 actual spend meets or exceeds the budgeted amount.
 
 Triggered by Pub/Sub messages from a GCP Budget notification channel.
-The message attributes carry `budgetAmount` and `costAmount`; the
-payload JSON carries the full budget event. We detach billing iff
-costAmount >= budgetAmount.
+Deployed as a Gen 2 Cloud Function, so the runtime delivers a
+CloudEvent. The Pub/Sub message JSON carries `budgetAmount` and
+`costAmount`; we detach billing iff costAmount >= budgetAmount.
 """
 
 import base64
 import json
 import os
 
+import functions_framework
 from google.cloud import billing_v1
 
 PROJECT_ID = os.environ["TARGET_PROJECT_ID"]
 PROJECT_NAME = f"projects/{PROJECT_ID}"
 
 
-def handle_budget_alert(event, context):
-    pubsub_message = event.get("data")
-    if not pubsub_message:
-        print("No data in event; ignoring.")
+@functions_framework.cloud_event
+def handle_budget_alert(cloud_event):
+    try:
+        encoded = cloud_event.data["message"]["data"]
+    except (KeyError, TypeError) as exc:
+        print(f"CloudEvent missing message.data: {exc}")
         return
 
     try:
-        payload = json.loads(base64.b64decode(pubsub_message).decode("utf-8"))
+        payload = json.loads(base64.b64decode(encoded).decode("utf-8"))
     except (ValueError, TypeError) as exc:
         print(f"Could not decode payload: {exc}")
         return

--- a/infra/budget-killswitch/main.py
+++ b/infra/budget-killswitch/main.py
@@ -1,0 +1,50 @@
+"""Cloud Function that detaches billing from a project when a budget's
+actual spend meets or exceeds the budgeted amount.
+
+Triggered by Pub/Sub messages from a GCP Budget notification channel.
+The message attributes carry `budgetAmount` and `costAmount`; the
+payload JSON carries the full budget event. We detach billing iff
+costAmount >= budgetAmount.
+"""
+
+import base64
+import json
+import os
+
+from google.cloud import billing_v1
+
+PROJECT_ID = os.environ["TARGET_PROJECT_ID"]
+PROJECT_NAME = f"projects/{PROJECT_ID}"
+
+
+def handle_budget_alert(event, context):
+    pubsub_message = event.get("data")
+    if not pubsub_message:
+        print("No data in event; ignoring.")
+        return
+
+    try:
+        payload = json.loads(base64.b64decode(pubsub_message).decode("utf-8"))
+    except (ValueError, TypeError) as exc:
+        print(f"Could not decode payload: {exc}")
+        return
+
+    cost = float(payload.get("costAmount", 0))
+    budget = float(payload.get("budgetAmount", 0))
+    print(f"Budget alert: cost={cost} budget={budget}")
+
+    if budget <= 0 or cost < budget:
+        print("Under threshold; no action.")
+        return
+
+    client = billing_v1.CloudBillingClient()
+    info = client.get_project_billing_info(name=PROJECT_NAME)
+    if not info.billing_enabled:
+        print("Billing already disabled; no action.")
+        return
+
+    client.update_project_billing_info(
+        name=PROJECT_NAME,
+        project_billing_info=billing_v1.ProjectBillingInfo(billing_account_name=""),
+    )
+    print(f"Disabled billing on {PROJECT_ID}.")

--- a/infra/budget-killswitch/requirements.txt
+++ b/infra/budget-killswitch/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-billing==1.14.0

--- a/infra/budget-killswitch/requirements.txt
+++ b/infra/budget-killswitch/requirements.txt
@@ -1,1 +1,2 @@
+functions-framework==3.*
 google-cloud-billing==1.14.0


### PR DESCRIPTION
## Summary
- Adds a Pub/Sub-triggered Cloud Function (Python 3.12) that detaches billing from the `detached-node` GCP project when the monthly `blog-spend-cap` budget is fully consumed.
- Budget alerts fire at 60% / 90% via email; 100% triggers the kill-switch via the `budget-alerts` Pub/Sub topic.
- Includes a README documenting the out-of-band IAM bindings (`billing.projectManager`, `run.invoker`, `iam.serviceAccountTokenCreator`) that `gcloud functions deploy` cannot create on its own.

## Status
Marked **draft / WIP** — the code is in place but the Cloud Function has not yet been deployed and the budget has not yet been created in the GCP console. This PR exists to stop the work from living untracked in the working tree.

## Motivation
After the 2026-04-22 Vercel billing incident and the 2026-04-24 seed-test-db prod wipe, there's appetite for a hard cost ceiling. $50/mo is well above current GCR spend (~$7/mo with `min-instances=1`) and below the budget where a runaway would hurt.

## Test plan
- [ ] Deploy the function to `us-west1`
- [ ] Create budget `blog-spend-cap` ($50/mo) and wire it to Pub/Sub topic `budget-alerts`
- [ ] Apply the three IAM bindings from the README
- [ ] Force-publish a synthetic threshold message and confirm the function runs (no-op when `costAmount < budgetAmount`)
- [ ] Document the recovery runbook for after a trigger (the README has a "Recovery" section to flesh out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)