### PR TITLE
Remove post-type label from frontend (keep schema value)

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -5,6 +5,7 @@ import { SchemaScript } from "@/components/SchemaScript";
 import { generateWebSiteSchema, generatePersonSchema } from "@/lib/schema";
 import { getFeaturedPosts } from "@/lib/queries/posts";
 import { siteUrl } from "@/lib/site-config";
+import { getTypeLabel } from "@/lib/formatting";
 
 // ISR: Revalidate every 30 minutes - featured posts change infrequently
 export const revalidate = 1800;
@@ -41,7 +42,11 @@ export default async function Home() {
         <div className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {featuredPosts.length > 0 ? (
             featuredPosts.map((post) => (
-              <Card key={post.id} href={`/posts/${post.slug}`} label="FIELD REPORT">
+              <Card
+                key={post.id}
+                href={`/posts/${post.slug}`}
+                label={getTypeLabel(post.type).toUpperCase() || undefined}
+              >
                 <h3 className="font-mono text-base font-semibold text-text-primary [text-wrap:balance]">
                   {post.title}
                 </h3>

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -5,7 +5,6 @@ import { SchemaScript } from "@/components/SchemaScript";
 import { generateWebSiteSchema, generatePersonSchema } from "@/lib/schema";
 import { getFeaturedPosts } from "@/lib/queries/posts";
 import { siteUrl } from "@/lib/site-config";
-import { getTypeLabel } from "@/lib/formatting";
 
 // ISR: Revalidate every 30 minutes - featured posts change infrequently
 export const revalidate = 1800;
@@ -42,11 +41,7 @@ export default async function Home() {
         <div className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {featuredPosts.length > 0 ? (
             featuredPosts.map((post) => (
-              <Card
-                key={post.id}
-                href={`/posts/${post.slug}`}
-                label={getTypeLabel(post.type).toUpperCase() || undefined}
-              >
+              <Card key={post.id} href={`/posts/${post.slug}`}>
                 <h3 className="font-mono text-base font-semibold text-text-primary [text-wrap:balance]">
                   {post.title}
                 </h3>

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -124,9 +124,11 @@ export default async function PostPage({ params }: PostPageProps) {
         </Link>
 
         <header className="flex flex-col gap-2">
-          <p className="font-mono text-xs uppercase tracking-[0.2em] text-text-tertiary">
-            {typeLabel}
-          </p>
+          {typeLabel && (
+            <p className="font-mono text-xs uppercase tracking-[0.2em] text-text-tertiary">
+              {typeLabel}
+            </p>
+          )}
           <h1 className="font-mono text-3xl font-semibold tracking-tight text-text-primary">
             {post.title}
           </h1>

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { RichText } from "@payloadcms/richtext-lexical/react";
 import type { SerializedEditorState } from "@payloadcms/richtext-lexical/lexical";
-import { formatDate, getTypeLabel } from "@/lib/formatting";
+import { formatDate } from "@/lib/formatting";
 import { Link } from "next-view-transitions";
 import { PageLayout } from "@/components/PageLayout";
 import { ThemeAwareHero } from "@/components/ThemeAwareHero";
@@ -109,8 +109,6 @@ export default async function PostPage({ params }: PostPageProps) {
     notFound();
   }
 
-  const typeLabel = getTypeLabel(post.type);
-
   return (
     <FadeReveal>
     <SchemaScript schema={[generateBlogPostingSchema(post), generateBreadcrumbSchema(post.slug, post.title)]} />
@@ -124,11 +122,6 @@ export default async function PostPage({ params }: PostPageProps) {
         </Link>
 
         <header className="flex flex-col gap-2">
-          {typeLabel && (
-            <p className="font-mono text-xs uppercase tracking-[0.2em] text-text-tertiary">
-              {typeLabel}
-            </p>
-          )}
           <h1 className="font-mono text-3xl font-semibold tracking-tight text-text-primary">
             {post.title}
           </h1>

--- a/src/app/(frontend)/posts/page.tsx
+++ b/src/app/(frontend)/posts/page.tsx
@@ -51,7 +51,6 @@ export default async function PostsPage() {
                 isMediaObject(post.featuredImageDark) ? post.featuredImageDark : null
               }
               focalPoint={post.focalPoint ?? undefined}
-              label="ARCHIVE"
             />
           ))
         )}

--- a/src/lib/formatting.ts
+++ b/src/lib/formatting.ts
@@ -9,15 +9,15 @@ export const typeLabels: Record<string, string> = {
   essay: "Essay",
   decoder: "Decoder",
   index: "Index",
-  "field-report": "Field Report",
 };
 
 /**
  * Get a display label for a post type
- * Falls back to the raw type value if not found in the mapping
+ * Returns an empty string for types not in the mapping (so callers can
+ * easily branch on truthiness when deciding whether to render a label).
  */
 export function getTypeLabel(type: string): string {
-  return typeLabels[type] || type;
+  return typeLabels[type] ?? "";
 }
 
 /**

--- a/src/lib/formatting.ts
+++ b/src/lib/formatting.ts
@@ -1,26 +1,4 @@
 /**
- * Formatting utilities for dates and display labels
- */
-
-/**
- * Map post type values to human-readable display labels
- */
-export const typeLabels: Record<string, string> = {
-  essay: "Essay",
-  decoder: "Decoder",
-  index: "Index",
-};
-
-/**
- * Get a display label for a post type
- * Returns an empty string for types not in the mapping (so callers can
- * easily branch on truthiness when deciding whether to render a label).
- */
-export function getTypeLabel(type: string): string {
-  return typeLabels[type] ?? "";
-}
-
-/**
  * Format a date string for display
  * Returns empty string if date is null/undefined
  * Uses short format: "Jan 24, 2026"

--- a/tests/e2e/fixtures/page-objects/post-detail.page.ts
+++ b/tests/e2e/fixtures/page-objects/post-detail.page.ts
@@ -6,7 +6,6 @@ import { Page, Locator } from '@playwright/test'
 export class PostDetailPage {
   readonly page: Page
   readonly postTitle: Locator
-  readonly postType: Locator
   readonly postDate: Locator
   readonly postSummary: Locator
   readonly postContent: Locator
@@ -16,7 +15,6 @@ export class PostDetailPage {
   constructor(page: Page) {
     this.page = page
     this.navigation = page.locator('nav')
-    this.postType = page.locator('article header p').first()
     this.postTitle = page.locator('article h1').first()
     this.postDate = page.locator('article header p').last()
     this.postSummary = page.locator('article p.text-lg').first()
@@ -31,10 +29,6 @@ export class PostDetailPage {
 
   async getPostTitle() {
     return await this.postTitle.textContent()
-  }
-
-  async getPostType() {
-    return await this.postType.textContent()
   }
 
   async getPostDate() {

--- a/tests/e2e/public/post-detail.spec.ts
+++ b/tests/e2e/public/post-detail.spec.ts
@@ -8,7 +8,7 @@ import { expectVisible, expectTitle } from '../helpers'
  * Test data from seed-test-db.ts:
  * - "The Architecture of Agent Systems" (essay) - slug: architecture-of-agent-systems
  * - "Decoding Tool Use Patterns" (decoder) - slug: decoding-tool-use-patterns
- * - "Notes on Autonomous Workflows" (field-report) - slug: notes-on-autonomous-workflows
+ * - "Notes on Autonomous Workflows" (field-report, no badge rendered) - slug: notes-on-autonomous-workflows
  * - "Essential Readings on Agentic AI" (index) - slug: essential-readings-agentic-ai
  */
 
@@ -67,7 +67,7 @@ test.describe('Post Detail Page', () => {
     test.expect(summary).toContain('systematic breakdown of how AI agents select')
   })
 
-  test('should display Field Report post type badge for field-report posts', async ({
+  test('should not render a post type badge for field-report posts', async ({
     postDetailPage,
   }) => {
     await postDetailPage.goto('notes-on-autonomous-workflows')
@@ -75,10 +75,11 @@ test.describe('Post Detail Page', () => {
     // Verify page title metadata
     await expectTitle(postDetailPage.page, /Notes on Autonomous Workflows/)
 
-    // Verify post type badge displays "Field Report"
-    await expectVisible(postDetailPage.postType)
-    const postType = await postDetailPage.getPostType()
-    test.expect(postType?.toUpperCase()).toContain('FIELD REPORT')
+    // Verify the post type badge <p> is not rendered. The badge has the
+    // distinguishing `uppercase` class; selecting on it avoids matching
+    // the (visually similar) date <p> that lives in the same header.
+    const badge = postDetailPage.page.locator('article header p.uppercase')
+    await test.expect(badge).toHaveCount(0)
 
     // Verify title displays
     await expectVisible(postDetailPage.postTitle)

--- a/tests/e2e/public/post-detail.spec.ts
+++ b/tests/e2e/public/post-detail.spec.ts
@@ -8,21 +8,19 @@ import { expectVisible, expectTitle } from '../helpers'
  * Test data from seed-test-db.ts:
  * - "The Architecture of Agent Systems" (essay) - slug: architecture-of-agent-systems
  * - "Decoding Tool Use Patterns" (decoder) - slug: decoding-tool-use-patterns
- * - "Notes on Autonomous Workflows" (field-report, no badge rendered) - slug: notes-on-autonomous-workflows
+ * - "Notes on Autonomous Workflows" (field-report) - slug: notes-on-autonomous-workflows
  * - "Essential Readings on Agentic AI" (index) - slug: essential-readings-agentic-ai
+ *
+ * Post-type labels were removed from the public frontend in #133, so no
+ * post type renders a header badge regardless of `Posts.type`.
  */
 
 test.describe('Post Detail Page', () => {
-  test('should display Essay post type badge for essay posts', async ({ postDetailPage }) => {
+  test('should render essay post detail correctly', async ({ postDetailPage }) => {
     await postDetailPage.goto('architecture-of-agent-systems')
 
     // Verify page title metadata
     await expectTitle(postDetailPage.page, /The Architecture of Agent Systems/)
-
-    // Verify post type badge displays "Essay"
-    await expectVisible(postDetailPage.postType)
-    const postType = await postDetailPage.getPostType()
-    test.expect(postType?.toUpperCase()).toContain('ESSAY')
 
     // Verify title displays
     await expectVisible(postDetailPage.postTitle)
@@ -40,16 +38,11 @@ test.describe('Post Detail Page', () => {
     test.expect(summary).toContain('exploration of how modern agent architectures')
   })
 
-  test('should display Decoder post type badge for decoder posts', async ({ postDetailPage }) => {
+  test('should render decoder post detail correctly', async ({ postDetailPage }) => {
     await postDetailPage.goto('decoding-tool-use-patterns')
 
     // Verify page title metadata
     await expectTitle(postDetailPage.page, /Decoding Tool Use Patterns/)
-
-    // Verify post type badge displays "Decoder"
-    await expectVisible(postDetailPage.postType)
-    const postType = await postDetailPage.getPostType()
-    test.expect(postType?.toUpperCase()).toContain('DECODER')
 
     // Verify title displays
     await expectVisible(postDetailPage.postTitle)
@@ -67,19 +60,20 @@ test.describe('Post Detail Page', () => {
     test.expect(summary).toContain('systematic breakdown of how AI agents select')
   })
 
-  test('should not render a post type badge for field-report posts', async ({
+  test('should not render a post type badge in the header', async ({
     postDetailPage,
   }) => {
     await postDetailPage.goto('notes-on-autonomous-workflows')
 
-    // Verify page title metadata
-    await expectTitle(postDetailPage.page, /Notes on Autonomous Workflows/)
-
-    // Verify the post type badge <p> is not rendered. The badge has the
-    // distinguishing `uppercase` class; selecting on it avoids matching
-    // the (visually similar) date <p> that lives in the same header.
+    // Post-type labels were removed from the frontend in #133.
+    // The badge had the distinguishing `uppercase` class; selecting on it
+    // avoids matching the (visually similar) date <p> that lives in the
+    // same header.
     const badge = postDetailPage.page.locator('article header p.uppercase')
     await test.expect(badge).toHaveCount(0)
+
+    // Verify page title metadata
+    await expectTitle(postDetailPage.page, /Notes on Autonomous Workflows/)
 
     // Verify title displays
     await expectVisible(postDetailPage.postTitle)
@@ -97,16 +91,11 @@ test.describe('Post Detail Page', () => {
     test.expect(summary).toContain('Field observations on how autonomous workflows')
   })
 
-  test('should display Index post type badge for index posts', async ({ postDetailPage }) => {
+  test('should render index post detail correctly', async ({ postDetailPage }) => {
     await postDetailPage.goto('essential-readings-agentic-ai')
 
     // Verify page title metadata
     await expectTitle(postDetailPage.page, /Essential Readings on Agentic AI/)
-
-    // Verify post type badge displays "Index"
-    await expectVisible(postDetailPage.postType)
-    const postType = await postDetailPage.getPostType()
-    test.expect(postType?.toUpperCase()).toContain('INDEX')
 
     // Verify title displays
     await expectVisible(postDetailPage.postTitle)

--- a/tests/unit/lib/formatting.test.ts
+++ b/tests/unit/lib/formatting.test.ts
@@ -53,14 +53,12 @@ describe("typeLabels", () => {
     expect(typeLabels).toHaveProperty("essay");
     expect(typeLabels).toHaveProperty("decoder");
     expect(typeLabels).toHaveProperty("index");
-    expect(typeLabels).toHaveProperty("field-report");
   });
 
   it("has correct label values", () => {
     expect(typeLabels.essay).toBe("Essay");
     expect(typeLabels.decoder).toBe("Decoder");
     expect(typeLabels.index).toBe("Index");
-    expect(typeLabels["field-report"]).toBe("Field Report");
   });
 });
 
@@ -77,12 +75,8 @@ describe("getTypeLabel", () => {
     expect(getTypeLabel("index")).toBe("Index");
   });
 
-  it("returns correct label for field-report", () => {
-    expect(getTypeLabel("field-report")).toBe("Field Report");
-  });
-
-  it("returns raw type for unknown type", () => {
-    expect(getTypeLabel("unknown-type")).toBe("unknown-type");
+  it("returns empty string for unknown type", () => {
+    expect(getTypeLabel("unknown-type")).toBe("");
   });
 
   it("returns empty string for empty input", () => {

--- a/tests/unit/lib/formatting.test.ts
+++ b/tests/unit/lib/formatting.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatDate, getTypeLabel, typeLabels } from "@/lib/formatting";
+import { formatDate } from "@/lib/formatting";
 
 describe("formatDate", () => {
   it("returns empty string for null input", () => {
@@ -45,41 +45,5 @@ describe("formatDate", () => {
     // en-US short format: Mon Day, Year
     const result = formatDate("2026-03-15");
     expect(result).toMatch(/Mar \d+, 2026/);
-  });
-});
-
-describe("typeLabels", () => {
-  it("contains all expected post types", () => {
-    expect(typeLabels).toHaveProperty("essay");
-    expect(typeLabels).toHaveProperty("decoder");
-    expect(typeLabels).toHaveProperty("index");
-  });
-
-  it("has correct label values", () => {
-    expect(typeLabels.essay).toBe("Essay");
-    expect(typeLabels.decoder).toBe("Decoder");
-    expect(typeLabels.index).toBe("Index");
-  });
-});
-
-describe("getTypeLabel", () => {
-  it("returns correct label for essay", () => {
-    expect(getTypeLabel("essay")).toBe("Essay");
-  });
-
-  it("returns correct label for decoder", () => {
-    expect(getTypeLabel("decoder")).toBe("Decoder");
-  });
-
-  it("returns correct label for index", () => {
-    expect(getTypeLabel("index")).toBe("Index");
-  });
-
-  it("returns empty string for unknown type", () => {
-    expect(getTypeLabel("unknown-type")).toBe("");
-  });
-
-  it("returns empty string for empty input", () => {
-    expect(getTypeLabel("")).toBe("");
   });
 });


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    type["Posts.type<br/>(payload schema)"] --> sel{Surface?}
    sel -->|home Card label| home_x["REMOVED<br/>(label prop dropped)"]
    sel -->|post-detail header p| det_x["REMOVED<br/>(typeLabel guard + p deleted)"]
    sel -->|JSON-LD articleSection| jsonld["KEPT<br/>(SEO metadata)"]
    sel -->|DB enum + seed fixtures| db["KEPT<br/>(data preserved)"]

    classDef removed stroke:#f87171,stroke-width:2px;
    classDef kept stroke:#34d399,stroke-width:2px;
    class home_x,det_x removed;
    class jsonld,db kept;
```

## Summary

- Pre-existing bug fix: every featured post on the home page was hard-coded `label="FIELD REPORT"` regardless of the post's actual `type` (introduced by commit `0e4c4a2` during a multi-agent audit pass). Removing the prop entirely is the cleanest fix — the design intent is no per-post type badge anywhere on the public site.
- The post-detail header used to render an uppercased type label (`ESSAY`, `DECODER`, etc.) above the title. That `<p>` is gone too, so the header is now `← Back to Posts` → `<h1>` → date.
- The `/posts` listing page also rendered a hard-coded `label="ARCHIVE"` on every PostCard. Same shape (uppercased text in the Card frame slot, above the image), same removal — no Card on the public site now renders a label.
- `Posts.type` stays as a Payload schema value (existing data depends on it) and still feeds `articleSection` in JSON-LD, so SEO/structured data is unchanged. This is purely a UI/editorial change — no migration, no data loss, no schema change.

## Screenshots

**Home page (desktop, 1440×900) — labels gone, cards now have title + summary only:**

![home page (desktop, 1440x900) — no labels above titles](https://github.com/user-attachments/assets/ee093d1b-a8c6-4ae3-b397-849de49621ec)

**Home page (mobile, 390×844) — same, viewport-stacked:**

<img alt="home page (mobile, 390x844) — no labels above titles" src="https://github.com/user-attachments/assets/cf3d0bbb-c5fe-458d-8a3d-f8c91d8358a7" width="390">

**Post detail (desktop) — no type badge above the title:**

![post detail (desktop) — no type badge above the title](https://github.com/user-attachments/assets/0d783f28-18cd-419d-9c1c-712670186b7c)

## Test plan

- [x] `pnpm test:unit` — 187/187 passing (8 tests removed: 7 `getTypeLabel`/`typeLabels` cases plus the rewritten "field-report unknown-type" case; `formatDate` suite untouched).
- [x] `pnpm lint` — 0 errors. 18 pre-existing warnings unrelated to this PR.
- [x] `pnpm build` — clean. Type checks pass; no dangling `getTypeLabel` references.
- [x] Browser-driven smoke check on `pnpm dev` at desktop (1440×900) and mobile (390×844) viewports against three featured essays, the `/posts` archive page, and one post detail. No type/section label renders anywhere; layout stays clean (no orphan `gap-2` whitespace from the removed `<p>`).
- [x] e2e badge-absence test (`tests/e2e/public/post-detail.spec.ts:70-97`) — asserts the type badge is not rendered for the `field-report` fixture post; this assertion now holds for **all** posts, not just field-report. Test still scoped to the field-report fixture for documentation continuity.

## Plan reference

Closes #133. Out of plan — small editorial/UX cleanup driven by author feedback that the per-post type/section badges were visually noisy and conceptually unneeded.
