### PR TITLE
fix(config): assert NEXT_PUBLIC_SERVER_URL instead of silent fallback

### DIFF
--- a/src/lib/schema/config.ts
+++ b/src/lib/schema/config.ts
@@ -12,8 +12,7 @@
 // These are the only changes needed for author identity migration. All schema
 // generators reference AUTHOR_CONFIG and will pick up the update automatically.
 
-const siteUrl =
-  process.env.NEXT_PUBLIC_SERVER_URL || "https://detached-node.dev";
+import { siteUrl } from '../site-url'
 
 const siteName = "detached-node";
 

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -6,8 +6,7 @@
 // from its own config for internal use; this module is the authoritative
 // source for frontend page components.
 
-export const siteUrl: string =
-  process.env.NEXT_PUBLIC_SERVER_URL || "https://detached-node.dev";
+export { siteUrl } from './site-url'
 
 export const siteName = "detached-node";
 

--- a/src/lib/site-url.ts
+++ b/src/lib/site-url.ts
@@ -2,4 +2,4 @@ import { assertRequiredEnv } from './env/required-env'
 
 const env = assertRequiredEnv(['NEXT_PUBLIC_SERVER_URL'] as const)
 
-export const siteUrl: string = env.NEXT_PUBLIC_SERVER_URL
+export const siteUrl = env.NEXT_PUBLIC_SERVER_URL

--- a/src/lib/site-url.ts
+++ b/src/lib/site-url.ts
@@ -1,0 +1,5 @@
+import { assertRequiredEnv } from './env/required-env'
+
+const env = assertRequiredEnv(['NEXT_PUBLIC_SERVER_URL'] as const)
+
+export const siteUrl: string = env.NEXT_PUBLIC_SERVER_URL

--- a/tests/unit/lib/site-url.test.ts
+++ b/tests/unit/lib/site-url.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+describe("site-url module", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.NEXT_PUBLIC_SERVER_URL;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    vi.resetModules();
+  });
+
+  it("throws when NEXT_PUBLIC_SERVER_URL is unset", async () => {
+    let message = "";
+    try {
+      await import("@/lib/site-url");
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("Missing required environment variables");
+    expect(message).toContain("NEXT_PUBLIC_SERVER_URL");
+  });
+
+  it("exports siteUrl equal to NEXT_PUBLIC_SERVER_URL when the var is set", async () => {
+    process.env.NEXT_PUBLIC_SERVER_URL = "https://example.com";
+    const { siteUrl } = await import("@/lib/site-url");
+    expect(siteUrl).toBe("https://example.com");
+  });
+});

--- a/tests/unit/lib/site-url.test.ts
+++ b/tests/unit/lib/site-url.test.ts
@@ -15,19 +15,23 @@ describe("site-url module", () => {
   });
 
   it("throws when NEXT_PUBLIC_SERVER_URL is unset", async () => {
-    let message = "";
-    try {
-      await import("@/lib/site-url");
-    } catch (err) {
-      message = (err as Error).message;
-    }
-    expect(message).toContain("Missing required environment variables");
-    expect(message).toContain("NEXT_PUBLIC_SERVER_URL");
+    await expect(import("@/lib/site-url")).rejects.toThrow(
+      /Missing required environment variables.*NEXT_PUBLIC_SERVER_URL/,
+    );
   });
 
   it("exports siteUrl equal to NEXT_PUBLIC_SERVER_URL when the var is set", async () => {
     process.env.NEXT_PUBLIC_SERVER_URL = "https://example.com";
     const { siteUrl } = await import("@/lib/site-url");
     expect(siteUrl).toBe("https://example.com");
+  });
+
+  // Regression tripwire: assertRequiredEnv currently accepts whitespace-only values.
+  // This test documents that boundary so a future tightening of assertRequiredEnv
+  // (a separate issue) would intentionally update it rather than silently pass.
+  it("does not throw on whitespace-only NEXT_PUBLIC_SERVER_URL (documents current assertRequiredEnv boundary)", async () => {
+    process.env.NEXT_PUBLIC_SERVER_URL = "   ";
+    const { siteUrl } = await import("@/lib/site-url");
+    expect(siteUrl).toBe("   ");
   });
 });


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  subgraph before["before"]
    direction TB
    SC1["src/lib/schema/config.ts"] -- "process.env || 'detached-node.dev'" --> URL1["siteUrl<br/>(silent fallback)"]
    SC2["src/lib/site-config.ts"]   -- "process.env || 'detached-node.dev'" --> URL2["siteUrl<br/>(silent fallback)"]
  end

  subgraph after["after"]
    direction TB
    SC3["src/lib/schema/config.ts"] -- "import" --> SU["src/lib/site-url.ts<br/>assertRequiredEnv"]
    SC4["src/lib/site-config.ts"]   -- "import" --> SU
    SU -- "throws if unset" --> URL3["siteUrl<br/>(validated)"]
  end

  before -. "fail loudly,<br/>not silently" .-> after
```

## Summary

- Centralizes the `NEXT_PUBLIC_SERVER_URL` read in a new \`src/lib/site-url.ts\` that calls \`assertRequiredEnv\`, so any code path reaching either consumer module fails loudly instead of emitting a plausible-looking production URL when the var is unset.
- Closes the gap @julianken-bot flagged as a SUGGESTION on PR #76 — the silent \`|| \"...\"\` pattern survived in two sibling files even after \`payload.config.ts\` was hardened.
- Preserves both \`siteUrl\` re-exports so existing import sites (\`src/lib/schema/config.ts\` and \`src/lib/site-config.ts\` are both authoritative for different consumers) keep working unchanged.

## Screenshots

N/A — not UI

## Test plan

- [x] \`npx vitest run tests/unit/lib/site-url.test.ts\` — 3/3 green (throw on unset, value on set, whitespace tripwire documenting current \`assertRequiredEnv\` boundary)
- [x] \`npx vitest run tests/unit/\` — full suite 177/177 green
- [x] \`npx tsc --noEmit\` — exit 0
- [x] \`npm run lint\` — 0 errors (18 pre-existing warnings, none in changed files)
- [x] \`npm run build\` — clean with required env vars set; fails loudly without them (verified — that is the point of the change)

## Plan reference

Out of plan — bot-flagged hardening from PR #76 review. Closes #78. See \`/Users/j/.claude/plans/lets-get-a-subagent-purrfect-lampson.md\` for the broader run this PR is the first step of.