### PR TITLE
fix(e2e): scope mermaid selector to .mermaid-figure

### DIFF
--- a/tests/e2e/public/mermaid.spec.ts
+++ b/tests/e2e/public/mermaid.spec.ts
@@ -20,7 +20,8 @@ const SVG_TIMEOUT = 10_000
 
 // Mermaid emits role="graphics-document document" (two space-separated tokens).
 // Use [role*="graphics-document"] so both the exact and combined values match.
-const MERMAID_SVG = 'svg[id^="mermaid-"][role*="graphics-document"]'
+// Scope to .mermaid-figure: the lightbox <dialog> in MermaidDiagram.tsx pre-renders a duplicate SVG with the same id.
+const MERMAID_SVG = '.mermaid-figure svg[id^="mermaid-"][role*="graphics-document"]'
 
 test.describe('Mermaid block rendering', () => {
   test('renders a mermaid block as SVG on the post page', async ({ postDetailPage }) => {


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    state["MermaidDiagram svg state<br/>(set on render/theme change)"] --> A["&lt;button .mermaid-figure&gt;<br/>SVG copy 1<br/>(in-flow, visible)"]
    state --> B["&lt;dialog aria-label='Expanded diagram'&gt;<br/>SVG copy 2<br/>(preloaded for instant lightbox)"]

    A --> sel1["test selector<br/>(scoped to .mermaid-figure)"]
    B -.no longer matched.-> sel1

    classDef test stroke:#34d399,stroke-width:2px;
    class sel1 test;
```

## Summary

- The mermaid lightbox feature (PR #115) renders the rendered SVG **twice** — once in the `.mermaid-figure` trigger button, once preloaded inside the `<dialog>` so the expand-to-modal animation starts on a pre-mounted node. Both copies carry the same `id` (same `svg` state variable, same `crypto.randomUUID()`).
- The e2e selector `svg[id^="mermaid-"][role*="graphics-document"]` therefore now resolves to **2 elements**, and Playwright's strict mode rejects every `expect()` against it. CI's E2E Shard 3/4 has been red on `main` since #115 merged (also visible on every Dependabot PR).
- Fix is one line: scope the test constant to `.mermaid-figure` so it matches only the in-page copy and ignores the lightbox preload. The component's dual-render is a deliberate UX choice (instant lightbox), so don't strip it.

## Screenshots

N/A — test-only change. The component itself is unchanged; only the test's selector is more specific.

## Test plan

- [x] `pnpm test:unit` — 195/195 passing (unrelated to this change; verifying the env is clean).
- [x] `pnpm lint` — 0 errors. 18 pre-existing warnings.
- [x] `pnpm build` — Next.js 16 build succeeds, all routes prerendered.
- [x] Verified `.mermaid-figure` stability: the class appears in `src/components/MermaidDiagram.tsx:281` (declaration) and `src/app/globals.css:725,730` (styling). A future refactor would touch the styles too, so the test selector breaking would be visible.
- [x] Verified the theme-toggle test still observes what it claims: both SVG copies consume the same `svg` state and re-render together with a fresh UUID on `resolvedTheme` change. Scoping to `.mermaid-figure` does not lose information.
- [ ] CI E2E Shard 3/4 — must go green on this PR. **This is the load-bearing verification** since unit/lint/build don't exercise the affected selector.

## Plan reference

Out of plan — pre-existing CI red on `main` surfaced by the julianken-bot review on PR #134. Unblocks #134 from queueing once merged.
