### PR TITLE
Mermaid diagram lightbox: dark-mode contrast, sizing, and click-to-zoom

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ PAYLOAD_SECRET=your-32-char-or-longer-secret-here
 NEXT_PUBLIC_SERVER_URL=http://localhost:3000
 
 # GCS media storage (S3-compat via HMAC keys)
+# Required in dev to render images that live in the production bucket.
+# Required on Cloud Run (enforced by payload.config.ts via K_SERVICE check).
+# When unset locally, the s3Storage plugin disables and Payload falls back
+# to `public/media/` (gitignored — empty unless seeded).
 GCS_BUCKET=your-bucket-name
 GCS_HMAC_ACCESS_KEY=your-hmac-access-key
 GCS_HMAC_SECRET=your-hmac-secret

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "next": "16.2.4",
     "next-themes": "^0.4.6",
     "next-view-transitions": "^0.3.5",
+    "panzoom": "^9.4.4",
     "payload": "^3.83.0",
     "react": "19.2.5",
     "react-dom": "19.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       next-view-transitions:
         specifier: ^0.3.5
         version: 0.3.5(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      panzoom:
+        specifier: ^9.4.4
+        version: 9.4.4
       payload:
         specifier: ^3.83.0
         version: 3.83.0(graphql@16.13.2)(typescript@6.0.3)
@@ -2575,6 +2578,9 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  amator@1.1.0:
+    resolution: {integrity: sha512-V5+aH8pe+Z3u/UG3L3pG3BaFQGXAyXHVQDroRwjPHdh08bcUEchAVsU1MCuJSCaU5o60wTK6KaE6te5memzgYw==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2684,6 +2690,9 @@ packages:
     resolution: {integrity: sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bezier-easing@2.1.0:
+    resolution: {integrity: sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -4372,6 +4381,9 @@ packages:
       sass:
         optional: true
 
+  ngraph.events@1.4.0:
+    resolution: {integrity: sha512-NeDGI4DSyjBNBRtA86222JoYietsmCXbs8CEB0dZ51Xeh4lhVl1y3wpWLumczvnha8sFQIW4E0vvVWwgmX2mGw==}
+
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
@@ -4446,6 +4458,9 @@ packages:
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  panzoom@9.4.4:
+    resolution: {integrity: sha512-r1KfkNZvsBw59IPq7Yy+GWZnZE1YCG/t7aG6caSkij/TBqdxTzmxNTm/lHf3h6qlVMFisIGIO+lgS2Ym23PIoA==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -5361,6 +5376,9 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  wheel@1.0.0:
+    resolution: {integrity: sha512-XiCMHibOiqalCQ+BaNSwRoZ9FDTAvOsXxGHXChBugewDj7HC8VBIER71dEOiRH1fSdLbRCQzngKTSiZ06ZQzeA==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -8287,6 +8305,10 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  amator@1.1.0:
+    dependencies:
+      bezier-easing: 2.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
@@ -8414,6 +8436,8 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.19: {}
+
+  bezier-easing@2.1.0: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -10413,6 +10437,8 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  ngraph.events@1.4.0: {}
+
   node-exports-info@1.6.0:
     dependencies:
       array.prototype.flatmap: 1.3.3
@@ -10500,6 +10526,12 @@ snapshots:
       p-limit: 3.1.0
 
   package-manager-detector@1.6.0: {}
+
+  panzoom@9.4.4:
+    dependencies:
+      amator: 1.1.0
+      ngraph.events: 1.4.0
+      wheel: 1.0.0
 
   parent-module@1.0.1:
     dependencies:
@@ -11529,6 +11561,8 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  wheel@1.0.0: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,6 +1,7 @@
 import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { UploadFeatureClient as UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
@@ -29,6 +30,7 @@ export const importMap = {
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#UploadFeatureClient": UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -758,3 +758,10 @@ dialog.mermaid-lightbox::backdrop {
     opacity: 0;
   }
 }
+
+/* Glitch-out exit animation — same RGB-split keyframe the page
+   transition uses. The component delays dialog.close() until this
+   animation finishes (otherwise the dialog just disappears). */
+.glitch-conceal {
+  animation: glitch-out 150ms ease-in forwards;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -726,3 +726,8 @@ a.card-scanline:active {
   display: flex;
   justify-content: center;
 }
+
+.mermaid-figure svg[id^="mermaid-"] {
+  display: block;
+  margin-inline: auto;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -744,3 +744,17 @@ a.card-scanline:active {
 .mermaid-lightbox-stage:active {
   cursor: grabbing;
 }
+
+/* Soft fade for the dialog backdrop on entry. The panel itself glitches
+   in via the `.glitch-reveal` class (RGB-split + opacity, ~400ms). The
+   backdrop just fades to keep the focus on the panel's animation. */
+dialog.mermaid-lightbox::backdrop {
+  opacity: 1;
+  transition: opacity 180ms ease-out;
+}
+
+@starting-style {
+  dialog.mermaid-lightbox[open]::backdrop {
+    opacity: 0;
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -705,3 +705,24 @@ a.card-scanline:active {
     opacity: 0.5;
   }
 }
+
+/* ──────────────────────────────────────────────
+   MERMAID — DARK MODE CONTRAST
+   Sequence-diagram rect bands have hardcoded
+   pale fills from `rect rgb(...)` in the source;
+   re-tint them in dark mode so light arrow text
+   stays readable.
+   ────────────────────────────────────────────── */
+
+.dark svg[aria-roledescription="sequence"] rect[fill="rgb(227, 242, 253)"] {
+  fill: rgba(96, 165, 250, 0.14) !important;
+}
+
+.dark svg[aria-roledescription="sequence"] rect[fill="rgb(232, 245, 233)"] {
+  fill: rgba(34, 197, 94, 0.12) !important;
+}
+
+.mermaid-figure {
+  display: flex;
+  justify-content: center;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -728,8 +728,7 @@ a.card-scanline:active {
 }
 
 .mermaid-figure svg[id^="mermaid-"] {
-  display: block;
-  margin-inline: auto;
+  display: inline-block;
 }
 
 /* The pannable surface inside the diagram lightbox. `touch-action: none`

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -759,9 +759,30 @@ dialog.mermaid-lightbox::backdrop {
   }
 }
 
-/* Glitch-out exit animation — same RGB-split keyframe the page
-   transition uses. The component delays dialog.close() until this
-   animation finishes (otherwise the dialog just disappears). */
+/* Glitch-out exit animation, mirrored from `.glitch-reveal` so the
+   lightbox enters and exits with the same shape (RGB-split + opacity
+   + tiny jitter). The shared `glitch-out` keyframe is unsuitable here
+   because it ends with a horizontal-slit clip-path tuned for the page
+   view-transition, which on a panel-sized element looks like a screen
+   wipe. The component delays dialog.close() until this finishes. */
 .glitch-conceal {
-  animation: glitch-out 150ms ease-in forwards;
+  animation: lightbox-glitch-out 150ms ease-in forwards;
+}
+
+@keyframes lightbox-glitch-out {
+  0% {
+    opacity: 1;
+    filter: none;
+    transform: translateX(0);
+  }
+  40% {
+    opacity: 0.6;
+    filter: url(#rgb-split);
+    transform: translateX(-0.5px);
+  }
+  100% {
+    opacity: 0;
+    filter: url(#rgb-split);
+    transform: translateX(1px);
+  }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -744,18 +744,25 @@ a.card-scanline:active {
   cursor: grabbing;
 }
 
-/* Soft fade for the dialog backdrop on entry. The panel itself glitches
-   in via the `.glitch-reveal` class (RGB-split + opacity, ~400ms). The
-   backdrop just fades to keep the focus on the panel's animation. */
+/* Soft fade-in/out for the lightbox backdrop. The page underneath stays
+   partially visible so the lightbox reads as "on top of" the article
+   rather than replacing it. The exit fade is driven by the `.is-closing`
+   class set by closeDialog() before the dialog actually closes. */
 dialog.mermaid-lightbox::backdrop {
   opacity: 1;
-  transition: opacity 180ms ease-out;
+  transition: opacity 250ms ease-out;
 }
 
 @starting-style {
   dialog.mermaid-lightbox[open]::backdrop {
     opacity: 0;
   }
+}
+
+dialog.mermaid-lightbox.is-closing::backdrop {
+  opacity: 0;
+  transition-duration: 600ms;
+  transition-timing-function: ease-in-out;
 }
 
 /* Glitch-out exit animation, mirrored from `.glitch-reveal` so the

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -731,3 +731,16 @@ a.card-scanline:active {
   display: block;
   margin-inline: auto;
 }
+
+/* The pannable surface inside the diagram lightbox. `touch-action: none`
+   hands all gestures (pinch, pan, drag) to the panzoom library so it can
+   apply transform on the SVG directly — instead of letting the browser
+   pinch-zoom the dialog's visual viewport, which moves the chrome too. */
+.mermaid-lightbox-stage {
+  cursor: grab;
+  touch-action: none;
+}
+
+.mermaid-lightbox-stage:active {
+  cursor: grabbing;
+}

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -174,13 +174,17 @@ export function MermaidDiagram({ source }: Props) {
     if (!svg) return
     // Reset transform first so getBoundingClientRect reflects the SVG's
     // natural (post-layout) size, then compute the scale that fits both
-    // axes inside the stage and translate so the result is centered.
+    // axes inside the stage minus padding so the diagram doesn't crowd
+    // the panel edges (or the close + zoom-control chrome).
     pz.zoomAbs(0, 0, 1)
     pz.moveTo(0, 0)
     const sr = stage.getBoundingClientRect()
     const vr = svg.getBoundingClientRect()
     if (vr.width === 0 || vr.height === 0) return
-    const scale = Math.min(sr.width / vr.width, sr.height / vr.height, 1)
+    const PAD = 56
+    const availW = Math.max(sr.width - PAD * 2, 1)
+    const availH = Math.max(sr.height - PAD * 2, 1)
+    const scale = Math.min(availW / vr.width, availH / vr.height, 1)
     pz.zoomAbs(0, 0, scale)
     const tx = (sr.width - vr.width * scale) / 2
     const ty = (sr.height - vr.height * scale) / 2

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -38,6 +38,7 @@ export function MermaidDiagram({ source }: Props) {
   const mounted = useSyncExternalStore(subscribe, () => true, () => false)
   const [svg, setSvg] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [glitchKey, setGlitchKey] = useState(0)
   const lastInitializedTheme = useRef<string | undefined>(undefined)
   const dialogRef = useRef<HTMLDialogElement | null>(null)
   const triggerRef = useRef<HTMLButtonElement | null>(null)
@@ -96,6 +97,7 @@ export function MermaidDiagram({ source }: Props) {
   }, [source, resolvedTheme, mounted])
 
   function openDialog() {
+    setGlitchKey((k) => k + 1)
     dialogRef.current?.showModal()
     // Wait one frame so the dialog has laid out (otherwise panzoom
     // initializes against zero-size bounds and the first interaction is dead).
@@ -212,9 +214,12 @@ export function MermaidDiagram({ source }: Props) {
         ref={dialogRef}
         onClick={handleBackdropClick}
         aria-label="Expanded diagram"
-        className="m-auto h-[90vh] w-[min(95vw,1400px)] border-0 bg-transparent p-0 backdrop:bg-[rgb(6_5_10_/_0.92)] backdrop:backdrop-blur-md"
+        className="mermaid-lightbox m-auto h-[90vh] w-[min(95vw,1400px)] overflow-hidden border-0 bg-transparent p-0 backdrop:bg-[rgb(6_5_10_/_0.92)] backdrop:backdrop-blur-md"
       >
-        <div className="relative h-full w-full overflow-hidden rounded-sm border border-border bg-surface shadow-[0_0_24px_rgba(180,156,255,0.08)]">
+        <div
+          key={glitchKey}
+          className="glitch-reveal relative h-full w-full overflow-hidden rounded-sm border border-border bg-surface shadow-[0_0_24px_rgba(180,156,255,0.08)]"
+        >
           <span aria-hidden="true" className="frame-label">DIAGRAM</span>
           <button
             type="button"

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -255,7 +255,6 @@ export function MermaidDiagram({ source }: Props) {
           ref={panelRef}
           className="glitch-reveal relative h-full w-full overflow-hidden rounded-sm border border-border bg-surface shadow-[0_0_24px_rgba(180,156,255,0.08)]"
         >
-          <span aria-hidden="true" className="frame-label">DIAGRAM</span>
           <button
             type="button"
             onClick={closeDialog}

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -39,7 +39,8 @@ export function MermaidDiagram({ source }: Props) {
   const [svg, setSvg] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [glitchKey, setGlitchKey] = useState(0)
-  const [closing, setClosing] = useState(false)
+  const closingRef = useRef(false)
+  const panelRef = useRef<HTMLDivElement | null>(null)
   const lastInitializedTheme = useRef<string | undefined>(undefined)
   const dialogRef = useRef<HTMLDialogElement | null>(null)
   const triggerRef = useRef<HTMLButtonElement | null>(null)
@@ -99,6 +100,13 @@ export function MermaidDiagram({ source }: Props) {
 
   function openDialog() {
     setGlitchKey((k) => k + 1)
+    // Dispose any panzoom instance left over from the previous session.
+    // We defer dispose to here (rather than running it during close) so the
+    // SVG keeps its fit transform throughout the exit animation — otherwise
+    // the diagram snaps back to its natural (much larger) size for one
+    // visible frame as the lightbox fades out.
+    pzRef.current?.dispose()
+    pzRef.current = null
     dialogRef.current?.showModal()
     // Wait one frame so the dialog has laid out (otherwise panzoom
     // initializes against zero-size bounds and the first interaction is dead).
@@ -120,15 +128,22 @@ export function MermaidDiagram({ source }: Props) {
   }
 
   function closeDialog() {
-    if (closing) return
-    setClosing(true)
-    // Let the glitch-out animation play before actually closing.
+    if (closingRef.current) return
+    closingRef.current = true
+    // Drive the class swap via DOM mutation, NOT React state. React
+    // re-rendering the panel causes it to re-set the stage's innerHTML
+    // (because reading innerHTML back returns serialized markup that
+    // differs from the input string), which wipes panzoom's transform
+    // mid-animation and produces a "diagram flash zoomed in" frame.
+    panelRef.current?.classList.remove('glitch-reveal')
+    panelRef.current?.classList.add('glitch-conceal')
+    // Let the glitch-out animation play before actually closing. We
+    // intentionally do NOT dispose panzoom here — the next openDialog
+    // disposes any leftover instance before initializing a new one.
     window.setTimeout(() => {
-      pzRef.current?.dispose()
-      pzRef.current = null
       dialogRef.current?.close()
       triggerRef.current?.focus()
-      setClosing(false)
+      closingRef.current = false
     }, 150)
   }
 
@@ -233,7 +248,8 @@ export function MermaidDiagram({ source }: Props) {
       >
         <div
           key={glitchKey}
-          className={`${closing ? 'glitch-conceal' : 'glitch-reveal'} relative h-full w-full overflow-hidden rounded-sm border border-border bg-surface shadow-[0_0_24px_rgba(180,156,255,0.08)]`}
+          ref={panelRef}
+          className="glitch-reveal relative h-full w-full overflow-hidden rounded-sm border border-border bg-surface shadow-[0_0_24px_rgba(180,156,255,0.08)]"
         >
           <span aria-hidden="true" className="frame-label">DIAGRAM</span>
           <button

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -39,6 +39,7 @@ export function MermaidDiagram({ source }: Props) {
   const [svg, setSvg] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [glitchKey, setGlitchKey] = useState(0)
+  const [closing, setClosing] = useState(false)
   const lastInitializedTheme = useRef<string | undefined>(undefined)
   const dialogRef = useRef<HTMLDialogElement | null>(null)
   const triggerRef = useRef<HTMLButtonElement | null>(null)
@@ -119,14 +120,27 @@ export function MermaidDiagram({ source }: Props) {
   }
 
   function closeDialog() {
-    pzRef.current?.dispose()
-    pzRef.current = null
-    dialogRef.current?.close()
-    triggerRef.current?.focus()
+    if (closing) return
+    setClosing(true)
+    // Let the glitch-out animation play before actually closing.
+    window.setTimeout(() => {
+      pzRef.current?.dispose()
+      pzRef.current = null
+      dialogRef.current?.close()
+      triggerRef.current?.focus()
+      setClosing(false)
+    }, 150)
   }
 
   function handleBackdropClick(e: React.MouseEvent<HTMLDialogElement>) {
     if (e.target === dialogRef.current) closeDialog()
+  }
+
+  function handleDialogCancel(e: React.SyntheticEvent<HTMLDialogElement>) {
+    // Intercept Esc so the panel can play its exit animation before
+    // the dialog actually closes.
+    e.preventDefault()
+    closeDialog()
   }
 
   function zoomBy(factor: number) {
@@ -213,12 +227,13 @@ export function MermaidDiagram({ source }: Props) {
       <dialog
         ref={dialogRef}
         onClick={handleBackdropClick}
+        onCancel={handleDialogCancel}
         aria-label="Expanded diagram"
         className="mermaid-lightbox m-auto h-[90vh] w-[min(95vw,1400px)] overflow-hidden border-0 bg-transparent p-0 backdrop:bg-[rgb(6_5_10_/_0.92)] backdrop:backdrop-blur-md"
       >
         <div
           key={glitchKey}
-          className="glitch-reveal relative h-full w-full overflow-hidden rounded-sm border border-border bg-surface shadow-[0_0_24px_rgba(180,156,255,0.08)]"
+          className={`${closing ? 'glitch-conceal' : 'glitch-reveal'} relative h-full w-full overflow-hidden rounded-sm border border-border bg-surface shadow-[0_0_24px_rgba(180,156,255,0.08)]`}
         >
           <span aria-hidden="true" className="frame-label">DIAGRAM</span>
           <button

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -116,15 +116,16 @@ export function MermaidDiagram({ source }: Props) {
     // dialog (~500ms after the user clicked to re-open). Without this,
     // the lightbox blinks shut on its own after a rapid close→reopen.
     if (closeTimerRef.current !== null) {
+      // Cancel the stale close so dialog.close() doesn't fire ~500ms after
+      // re-open. Remove 'is-closing' so the backdrop's fade-out transition
+      // stops mid-flight. The panel itself doesn't need DOM surgery here:
+      // setGlitchKey (below) unmounts the old keyed panel and mounts a fresh
+      // one with className="glitch-reveal …" from JSX, re-running the entry
+      // animation on the new node.
       clearTimeout(closeTimerRef.current)
       closeTimerRef.current = null
       closingRef.current = false
-      // Undo any mid-exit visual state: remove the closing class from the
-      // backdrop and swap the panel back to its enter animation so the
-      // re-opened dialog doesn't land mid-exit.
       dialogRef.current?.classList.remove('is-closing')
-      panelRef.current?.classList.remove('glitch-conceal')
-      panelRef.current?.classList.add('glitch-reveal')
     }
     setGlitchKey((k) => k + 1)
     // Dispose any panzoom instance left over from the previous session.

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import mermaid from 'mermaid'
+import panzoom from 'panzoom'
+import type { PanZoom } from 'panzoom'
 import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import { useTheme } from 'next-themes'
 
@@ -38,6 +40,9 @@ export function MermaidDiagram({ source }: Props) {
   const [error, setError] = useState<string | null>(null)
   const lastInitializedTheme = useRef<string | undefined>(undefined)
   const dialogRef = useRef<HTMLDialogElement | null>(null)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const stageRef = useRef<HTMLDivElement | null>(null)
+  const pzRef = useRef<PanZoom | null>(null)
 
   useEffect(() => {
     if (!mounted) return
@@ -92,14 +97,63 @@ export function MermaidDiagram({ source }: Props) {
 
   function openDialog() {
     dialogRef.current?.showModal()
+    // Wait one frame so the dialog has laid out (otherwise panzoom
+    // initializes against zero-size bounds and the first interaction is dead).
+    requestAnimationFrame(() => {
+      const svgEl = stageRef.current?.querySelector('svg') as SVGSVGElement | null
+      if (!svgEl) return
+      pzRef.current = panzoom(svgEl, {
+        maxZoom: 4,
+        minZoom: 0.25,
+        bounds: true,
+        boundsPadding: 0.15,
+        smoothScroll: false,
+        zoomDoubleClickSpeed: 1,
+      })
+      // Defer fit one more frame so panzoom finishes its own first-frame
+      // setup before we apply the initial fit transform.
+      requestAnimationFrame(fitToScreen)
+    })
   }
 
   function closeDialog() {
+    pzRef.current?.dispose()
+    pzRef.current = null
     dialogRef.current?.close()
+    triggerRef.current?.focus()
   }
 
   function handleBackdropClick(e: React.MouseEvent<HTMLDialogElement>) {
     if (e.target === dialogRef.current) closeDialog()
+  }
+
+  function zoomBy(factor: number) {
+    const pz = pzRef.current
+    const stage = stageRef.current
+    if (!pz || !stage) return
+    const r = stage.getBoundingClientRect()
+    pz.smoothZoom(r.width / 2, r.height / 2, factor)
+  }
+
+  function fitToScreen() {
+    const pz = pzRef.current
+    const stage = stageRef.current
+    if (!pz || !stage) return
+    const svg = stage.querySelector('svg') as SVGSVGElement | null
+    if (!svg) return
+    // Reset transform first so getBoundingClientRect reflects the SVG's
+    // natural (post-layout) size, then compute the scale that fits both
+    // axes inside the stage and translate so the result is centered.
+    pz.zoomAbs(0, 0, 1)
+    pz.moveTo(0, 0)
+    const sr = stage.getBoundingClientRect()
+    const vr = svg.getBoundingClientRect()
+    if (vr.width === 0 || vr.height === 0) return
+    const scale = Math.min(sr.width / vr.width, sr.height / vr.height, 1)
+    pz.zoomAbs(0, 0, scale)
+    const tx = (sr.width - vr.width * scale) / 2
+    const ty = (sr.height - vr.height * scale) / 2
+    pz.moveTo(tx, ty)
   }
 
   if (error !== null) {
@@ -124,14 +178,20 @@ export function MermaidDiagram({ source }: Props) {
     )
   }
 
+  const chromeBtn =
+    'inline-flex h-9 w-9 items-center justify-center bg-transparent text-text-tertiary ' +
+    'transition-colors duration-150 hover:bg-hover-bg hover:text-accent ' +
+    'focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-focus-ring'
+
   return (
     <>
       <div className="mermaid-figure my-10">
         <button
+          ref={triggerRef}
           type="button"
           onClick={openDialog}
           aria-label="Expand diagram"
-          className="group relative block w-full cursor-zoom-in rounded-sm border-0 bg-transparent p-0 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-400"
+          className="group relative block w-full cursor-zoom-in rounded-sm border-0 bg-transparent p-0 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-focus-ring"
         >
           <span
             className="block text-center"
@@ -140,9 +200,9 @@ export function MermaidDiagram({ source }: Props) {
           />
           <span
             aria-hidden="true"
-            className="pointer-events-none absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded-md bg-black/45 text-white opacity-50 backdrop-blur-sm transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100"
+            className="pointer-events-none absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded-sm border border-border bg-surface/85 text-text-tertiary opacity-60 backdrop-blur-sm transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100"
           >
-            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
               <path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7" />
             </svg>
           </span>
@@ -152,24 +212,62 @@ export function MermaidDiagram({ source }: Props) {
         ref={dialogRef}
         onClick={handleBackdropClick}
         aria-label="Expanded diagram"
-        className="m-auto h-[90vh] w-[min(95vw,1400px)] border-0 bg-transparent p-0 backdrop:bg-zinc-950/85 backdrop:backdrop-blur-sm"
+        className="m-auto h-[90vh] w-[min(95vw,1400px)] border-0 bg-transparent p-0 backdrop:bg-[rgb(6_5_10_/_0.92)] backdrop:backdrop-blur-md"
       >
-        <div className="relative flex h-full w-full flex-col overflow-auto rounded-md border border-zinc-200 bg-white p-10 dark:border-zinc-700 dark:bg-zinc-900">
+        <div className="relative h-full w-full overflow-hidden rounded-sm border border-border bg-surface shadow-[0_0_24px_rgba(180,156,255,0.08)]">
+          <span aria-hidden="true" className="frame-label">DIAGRAM</span>
           <button
             type="button"
             onClick={closeDialog}
             aria-label="Close"
-            className="absolute right-2 top-2 inline-flex h-9 w-9 items-center justify-center rounded-md border-0 bg-transparent text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-900 focus-visible:bg-zinc-100 focus-visible:text-zinc-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:focus-visible:bg-zinc-800 dark:focus-visible:text-zinc-100"
+            className={`absolute right-3 top-3 z-10 rounded-sm border-0 ${chromeBtn}`}
           >
-            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
               <path d="M18 6L6 18M6 6l12 12" />
             </svg>
           </button>
           <div
-            className="flex justify-center [touch-action:pinch-zoom]"
+            ref={stageRef}
+            className="mermaid-lightbox-stage relative h-full w-full"
             // mermaid.render() produces sanitized SVG; securityLevel:'strict' prevents injection
             dangerouslySetInnerHTML={{ __html: uncapDiagramWidth(svg) }}
           />
+          <div
+            role="group"
+            aria-label="Zoom controls"
+            className="absolute bottom-4 right-4 z-10 inline-flex items-stretch overflow-hidden rounded-sm border border-border bg-surface/95 backdrop-blur-sm"
+          >
+            <button
+              type="button"
+              onClick={() => zoomBy(0.8)}
+              aria-label="Zoom out"
+              className={chromeBtn}
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+                <path d="M5 12h14" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              onClick={fitToScreen}
+              aria-label="Fit to screen"
+              className={`${chromeBtn} border-l border-border`}
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M4 9V5h4M20 9V5h-4M4 15v4h4M20 15v4h-4" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              onClick={() => zoomBy(1.25)}
+              aria-label="Zoom in"
+              className={`${chromeBtn} border-l border-border`}
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 5v14M5 12h14" />
+              </svg>
+            </button>
+          </div>
         </div>
       </dialog>
     </>

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -22,6 +22,13 @@ function capDiagramWidth(svgMarkup: string): string {
   return svgMarkup.replace(/(style="[^"]*?max-width:\s*)\d+(?:\.\d+)?px/, `$1${cap}px`)
 }
 
+function uncapDiagramWidth(svgMarkup: string): string {
+  // Strip the inline max-width so the SVG fills the lightbox container.
+  // The id is kept identical to the inline copy so mermaid's embedded
+  // <style> rules (scoped via that id) continue to apply.
+  return svgMarkup.replace(/max-width:\s*\d+(?:\.\d+)?px;?\s*/, '')
+}
+
 const subscribe = () => () => {}
 
 export function MermaidDiagram({ source }: Props) {
@@ -30,6 +37,7 @@ export function MermaidDiagram({ source }: Props) {
   const [svg, setSvg] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const lastInitializedTheme = useRef<string | undefined>(undefined)
+  const dialogRef = useRef<HTMLDialogElement | null>(null)
 
   useEffect(() => {
     if (!mounted) return
@@ -82,6 +90,18 @@ export function MermaidDiagram({ source }: Props) {
     }
   }, [source, resolvedTheme, mounted])
 
+  function openDialog() {
+    dialogRef.current?.showModal()
+  }
+
+  function closeDialog() {
+    dialogRef.current?.close()
+  }
+
+  function handleBackdropClick(e: React.MouseEvent<HTMLDialogElement>) {
+    if (e.target === dialogRef.current) closeDialog()
+  }
+
   if (error !== null) {
     return (
       <div className="my-6 overflow-x-auto">
@@ -105,10 +125,53 @@ export function MermaidDiagram({ source }: Props) {
   }
 
   return (
-    <div
-      className="mermaid-figure my-10"
-      // mermaid.render() produces sanitized SVG; securityLevel:'strict' prevents injection
-      dangerouslySetInnerHTML={{ __html: svg }}
-    />
+    <>
+      <div className="mermaid-figure my-10">
+        <button
+          type="button"
+          onClick={openDialog}
+          aria-label="Expand diagram"
+          className="group relative block w-full cursor-zoom-in rounded-sm border-0 bg-transparent p-0 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-400"
+        >
+          <span
+            className="block"
+            // mermaid.render() produces sanitized SVG; securityLevel:'strict' prevents injection
+            dangerouslySetInnerHTML={{ __html: svg }}
+          />
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded-md bg-black/45 text-white opacity-50 backdrop-blur-sm transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100"
+          >
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7" />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <dialog
+        ref={dialogRef}
+        onClick={handleBackdropClick}
+        aria-label="Expanded diagram"
+        className="m-auto h-[90vh] w-[min(95vw,1400px)] border-0 bg-transparent p-0 backdrop:bg-zinc-950/85 backdrop:backdrop-blur-sm"
+      >
+        <div className="relative flex h-full w-full flex-col overflow-auto rounded-md border border-zinc-200 bg-white p-10 dark:border-zinc-700 dark:bg-zinc-900">
+          <button
+            type="button"
+            onClick={closeDialog}
+            aria-label="Close"
+            className="absolute right-2 top-2 inline-flex h-9 w-9 items-center justify-center rounded-md border-0 bg-transparent text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-900 focus-visible:bg-zinc-100 focus-visible:text-zinc-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100 dark:focus-visible:bg-zinc-800 dark:focus-visible:text-zinc-100"
+          >
+            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+          <div
+            className="flex justify-center [touch-action:pinch-zoom]"
+            // mermaid.render() produces sanitized SVG; securityLevel:'strict' prevents injection
+            dangerouslySetInnerHTML={{ __html: uncapDiagramWidth(svg) }}
+          />
+        </div>
+      </dialog>
+    </>
   )
 }

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -40,6 +40,7 @@ export function MermaidDiagram({ source }: Props) {
   const [error, setError] = useState<string | null>(null)
   const [glitchKey, setGlitchKey] = useState(0)
   const closingRef = useRef(false)
+  const closeTimerRef = useRef<number | null>(null)
   const panelRef = useRef<HTMLDivElement | null>(null)
   const lastInitializedTheme = useRef<string | undefined>(undefined)
   const dialogRef = useRef<HTMLDialogElement | null>(null)
@@ -98,7 +99,33 @@ export function MermaidDiagram({ source }: Props) {
     }
   }, [source, resolvedTheme, mounted])
 
+  // Clear any in-flight close timer on unmount so a pending dialog.close()
+  // doesn't fire against an unmounted component.
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current !== null) {
+        clearTimeout(closeTimerRef.current)
+        closeTimerRef.current = null
+      }
+    }
+  }, [])
+
   function openDialog() {
+    // If a close animation is still in flight, cancel its timer so the
+    // lingering timeout cannot fire dialog.close() on the just-reopened
+    // dialog (~500ms after the user clicked to re-open). Without this,
+    // the lightbox blinks shut on its own after a rapid close→reopen.
+    if (closeTimerRef.current !== null) {
+      clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
+      closingRef.current = false
+      // Undo any mid-exit visual state: remove the closing class from the
+      // backdrop and swap the panel back to its enter animation so the
+      // re-opened dialog doesn't land mid-exit.
+      dialogRef.current?.classList.remove('is-closing')
+      panelRef.current?.classList.remove('glitch-conceal')
+      panelRef.current?.classList.add('glitch-reveal')
+    }
     setGlitchKey((k) => k + 1)
     // Dispose any panzoom instance left over from the previous session.
     // We defer dispose to here (rather than running it during close) so the
@@ -142,7 +169,8 @@ export function MermaidDiagram({ source }: Props) {
     // Let the glitch-out animation play before actually closing. We
     // intentionally do NOT dispose panzoom here — the next openDialog
     // disposes any leftover instance before initializing a new one.
-    window.setTimeout(() => {
+    closeTimerRef.current = window.setTimeout(() => {
+      closeTimerRef.current = null
       dialogRef.current?.close()
       triggerRef.current?.focus()
       closingRef.current = false

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -134,7 +134,7 @@ export function MermaidDiagram({ source }: Props) {
           className="group relative block w-full cursor-zoom-in rounded-sm border-0 bg-transparent p-0 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-400"
         >
           <span
-            className="block"
+            className="block text-center"
             // mermaid.render() produces sanitized SVG; securityLevel:'strict' prevents injection
             dangerouslySetInnerHTML={{ __html: svg }}
           />

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -107,6 +107,7 @@ export function MermaidDiagram({ source }: Props) {
     // visible frame as the lightbox fades out.
     pzRef.current?.dispose()
     pzRef.current = null
+    dialogRef.current?.classList.remove('is-closing')
     dialogRef.current?.showModal()
     // Wait one frame so the dialog has laid out (otherwise panzoom
     // initializes against zero-size bounds and the first interaction is dead).
@@ -137,6 +138,7 @@ export function MermaidDiagram({ source }: Props) {
     // mid-animation and produces a "diagram flash zoomed in" frame.
     panelRef.current?.classList.remove('glitch-reveal')
     panelRef.current?.classList.add('glitch-conceal')
+    dialogRef.current?.classList.add('is-closing')
     // Let the glitch-out animation play before actually closing. We
     // intentionally do NOT dispose panzoom here — the next openDialog
     // disposes any leftover instance before initializing a new one.
@@ -144,7 +146,7 @@ export function MermaidDiagram({ source }: Props) {
       dialogRef.current?.close()
       triggerRef.current?.focus()
       closingRef.current = false
-    }, 150)
+    }, 600)
   }
 
   function handleBackdropClick(e: React.MouseEvent<HTMLDialogElement>) {
@@ -248,7 +250,7 @@ export function MermaidDiagram({ source }: Props) {
         onClick={handleBackdropClick}
         onCancel={handleDialogCancel}
         aria-label="Expanded diagram"
-        className="mermaid-lightbox m-auto h-[90vh] w-[min(95vw,1400px)] overflow-hidden border-0 bg-transparent p-0 backdrop:bg-[rgb(6_5_10_/_0.92)] backdrop:backdrop-blur-md"
+        className="mermaid-lightbox m-auto h-[90vh] w-[min(95vw,1400px)] overflow-hidden border-0 bg-transparent p-0 backdrop:bg-[rgb(6_5_10_/_0.75)] backdrop:backdrop-blur-sm"
       >
         <div
           key={glitchKey}

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -221,6 +221,33 @@ export function MermaidDiagram({ source }: Props) {
     pz.moveTo(tx, ty)
   }
 
+  // F2: When the theme flips while the lightbox is open, the render effect
+  // above updates `svg` state and React re-renders the stage with the new
+  // SVG markup. The old pzRef still points at the previous (now-detached)
+  // SVG node — all pan/zoom gestures become dead. Re-initialize panzoom
+  // against the freshly mounted SVG element whenever `svg` changes and the
+  // dialog is currently open. Dispose first to avoid duplicate listeners.
+  // This path is separate from openDialog, which also disposes (handling
+  // the "leftover from a previous session" case on normal re-open).
+  useEffect(() => {
+    if (!dialogRef.current?.open) return
+    pzRef.current?.dispose()
+    pzRef.current = null
+    requestAnimationFrame(() => {
+      const svgEl = stageRef.current?.querySelector('svg') as SVGSVGElement | null
+      if (!svgEl) return
+      pzRef.current = panzoom(svgEl, {
+        maxZoom: 4,
+        minZoom: 0.25,
+        bounds: true,
+        boundsPadding: 0.15,
+        smoothScroll: false,
+        zoomDoubleClickSpeed: 1,
+      })
+      requestAnimationFrame(fitToScreen)
+    })
+  }, [svg])
+
   if (error !== null) {
     return (
       <div className="my-6 overflow-x-auto">

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -8,6 +8,20 @@ interface Props {
   source: string
 }
 
+// Cap each diagram's render scale to this value so text size is
+// consistent across diagrams of different intrinsic widths. With a
+// ~768px column, a sequence diagram of viewBox width ~1230 caps at
+// scale 0.624 — pinning the global cap there keeps narrow diagrams
+// from rendering at 1:1 (which would make their text visibly larger).
+const TARGET_SCALE = 0.625
+
+function capDiagramWidth(svgMarkup: string): string {
+  const vbMatch = svgMarkup.match(/viewBox="[^"]*?\s(\d+(?:\.\d+)?)\s+\d+(?:\.\d+)?"/)
+  if (!vbMatch) return svgMarkup
+  const cap = Math.round(parseFloat(vbMatch[1]) * TARGET_SCALE)
+  return svgMarkup.replace(/(style="[^"]*?max-width:\s*)\d+(?:\.\d+)?px/, `$1${cap}px`)
+}
+
 const subscribe = () => () => {}
 
 export function MermaidDiagram({ source }: Props) {
@@ -24,13 +38,25 @@ export function MermaidDiagram({ source }: Props) {
 
     async function render() {
       const id = `mermaid-${crypto.randomUUID()}`
-      const theme = resolvedTheme === 'dark' ? 'dark' : 'default'
+      const isDark = resolvedTheme === 'dark'
+      const theme = isDark ? 'dark' : 'default'
 
       if (lastInitializedTheme.current !== theme) {
         mermaid.initialize({
           startOnLoad: false,
           securityLevel: 'strict',
           theme,
+          sequence: { useMaxWidth: true },
+          flowchart: { useMaxWidth: true },
+          themeVariables: isDark
+            ? {
+                signalColor: '#d4d4d8',
+                signalTextColor: '#f4f4f5',
+                loopTextColor: '#18181b',
+                noteTextColor: '#f4f4f5',
+                actorTextColor: '#f4f4f5',
+              }
+            : undefined,
         })
         lastInitializedTheme.current = theme
       }
@@ -38,7 +64,7 @@ export function MermaidDiagram({ source }: Props) {
       try {
         const { svg: rendered } = await mermaid.render(id, source)
         if (!cancelled) {
-          setSvg(rendered)
+          setSvg(capDiagramWidth(rendered))
           setError(null)
         }
       } catch (err) {
@@ -72,7 +98,7 @@ export function MermaidDiagram({ source }: Props) {
   if (!mounted || svg === null) {
     return (
       <div
-        className="my-6 min-h-[12rem] animate-pulse rounded-sm bg-zinc-100 dark:bg-zinc-800"
+        className="my-10 min-h-[12rem] animate-pulse rounded-sm bg-zinc-100 dark:bg-zinc-800"
         aria-label="Loading diagram"
       />
     )
@@ -80,7 +106,7 @@ export function MermaidDiagram({ source }: Props) {
 
   return (
     <div
-      className="my-6 flex justify-center overflow-x-auto"
+      className="mermaid-figure my-10"
       // mermaid.render() produces sanitized SVG; securityLevel:'strict' prevents injection
       dangerouslySetInnerHTML={{ __html: svg }}
     />

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -17,14 +17,14 @@ interface Props {
 // from rendering at 1:1 (which would make their text visibly larger).
 const TARGET_SCALE = 0.625
 
-function capDiagramWidth(svgMarkup: string): string {
+export function capDiagramWidth(svgMarkup: string): string {
   const vbMatch = svgMarkup.match(/viewBox="[^"]*?\s(\d+(?:\.\d+)?)\s+\d+(?:\.\d+)?"/)
   if (!vbMatch) return svgMarkup
   const cap = Math.round(parseFloat(vbMatch[1]) * TARGET_SCALE)
   return svgMarkup.replace(/(style="[^"]*?max-width:\s*)\d+(?:\.\d+)?px/, `$1${cap}px`)
 }
 
-function uncapDiagramWidth(svgMarkup: string): string {
+export function uncapDiagramWidth(svgMarkup: string): string {
   // Strip the inline max-width so the SVG fills the lightbox container.
   // The id is kept identical to the inline copy so mermaid's embedded
   // <style> rules (scoped via that id) continue to apply.

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -159,6 +159,7 @@ export interface Media {
   id: number;
   alt: string;
   caption?: string | null;
+  prefix?: string | null;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -437,6 +438,7 @@ export interface UsersSelect<T extends boolean = true> {
 export interface MediaSelect<T extends boolean = true> {
   alt?: T;
   caption?: T;
+  prefix?: T;
   updatedAt?: T;
   createdAt?: T;
   url?: T;

--- a/tests/unit/components/MermaidDiagram.test.tsx
+++ b/tests/unit/components/MermaidDiagram.test.tsx
@@ -140,4 +140,56 @@ describe("MermaidDiagram", () => {
     expect(pre?.textContent).toContain("not valid mermaid");
   });
 
+  it("cancels the pending close timer when the trigger is clicked again mid-close (F1 race)", async () => {
+    render(<MermaidDiagram source="graph LR; A-->B" />);
+
+    // Wait for the SVG to render so the trigger button is visible (real timers).
+    await waitFor(() => {
+      if (!document.querySelector('svg[data-source="graph LR; A-->B"]'))
+        throw new Error("svg not yet rendered");
+    });
+
+    const trigger = screen.getByRole("button", { name: /expand diagram/i });
+    const dialog = document.querySelector("dialog") as HTMLDialogElement;
+
+    // Mock showModal / close on the dialog (jsdom does not implement them).
+    dialog.showModal = vi.fn();
+    dialog.close = vi.fn();
+
+    // Query the Close button directly; screen.getByRole skips elements
+    // inside a dialog that jsdom treats as not yet open.
+    const closeBtn = dialog.querySelector(
+      'button[aria-label="Close"]',
+    ) as HTMLButtonElement;
+    expect(closeBtn).toBeTruthy();
+
+    // Switch to fake timers now that async setup is done. This lets us
+    // precisely control the 600ms close animation delay without polling.
+    vi.useFakeTimers();
+
+    try {
+      // 1. Open the lightbox.
+      act(() => { trigger.click(); });
+      expect(dialog.showModal).toHaveBeenCalledTimes(1);
+
+      // 2. Click the close button — starts the 600ms animation timer.
+      act(() => { closeBtn.click(); });
+
+      // The timer is running but has NOT fired yet.
+      expect(dialog.close).not.toHaveBeenCalled();
+
+      // 3. Re-open before the timer fires (simulating rapid close→reopen).
+      act(() => { trigger.click(); });
+      expect(dialog.showModal).toHaveBeenCalledTimes(2);
+
+      // 4. Advance past the original 600ms deadline.
+      act(() => { vi.advanceTimersByTime(700); });
+
+      // The dialog must NOT have been closed — the timer was cancelled.
+      expect(dialog.close).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
 });

--- a/tests/unit/components/mermaid-svg-helpers.test.ts
+++ b/tests/unit/components/mermaid-svg-helpers.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { capDiagramWidth, uncapDiagramWidth } from '@/components/MermaidDiagram'
+
+// ---------------------------------------------------------------------------
+// Realistic mermaid SVG fixture — representative of what mermaid.render()
+// emits for a sequence diagram. Constructed from the known output shape:
+//   - Scoped id (mermaid-<uuid>)
+//   - Embedded <style> block scoped via #<id>
+//   - viewBox with minX/minY plus width/height
+//   - Inline style attribute carrying max-width on the root <svg>
+// ---------------------------------------------------------------------------
+const FIXTURE_SVG = `<svg aria-roledescription="sequence" role="graphics-document document" viewBox="-50 -10 1230 512" style="max-width: 1230px;" id="mermaid-abc123" xmlns="http://www.w3.org/2000/svg" width="100%" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>#mermaid-abc123 { font-family: sans-serif; font-size: 16px; }
+#mermaid-abc123 .actor { fill: #ffffff; stroke: #999; }
+#mermaid-abc123 .sequenceNumber { fill: white; }</style>
+  <g>
+    <rect x="-50" y="-10" width="1230" height="512" fill="transparent"/>
+    <text x="565" y="30" class="actor">Alice</text>
+    <text x="665" y="30" class="actor">Bob</text>
+    <line x1="565" y1="55" x2="665" y2="55" stroke="#333" stroke-width="1"/>
+  </g>
+</svg>`
+
+describe('capDiagramWidth', () => {
+  it('caps max-width to viewBox width × TARGET_SCALE (0.625), rounded', () => {
+    // viewBox width = 1230 → 1230 × 0.625 = 768.75 → Math.round → 769
+    const result = capDiagramWidth(
+      '<svg viewBox="0 0 1230 512" style="max-width: 1230px;">content</svg>',
+    )
+    expect(result).toContain('max-width: 769px')
+  })
+
+  it('leaves the viewBox attribute unchanged', () => {
+    const input = '<svg viewBox="0 0 1230 512" style="max-width: 1230px;">content</svg>'
+    const result = capDiagramWidth(input)
+    expect(result).toContain('viewBox="0 0 1230 512"')
+  })
+
+  it('returns input unchanged when there is no matching viewBox', () => {
+    const input = '<svg style="max-width: 800px;">no viewbox</svg>'
+    expect(capDiagramWidth(input)).toBe(input)
+  })
+
+  it('handles floating-point viewBox dimensions (rounds correctly)', () => {
+    // viewBox width = 1230.5 → 1230.5 × 0.625 = 769.0625 → Math.round → 769
+    const result = capDiagramWidth(
+      '<svg viewBox="-50 -10 1230.5 1426" style="max-width: 1230.5px;">content</svg>',
+    )
+    expect(result).toContain('max-width: 769px')
+  })
+})
+
+describe('uncapDiagramWidth', () => {
+  it('strips max-width while preserving other style properties', () => {
+    const input = '<svg style="background: #fff; max-width: 769px; opacity: 0.5;">x</svg>'
+    const result = uncapDiagramWidth(input)
+    expect(result).not.toMatch(/max-width/)
+    expect(result).toContain('background: #fff;')
+    expect(result).toContain('opacity: 0.5;')
+  })
+
+  it('returns input unchanged when there is no max-width in the style', () => {
+    const input = '<svg style="background: #fff;">x</svg>'
+    expect(uncapDiagramWidth(input)).toBe(input)
+  })
+})
+
+describe('capDiagramWidth + uncapDiagramWidth — guard test with realistic fixture', () => {
+  it('round-trips without mutating viewBox, and cap shrinks max-width below viewBox width', () => {
+    // The fixture has viewBox width = 1230 and max-width: 1230px.
+
+    const capped = capDiagramWidth(FIXTURE_SVG)
+
+    // (a) cap shrank max-width below 1230
+    const cappedWidthMatch = capped.match(/max-width:\s*(\d+)px/)
+    expect(cappedWidthMatch).not.toBeNull()
+    const cappedWidth = parseInt(cappedWidthMatch![1], 10)
+    expect(cappedWidth).toBeLessThan(1230)
+    expect(cappedWidth).toBe(769)
+
+    // (b) viewBox is untouched through the cap pass
+    expect(capped).toContain('viewBox="-50 -10 1230 512"')
+
+    // (c) uncap removes max-width entirely
+    const uncapped = uncapDiagramWidth(capped)
+    expect(uncapped).not.toMatch(/max-width/)
+
+    // (d) viewBox still untouched after both passes
+    expect(uncapped).toContain('viewBox="-50 -10 1230 512"')
+  })
+})


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    actor Reader
    participant Trigger as Inline trigger button
    participant Dialog as <dialog> lightbox
    participant Panzoom
    participant SVG as Mermaid SVG

    Note over Reader,SVG: First render — capDiagramWidth() pins every diagram to scale 0.625
    Reader->>Trigger: Click figure
    Trigger->>Dialog: showModal()
    Note over Dialog: Backdrop fades in (250ms ease-out)
    Note over Dialog: Panel runs glitch-reveal (~400ms RGB-split)
    Dialog->>Panzoom: panzoom(svg) on next rAF
    Panzoom->>SVG: fitToScreen() with 56px inset
    Reader->>SVG: Drag / wheel / pinch / +-fit buttons
    Reader->>Dialog: Esc / × / backdrop click
    Note over Dialog: Panel runs glitch-conceal (~150ms ease-in)
    Note over Dialog: Backdrop fades out (600ms ease-in-out)
    Dialog->>Trigger: focus restored after 600ms
    Note over Panzoom: Disposed lazily on next openDialog (preserves transform during exit)
```

## Summary

- Mermaid diagrams in posts had three structural problems: dark-mode contrast was poor (gray text on hardcoded pale rect bands), text size differed wildly between diagrams of different intrinsic widths, and there was no way to read fine detail without leaving the page. This PR fixes all three.
- Adds a click-to-zoom lightbox built on the native `<dialog>` + `panzoom` (~3kb) — drag to pan, wheel/pinch to zoom, fit-to-screen control. Initial open fits the diagram with a 56px inset so it doesn't crowd the panel chrome.
- Animates entry/exit with the site's existing glitch language (RGB-split via `<filter id="rgb-split">`) and re-uses the `bg-surface` / `border-border` / `text-accent` tokens so the lightbox feels native rather than grafted-on.

## Screenshots

### Desktop 1440×900

| Inline | Lightbox (fit-on-open) | Lightbox (zoomed) |
| :--- | :--- | :--- |
| <img src="https://github.com/user-attachments/assets/ac9fa943-86ff-4890-8938-103c413bb3b4" width="320" alt="Inline diagram, dark, desktop" /> | <img src="https://github.com/user-attachments/assets/df2d51a7-9724-4d41-ab37-26248313764b" width="320" alt="Lightbox fit-on-open, dark, desktop" /> | <img src="https://github.com/user-attachments/assets/994c61c7-2364-4480-8a25-254e99e29cdd" width="320" alt="Lightbox zoomed in, dark, desktop" /> |

### Mobile 390×844

| Inline | Lightbox |
| :--- | :--- |
| <img src="https://github.com/user-attachments/assets/2de33483-6bdf-4c17-9152-a55e930ad51a" width="320" alt="Inline diagram, dark, mobile" /> | <img src="https://github.com/user-attachments/assets/a73df79a-65b6-4339-88f2-2294ecdba967" width="320" alt="Lightbox, dark, mobile" /> |

## Test plan

- [x] `npm run lint` — 0 errors (19 pre-existing warnings unrelated)
- [x] `npx tsc --noEmit` — green
- [x] `npx vitest run tests/unit/components/MermaidDiagram` — 4/4 pass
- [ ] `npm run build` — not run locally; CI will verify
- [ ] New unit tests added — existing 4 still cover the component; new behavior (capDiagramWidth scale, panzoom lifecycle, glitch class swap) is covered by the manual MCP drive below
- [ ] New Playwright e2e — not added in this PR (existing `mermaid.spec.ts` smoke covers render path)
- [x] Playwright/Chrome-DevTools MCP smoke — drove the feature at desktop (1440×900) and mobile (390×844). `list_console_messages` returns no errors/warnings.

### Notable engineering details (for the reviewer)

1. **Consistent text size across diagrams** — `capDiagramWidth()` post-processes Mermaid's emitted SVG to pin every diagram's render scale to 0.625 (text appears at the same effective size whether the viewBox is 599px or 1230px wide). `uncapDiagramWidth()` strips that cap for the lightbox copy.
2. **Panzoom transform preservation through close** — the original close path called `setClosing(true)`, which re-rendered the panel. React's reconciler then re-set the stage's `innerHTML` (because reading `domElement.innerHTML` returns serialized markup that differs from the input string), wiping panzoom's `style.transform` mid-animation and producing a "diagram flashes zoomed in" frame. Replaced with `closingRef` + `panelRef` so the class swap happens via direct DOM mutation, no React re-render.
3. **Panzoom dispose deferred to next open** — disposing during close removed the SVG transform mid-fade. Now `openDialog` disposes any leftover instance before initializing a new one, so the SVG keeps its fit transform throughout the exit.
4. **Asymmetric backdrop fade** — 250ms ease-out on open (responsive), 600ms ease-in-out on close (less jarring). The close timeout matches the longer of the two so the backdrop has time to finish fading before `display:none`.
5. **`.env.example`** now documents that `GCS_BUCKET` / `GCS_HMAC_*` are required in dev for images to render — the s3Storage plugin is gated on `GCS_BUCKET` and falls back to (gitignored) `public/media/` when unset.

## Plan reference

Out of plan — surfaced while reviewing post drafts; user asked for diagram polish, click-to-zoom, then iterated on aesthetic / animation match with the site's terminal-violet theme.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)