### PR TITLE
feat(media): low-quality image placeholder (LQIP) on uploads

### DIFF
--- a/migrations/20260425_220000_add_media_lqip.ts
+++ b/migrations/20260425_220000_add_media_lqip.ts
@@ -1,0 +1,32 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Database Migration: Add lqip field to Media
+ *
+ * Adds a nullable text column `lqip` to the `media` table to store the
+ * auto-generated AVIF low-quality image placeholder data URL.
+ *
+ * The column is nullable so existing Media docs are not broken — documents
+ * uploaded before this migration (or where sharp generation fails) will
+ * have NULL, and the application falls back to the 1×1 transparent PNG.
+ *
+ * Uses ADD COLUMN IF NOT EXISTS / DROP COLUMN IF EXISTS for idempotency so
+ * the migration is safe against databases where the column may already exist
+ * (e.g. if `push: true` was used in development).
+ *
+ * Down migration: drops the lqip column.
+ */
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "media"
+      ADD COLUMN IF NOT EXISTS "lqip" varchar;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "media"
+      DROP COLUMN IF EXISTS "lqip";
+  `)
+}

--- a/migrations/index.ts
+++ b/migrations/index.ts
@@ -8,6 +8,7 @@ import * as migration_20260422_204600_add_posts_seo_fields from './20260422_2046
 import * as migration_20260422_204700_add_media_prefix from './20260422_204700_add_media_prefix';
 import * as migration_20260424_035219_add_mermaid_block from './20260424_035219_add_mermaid_block';
 import * as migration_20260425_202704_add_posts_focal_point from './20260425_202704_add_posts_focal_point';
+import * as migration_20260425_220000_add_media_lqip from './20260425_220000_add_media_lqip';
 
 export const migrations = [
   {
@@ -58,6 +59,11 @@ export const migrations = [
   {
     up: migration_20260425_202704_add_posts_focal_point.up,
     down: migration_20260425_202704_add_posts_focal_point.down,
-    name: '20260425_202704_add_posts_focal_point'
+    name: '20260425_202704_add_posts_focal_point',
+  },
+  {
+    up: migration_20260425_220000_add_media_lqip.up,
+    down: migration_20260425_220000_add_media_lqip.down,
+    name: '20260425_220000_add_media_lqip',
   },
 ];

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:unit:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:debug": "playwright test --debug"
+    "test:e2e:debug": "playwright test --debug",
+    "backfill:lqip": "tsx scripts/backfill-lqip.ts"
   },
   "dependencies": {
     "@payloadcms/db-postgres": "^3.83.0",

--- a/scripts/backfill-lqip.ts
+++ b/scripts/backfill-lqip.ts
@@ -32,30 +32,18 @@ async function main() {
 
   const payload = await getPayload({ config })
 
-  const { totalDocs } = await payload.find({
-    collection: 'media',
-    limit: 0,
-    pagination: false,
-    where: {
-      lqip: { exists: false },
-    },
-  })
-
-  // `limit: 0` with `pagination: false` returns all docs in a single query.
-  // The `docs` array will be empty when limit=0; re-fetch properly.
   const all = await payload.find({
     collection: 'media',
-    limit: totalDocs || 1000,
     pagination: false,
     where: {
       lqip: { exists: false },
     },
   })
 
-  const pending = all.docs.filter((doc) => !doc.lqip)
+  const pending = all.docs
   const total = pending.length
 
-  console.log(`[backfill-lqip] ${total} doc(s) without LQIP (of ${all.totalDocs} total media)`)
+  console.log(`[backfill-lqip] ${total} doc(s) without LQIP (of ${all.totalDocs} total media matched)`)
 
   let succeeded = 0
   let failed = 0

--- a/scripts/backfill-lqip.ts
+++ b/scripts/backfill-lqip.ts
@@ -1,0 +1,121 @@
+/**
+ * Backfill LQIP (Low-Quality Image Placeholder) for existing Media docs.
+ *
+ * INTENDED FOR ONE-SHOT POST-DEPLOY INVOCATION against the Vercel Blob store.
+ * DO NOT run this in CI or as part of the deploy pipeline.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-lqip.ts            # live run
+ *   npx tsx scripts/backfill-lqip.ts --dry-run  # preview without writes
+ *
+ * Prerequisites:
+ *   - DATABASE_URL and PAYLOAD_SECRET in environment (e.g. via .env.local)
+ *   - Network access to Vercel Blob URLs (doc.url)
+ *
+ * Review the --dry-run output before the live run.
+ */
+
+import 'dotenv/config'
+import { getPayload } from 'payload'
+import config from '../src/payload.config'
+import { generateLqipDataUrl } from '../src/lib/lqip/encode'
+
+const DRY_RUN = process.argv.includes('--dry-run')
+const SLEEP_MS = 200
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function main() {
+  console.log(`[backfill-lqip] Starting${DRY_RUN ? ' (DRY RUN — no writes)' : ''}…`)
+
+  const payload = await getPayload({ config })
+
+  const { totalDocs } = await payload.find({
+    collection: 'media',
+    limit: 0,
+    pagination: false,
+    where: {
+      lqip: { exists: false },
+    },
+  })
+
+  // `limit: 0` with `pagination: false` returns all docs in a single query.
+  // The `docs` array will be empty when limit=0; re-fetch properly.
+  const all = await payload.find({
+    collection: 'media',
+    limit: totalDocs || 1000,
+    pagination: false,
+    where: {
+      lqip: { exists: false },
+    },
+  })
+
+  const pending = all.docs.filter((doc) => !doc.lqip)
+  const total = pending.length
+
+  console.log(`[backfill-lqip] ${total} doc(s) without LQIP (of ${all.totalDocs} total media)`)
+
+  let succeeded = 0
+  let failed = 0
+
+  for (let i = 0; i < pending.length; i++) {
+    const doc = pending[i]
+    const label = `[${i + 1}/${total}] id=${doc.id} filename=${doc.filename ?? '(none)'}`
+
+    if (!doc.url) {
+      console.warn(`${label} — SKIP: no url`)
+      failed++
+      continue
+    }
+
+    if (DRY_RUN) {
+      console.log(`${label} — would generate LQIP from ${doc.url}`)
+      continue
+    }
+
+    try {
+      const response = await fetch(doc.url)
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} fetching ${doc.url}`)
+      }
+      const arrayBuffer = await response.arrayBuffer()
+      const lqip = await generateLqipDataUrl(Buffer.from(arrayBuffer))
+
+      await payload.update({
+        collection: 'media',
+        id: doc.id,
+        data: { lqip },
+      })
+
+      console.log(`${label} — generated (${lqip.length} chars)`)
+      succeeded++
+    } catch (err) {
+      console.error(
+        `${label} — FAILED: ${err instanceof Error ? err.message : String(err)}`
+      )
+      failed++
+    }
+
+    // Respect Vercel Blob rate limits between iterations.
+    if (i < pending.length - 1) {
+      await sleep(SLEEP_MS)
+    }
+  }
+
+  if (!DRY_RUN) {
+    console.log(
+      `[backfill-lqip] Done. succeeded=${succeeded} failed=${failed} total=${total}`
+    )
+  } else {
+    console.log(`[backfill-lqip] Dry run complete. ${total} doc(s) would be processed.`)
+  }
+
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error('[backfill-lqip] Fatal error:', err)
+  process.exit(1)
+})

--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { generateLqipHook } from '@/lib/hooks/generate-lqip'
 
 export const Media: CollectionConfig = {
   slug: 'media',
@@ -10,6 +11,9 @@ export const Media: CollectionConfig = {
     create: ({ req: { user } }) => !!user,
     update: ({ req: { user } }) => !!user,
     delete: ({ req: { user } }) => !!user,
+  },
+  hooks: {
+    beforeChange: [generateLqipHook],
   },
   upload: {
     staticDir: 'public/media',
@@ -30,6 +34,14 @@ export const Media: CollectionConfig = {
     {
       name: 'caption',
       type: 'textarea',
+    },
+    {
+      name: 'lqip',
+      type: 'text',
+      admin: {
+        readOnly: true,
+        description: 'Auto-generated AVIF data URL placeholder. Populated on upload.',
+      },
     },
   ],
 }

--- a/src/components/OptimizedImage.tsx
+++ b/src/components/OptimizedImage.tsx
@@ -1,6 +1,10 @@
 import Image from "next/image";
 import type { CSSProperties } from "react";
 
+// 1×1 transparent PNG — permanent fallback for Media docs without a populated lqip.
+const FALLBACK_BLUR_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mN8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+
 interface CommonProps {
   src: string;
   alt: string;
@@ -9,6 +13,8 @@ interface CommonProps {
   className?: string;
   sizes?: string;
   style?: CSSProperties;
+  /** Per-image AVIF LQIP data URL. Defaults to a 1×1 transparent PNG. */
+  blurDataURL?: string;
 }
 
 type OptimizedImageProps = CommonProps &
@@ -62,6 +68,7 @@ export function OptimizedImage(props: OptimizedImageProps) {
     className = "",
     sizes,
     style,
+    blurDataURL = FALLBACK_BLUR_DATA_URL,
   } = props;
 
   const dimensionProps = props.fill
@@ -79,7 +86,7 @@ export function OptimizedImage(props: OptimizedImageProps) {
       className={className}
       style={style}
       placeholder="blur"
-      blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mN8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+      blurDataURL={blurDataURL}
     />
   );
 }

--- a/src/components/OptimizedImage.tsx
+++ b/src/components/OptimizedImage.tsx
@@ -13,7 +13,14 @@ interface CommonProps {
   className?: string;
   sizes?: string;
   style?: CSSProperties;
-  /** Per-image AVIF LQIP data URL. Defaults to a 1×1 transparent PNG. */
+  /**
+   * Controls the Next.js Image placeholder strategy.
+   * - "blur" (default): shows a blur-up animation while loading; blurDataURL
+   *   falls back to the 1×1 transparent PNG when not supplied.
+   * - "empty": no placeholder; use for non-hero images that don't need blur-up.
+   */
+  placeholder?: "blur" | "empty";
+  /** Per-image AVIF LQIP data URL. Only used when placeholder="blur". */
   blurDataURL?: string;
 }
 
@@ -68,8 +75,12 @@ export function OptimizedImage(props: OptimizedImageProps) {
     className = "",
     sizes,
     style,
-    blurDataURL = FALLBACK_BLUR_DATA_URL,
+    placeholder = "blur",
+    blurDataURL,
   } = props;
+
+  const resolvedBlurDataURL =
+    placeholder === "blur" ? (blurDataURL ?? FALLBACK_BLUR_DATA_URL) : undefined;
 
   const dimensionProps = props.fill
     ? { fill: true as const }
@@ -85,8 +96,8 @@ export function OptimizedImage(props: OptimizedImageProps) {
       sizes={sizes || "(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"}
       className={className}
       style={style}
-      placeholder="blur"
-      blurDataURL={blurDataURL}
+      placeholder={placeholder}
+      blurDataURL={resolvedBlurDataURL}
     />
   );
 }

--- a/src/components/ThemeAwareHero.tsx
+++ b/src/components/ThemeAwareHero.tsx
@@ -75,6 +75,7 @@ export function ThemeAwareHero({
         sizes={sizes}
         className="object-cover dark:hidden"
         style={imgStyle}
+        blurDataURL={light.lqip ?? undefined}
       />
       <OptimizedImage
         src={dark.url}
@@ -84,6 +85,7 @@ export function ThemeAwareHero({
         sizes={sizes}
         className="hidden object-cover dark:block"
         style={imgStyle}
+        blurDataURL={dark.lqip ?? undefined}
       />
     </div>
   );

--- a/src/lib/hooks/generate-lqip.ts
+++ b/src/lib/hooks/generate-lqip.ts
@@ -1,0 +1,48 @@
+import type { CollectionBeforeChangeHook } from 'payload'
+import { generateLqipDataUrl } from '@/lib/lqip/encode'
+
+/**
+ * Payload beforeChange hook for the Media collection.
+ *
+ * On create-only operations: reads the uploaded file buffer, generates a
+ * 24×12 AVIF LQIP data URL, and attaches it as `lqip` on the document.
+ *
+ * Fail-soft: any error (missing buffer, non-image, sharp failure) logs a
+ * warning and returns data UNCHANGED. Never throws or blocks the upload.
+ */
+export const generateLqipHook: CollectionBeforeChangeHook = async ({
+  data,
+  req,
+  operation,
+}) => {
+  // Only run on create — skip metadata-only updates.
+  if (operation !== 'create') {
+    return data
+  }
+
+  // Guard: need a file buffer.
+  const file = req.file
+  if (!file?.data) {
+    req.payload.logger.warn('[generate-lqip] No file buffer on request — skipping LQIP generation')
+    return data
+  }
+
+  // Guard: must be an image mimeType.
+  const mimeType = file.mimetype ?? data?.mimeType ?? ''
+  if (!mimeType.startsWith('image/')) {
+    req.payload.logger.warn(
+      `[generate-lqip] Non-image mimeType "${mimeType}" — skipping LQIP generation`
+    )
+    return data
+  }
+
+  try {
+    const lqip = await generateLqipDataUrl(Buffer.from(file.data))
+    return { ...data, lqip }
+  } catch (err) {
+    req.payload.logger.warn(
+      `[generate-lqip] Failed to generate LQIP: ${err instanceof Error ? err.message : String(err)}`
+    )
+    return data
+  }
+}

--- a/src/lib/lqip/encode.ts
+++ b/src/lib/lqip/encode.ts
@@ -1,0 +1,18 @@
+import sharp from 'sharp'
+
+/**
+ * Generate a low-quality image placeholder (LQIP) data URL from a buffer.
+ *
+ * Resizes to 24×12 px, encodes as AVIF at quality 30, and returns a
+ * base64 data URL suitable for next/image's blurDataURL prop.
+ *
+ * Throws on error — callers are responsible for fail-soft handling.
+ */
+export async function generateLqipDataUrl(buffer: Buffer): Promise<string> {
+  const avif = await sharp(buffer)
+    .resize(24, 12, { fit: 'cover' })
+    .avif({ quality: 30 })
+    .toBuffer()
+
+  return `data:image/avif;base64,${avif.toString('base64')}`
+}

--- a/src/lib/lqip/encode.ts
+++ b/src/lib/lqip/encode.ts
@@ -10,6 +10,10 @@ import sharp from 'sharp'
  */
 export async function generateLqipDataUrl(buffer: Buffer): Promise<string> {
   const avif = await sharp(buffer)
+    // fit: 'cover' is deliberate — it mirrors the consumer container's
+    // object-fit: cover (ThemeAwareHero), so the LQIP previews the same
+    // crop the user will see. fit: 'inside' would preview content that
+    // won't be rendered at hero render time.
     .resize(24, 12, { fit: 'cover' })
     .avif({ quality: 30 })
     .toBuffer()

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -159,6 +159,7 @@ export interface Media {
   id: number;
   alt: string;
   caption?: string | null;
+  lqip?: string | null;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -450,6 +451,7 @@ export interface UsersSelect<T extends boolean = true> {
 export interface MediaSelect<T extends boolean = true> {
   alt?: T;
   caption?: T;
+  lqip?: T;
   updatedAt?: T;
   createdAt?: T;
   url?: T;

--- a/tests/unit/components/OptimizedImage.test.tsx
+++ b/tests/unit/components/OptimizedImage.test.tsx
@@ -84,4 +84,13 @@ describe('OptimizedImage blurDataURL prop', () => {
     const img = container.querySelector('img')
     expect(img?.getAttribute('data-blur-data-url')).toBe(FALLBACK_1X1_PNG)
   })
+
+  it('does not pass blurDataURL when placeholder="empty"', () => {
+    const { container } = render(
+      <OptimizedImage fill src="/media/test.png" alt="test" placeholder="empty" />
+    )
+    const img = container.querySelector('img')
+    // placeholder="empty" must not materialise a blur data URL
+    expect(img?.getAttribute('data-blur-data-url')).toBeNull()
+  })
 })

--- a/tests/unit/components/OptimizedImage.test.tsx
+++ b/tests/unit/components/OptimizedImage.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import React from 'react'
+import { OptimizedImage } from '@/components/OptimizedImage'
+
+// Mock next/image so we can assert prop pass-through without the full Next pipeline.
+vi.mock('next/image', () => ({
+  default: ({
+    src,
+    alt,
+    blurDataURL,
+    placeholder,
+    className,
+    fill,
+    priority,
+    fetchPriority,
+    sizes,
+    width,
+    height,
+    style,
+    ...rest
+  }: {
+    src: string
+    alt: string
+    blurDataURL?: string
+    placeholder?: string
+    className?: string
+    fill?: boolean
+    priority?: boolean
+    fetchPriority?: string
+    sizes?: string
+    width?: number
+    height?: number
+    style?: React.CSSProperties
+    [key: string]: unknown
+  }) => {
+    void rest
+    return React.createElement('img', {
+      src,
+      alt,
+      className,
+      style,
+      'data-blur-data-url': blurDataURL,
+      'data-placeholder': placeholder,
+      'data-fill': fill ? 'true' : undefined,
+      'data-priority': priority ? 'true' : undefined,
+      'data-fetch-priority': fetchPriority,
+      'data-sizes': sizes,
+      'data-width': width,
+      'data-height': height,
+    })
+  },
+}))
+
+const FALLBACK_1X1_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mN8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=='
+
+describe('OptimizedImage blurDataURL prop', () => {
+  it('forwards a custom blurDataURL prop to next/image', () => {
+    const { container } = render(
+      <OptimizedImage
+        fill
+        src="/media/test.png"
+        alt="test"
+        blurDataURL="data:foo"
+      />
+    )
+    const img = container.querySelector('img')
+    expect(img?.getAttribute('data-blur-data-url')).toBe('data:foo')
+  })
+
+  it('uses the 1×1 transparent PNG fallback when blurDataURL is not provided', () => {
+    const { container } = render(
+      <OptimizedImage fill src="/media/test.png" alt="test" />
+    )
+    const img = container.querySelector('img')
+    expect(img?.getAttribute('data-blur-data-url')).toBe(FALLBACK_1X1_PNG)
+  })
+
+  it('uses the 1×1 PNG fallback when blurDataURL is explicitly undefined', () => {
+    const { container } = render(
+      <OptimizedImage fill src="/media/test.png" alt="test" blurDataURL={undefined} />
+    )
+    const img = container.querySelector('img')
+    expect(img?.getAttribute('data-blur-data-url')).toBe(FALLBACK_1X1_PNG)
+  })
+})

--- a/tests/unit/components/ThemeAwareHero.test.tsx
+++ b/tests/unit/components/ThemeAwareHero.test.tsx
@@ -19,6 +19,8 @@ vi.mock("next/image", () => ({
     width,
     height,
     style,
+    blurDataURL,
+    placeholder,
     ...rest
   }: {
     src: string;
@@ -31,11 +33,14 @@ vi.mock("next/image", () => ({
     width?: number;
     height?: number;
     style?: React.CSSProperties;
+    blurDataURL?: string;
+    placeholder?: string;
     [key: string]: unknown;
   }) => {
     // Strip out Next.js-only props that would generate React warnings on an
     // intrinsic <img> element; preserve the props we actually want to assert.
     void rest;
+    void placeholder;
     return React.createElement("img", {
       src,
       alt,
@@ -47,6 +52,7 @@ vi.mock("next/image", () => ({
       "data-sizes": sizes,
       "data-width": width,
       "data-height": height,
+      "data-blur-data-url": blurDataURL,
     });
   },
 }));
@@ -309,6 +315,65 @@ describe("ThemeAwareHero", () => {
     expect(images).toHaveLength(2);
     images.forEach((img) => {
       expect((img as HTMLElement).style.objectPosition).toBe("0% 0%");
+    });
+  });
+
+  // --- LQIP tests ---
+
+  it("passes light.lqip as blurDataURL to the light <OptimizedImage>", () => {
+    const lightWithLqip = makeMedia({
+      ...lightMedia,
+      lqip: "data:image/avif;base64,lightlqip",
+    });
+    const { container } = render(
+      <ThemeAwareHero light={lightWithLqip} dark={darkMedia} alt="Hero" />
+    );
+    const lightImg = container.querySelector(
+      'img[src="/media/post-light.png"]'
+    ) as HTMLElement;
+    expect(lightImg.getAttribute("data-blur-data-url")).toBe(
+      "data:image/avif;base64,lightlqip"
+    );
+  });
+
+  it("passes both light.lqip and dark.lqip to their respective <OptimizedImage> children", () => {
+    const lightWithLqip = makeMedia({
+      ...lightMedia,
+      lqip: "data:image/avif;base64,lightlqip",
+    });
+    const darkWithLqip = makeMedia({
+      ...darkMedia,
+      lqip: "data:image/avif;base64,darklqip",
+    });
+    const { container } = render(
+      <ThemeAwareHero light={lightWithLqip} dark={darkWithLqip} alt="Hero" />
+    );
+    const lightImg = container.querySelector(
+      'img[src="/media/post-light.png"]'
+    ) as HTMLElement;
+    const darkImg = container.querySelector(
+      'img[src="/media/post-dark.png"]'
+    ) as HTMLElement;
+    expect(lightImg.getAttribute("data-blur-data-url")).toBe(
+      "data:image/avif;base64,lightlqip"
+    );
+    expect(darkImg.getAttribute("data-blur-data-url")).toBe(
+      "data:image/avif;base64,darklqip"
+    );
+  });
+
+  it("renders without custom blurDataURL when neither light nor dark has lqip (default fallback)", () => {
+    // When lqip is absent, ThemeAwareHero passes undefined → OptimizedImage
+    // uses its own 1×1 PNG default. The rendered img should NOT have a
+    // custom AVIF data URL.
+    const { container } = render(
+      <ThemeAwareHero light={lightMedia} dark={darkMedia} alt="Hero" />
+    );
+    const images = container.querySelectorAll("img");
+    images.forEach((img) => {
+      const val = img.getAttribute("data-blur-data-url");
+      // OptimizedImage's fallback 1×1 PNG — not a custom AVIF lqip
+      expect(val).not.toMatch(/^data:image\/avif/);
     });
   });
 });

--- a/tests/unit/lib/hooks/generate-lqip.test.ts
+++ b/tests/unit/lib/hooks/generate-lqip.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { generateLqipHook } from '@/lib/hooks/generate-lqip'
+import type { CollectionBeforeChangeHook } from 'payload'
+
+// ---------------------------------------------------------------------------
+// Minimal valid 2×2 red PNG buffer (real, not mocked — so sharp can decode it)
+// Generated via: sharp({ create: { width: 2, height: 2, channels: 3, background: { r: 255, g: 0, b: 0 } } }).png().toBuffer()
+// ---------------------------------------------------------------------------
+const MINIMAL_PNG = Buffer.from(
+  '89504e470d0a1a0a0000000d4948445200000002000000020802000000fdd49a730000000970485973000003e8000003e801b57b526b0000001349444154789c63f8cfc0f09f018cff333000001fee03fd351b00330000000049454e44ae426082',
+  'hex'
+)
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal fake Payload hook args object
+// ---------------------------------------------------------------------------
+type HookArgs = Parameters<CollectionBeforeChangeHook>[0]
+
+function makeArgs(overrides: Partial<HookArgs> & { file?: { data?: Buffer | null; mimetype?: string } | null } = {}): HookArgs {
+  const { file, ...rest } = overrides
+  const warnSpy = vi.fn()
+  return {
+    data: {},
+    req: {
+      file: file === undefined
+        ? { data: MINIMAL_PNG, mimetype: 'image/png', name: 'test.png', size: MINIMAL_PNG.length }
+        : file,
+      payload: {
+        logger: { warn: warnSpy },
+      },
+    } as unknown as HookArgs['req'],
+    operation: 'create',
+    collection: {} as HookArgs['collection'],
+    context: {},
+    ...rest,
+  } as unknown as HookArgs
+}
+
+function getWarnSpy(args: HookArgs): ReturnType<typeof vi.fn> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (args.req.payload.logger as any).warn
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('generateLqipHook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('generates a non-empty data URL prefixed data:image/avif;base64, for a valid PNG buffer', async () => {
+    const args = makeArgs()
+    const result = await generateLqipHook(args)
+    expect(result).toHaveProperty('lqip')
+    expect(typeof result.lqip).toBe('string')
+    expect(result.lqip).toMatch(/^data:image\/avif;base64,/)
+    expect((result.lqip as string).length).toBeGreaterThan(30)
+  })
+
+  it('returns data UNCHANGED when operation === "update" (skip on update)', async () => {
+    const args = makeArgs({ operation: 'update' as HookArgs['operation'] })
+    const result = await generateLqipHook(args)
+    expect(result).not.toHaveProperty('lqip')
+    // warn should NOT have been called — this is a deliberate skip, not an error
+    expect(getWarnSpy(args)).not.toHaveBeenCalled()
+  })
+
+  it('returns data UNCHANGED + logs warning when buffer is missing (no req.file)', async () => {
+    const args = makeArgs({ file: null })
+    const result = await generateLqipHook(args)
+    expect(result).not.toHaveProperty('lqip')
+    expect(getWarnSpy(args)).toHaveBeenCalledOnce()
+    expect(getWarnSpy(args).mock.calls[0][0]).toMatch(/no file buffer/i)
+  })
+
+  it('returns data UNCHANGED + logs warning when buffer is missing (req.file.data is null)', async () => {
+    const args = makeArgs({ file: { data: null, mimetype: 'image/png' } })
+    const result = await generateLqipHook(args)
+    expect(result).not.toHaveProperty('lqip')
+    expect(getWarnSpy(args)).toHaveBeenCalledOnce()
+  })
+
+  it('returns data UNCHANGED + logs warning when buffer is malformed (cannot be decoded by sharp)', async () => {
+    const args = makeArgs({ file: { data: Buffer.from('not-a-real-image'), mimetype: 'image/png' } })
+    const result = await generateLqipHook(args)
+    expect(result).not.toHaveProperty('lqip')
+    expect(getWarnSpy(args)).toHaveBeenCalledOnce()
+    expect(getWarnSpy(args).mock.calls[0][0]).toMatch(/failed to generate/i)
+  })
+
+  it('returns data UNCHANGED + logs warning when mimeType is not image/*', async () => {
+    const args = makeArgs({ file: { data: MINIMAL_PNG, mimetype: 'application/pdf' } })
+    const result = await generateLqipHook(args)
+    expect(result).not.toHaveProperty('lqip')
+    expect(getWarnSpy(args)).toHaveBeenCalledOnce()
+    expect(getWarnSpy(args).mock.calls[0][0]).toMatch(/non-image mimetype/i)
+  })
+})


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
  subgraph upload["Upload pipeline"]
    U[Author uploads image] --> H["beforeChange hook<br/>generate-lqip.ts"]
    H -->|"create only<br/>fail-soft"| E["lqip/encode.ts<br/>sharp 24×12 AVIF q=30"]
    E -->|"data:image/avif;<br/>base64,…"| M[Media.lqip column]
  end

  subgraph backfill["Backfill (manual, post-deploy)"]
    BF["scripts/backfill-lqip.ts<br/>--dry-run available<br/>200ms rate limit"]
    BF -->|"fetch + encode + update"| M
  end

  subgraph render["Render"]
    M -.->|"light.lqip / dark.lqip"| TAH[ThemeAwareHero]
    TAH -->|"blurDataURL ?? FALLBACK"| OI[OptimizedImage]
    OI -->|"placeholder='blur'<br/>blurDataURL"| NI["next/image"]
  end

  subgraph fallback["Fallback (no LQIP)"]
    F[1×1 transparent PNG] -.->|"FALLBACK_BLUR_DATA_URL"| OI
  end

  style upload fill:#1f2937,color:#fff
  style render fill:#1f2937,color:#fff
  style fallback fill:#374151,color:#fff
```

## Summary

- **AVIF data URL chosen over blurhash + dominant color** — Phase A reviewer consensus (option 2 in #90). SSR-safe, no client decode, ~500 bytes per image.
- **Hook is create-only and fail-soft** — re-encoding on every metadata edit would be wasteful, and a corrupt upload should land without lqip rather than block the upload entirely.
- **OptimizedImage gained an explicit `placeholder` prop** during review (not in the original spec) — the original draft hardcoded \`placeholder=\"blur\"\` for every caller. Since OptimizedImage is the shared image primitive site-wide, an opt-out matters for any future non-hero callsite that wants \`placeholder=\"empty\"\`. Default stays \"blur\" to preserve current behavior.
- **Backfill is NOT executed by this PR** — the script is intended for one-shot post-deploy invocation. Run \`npm run backfill:lqip -- --dry-run\` first to preview against Vercel Blob, then drop \`--dry-run\`.

## Screenshots

The diff produces **no custom UI**. Both surfaces are entirely test-pinned and Payload-auto-generated:

- **Admin**: Payload renders the new \`lqip\` field as a read-only text input from the schema (\`admin: { readOnly: true, description: '…' }\` in \`Media.ts\`). Authors don't interact with this field — it's populated by the hook.
- **Frontend rendering**: a single \`blurDataURL\` prop forwarded to \`next/image\`. Behavior pinned by:
  - 6 hook tests (\`tests/unit/lib/hooks/generate-lqip.test.ts\`) covering success, update-skip, missing buffer, malformed buffer, non-image mimeType
  - 4 OptimizedImage tests including the new \`placeholder=\"empty\"\` opt-out path
  - 3 ThemeAwareHero LQIP tests (forwarding for light, dark, both, neither)

The visual evidence Julian would want — a real hero loading with the new blurred placeholder vs. the old solid muted box — requires a deployed environment with the backfill executed against Vercel Blob. That happens post-merge per the deferred-backfill design above.

## Test plan

- [x] \`npx vitest run tests/unit/lib/hooks/generate-lqip\` — 6/6 green
- [x] \`npx vitest run tests/unit/components/OptimizedImage\` — 8/8 green (incl. new placeholder=empty test)
- [x] \`npx vitest run tests/unit/components/ThemeAwareHero\` — 21/21 green (3 new LQIP tests)
- [x] \`npx vitest run tests/unit/\` — 195/195 green
- [x] \`npx tsc --noEmit\` — exit 0
- [x] \`npm run lint\` — 0 errors (18 pre-existing warnings)
- [x] Migration is idempotent (\`ADD COLUMN IF NOT EXISTS\`); registered in \`migrations/index.ts\` after the focal-point migration
- [ ] Post-deploy: \`npm run backfill:lqip -- --dry-run\` then live run against Vercel Blob (deferred)
- [ ] Post-deploy: visual confirmation on a slow-network throttle that hero region shows real placeholder (deferred)

## Plan reference

Part of issue #90. Phase B of the hero image load-in plan filed 2026-04-22. Pairs with the just-merged #122 (focalPoint field — both compose in \`ThemeAwareHero\` without conflict). See \`/Users/j/.claude/plans/lets-get-a-subagent-purrfect-lampson.md\`.

Closes #90