### PR TITLE
ci(deploy): run Payload migrations before Docker build

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -69,6 +69,25 @@ on a ready-to-merge PR. -->
       Reviewers repeat the drive + console check via `gh pr checkout <N>` +
       `npm run dev` against the PR head SHA before approving.
 
+## Migration checklist
+
+<!-- Delete this entire section if no migration in this PR. The deploy pipeline
+runs migrations BEFORE the new container builds, so the OLD container serves
+traffic against the NEW schema for the duration of the build. Every migration
+must be backwards-compatible with the previous container — see
+migrations/README.md "N-1 Backwards-Compatibility Contract" for the full
+spec. -->
+
+- [ ] Migration is additive-nullable, default-bearing, `CREATE INDEX
+      CONCURRENTLY`, or `ADD CONSTRAINT NOT VALID` — OR is part of a documented
+      two-PR sequence (PR 1 additive + PR 2 cutover)
+- [ ] I walked through every `SELECT` / `INSERT` / `UPDATE` in
+      `src/lib/queries/` and confirmed the old container's queries still
+      succeed against the new schema
+- [ ] If this is a destructive change (DROP COLUMN, RENAME, type change),
+      the corresponding "PR 2 cutover" issue is filed and linked above
+- [ ] Migration's `down()` reverses cleanly
+
 ## Plan reference
 
 <!-- Link the issue, Linear ticket, brainstorm doc, or design doc this PR

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,15 +37,16 @@ jobs:
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ vars.GCP_REGION }}-docker.pkg.dev
 
-      - name: Build Docker image
-        run: |
-          docker build \
-            --build-arg "NEXT_PUBLIC_SERVER_URL=${{ vars.NEXT_PUBLIC_SERVER_URL }}" \
-            --build-arg DATABASE_URL=${{ secrets.SUPABASE_SESSION_URL }} \
-            --build-arg PAYLOAD_SECRET=${{ secrets.PAYLOAD_SECRET }} \
-            -t ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/tech-blog/app:${{ github.sha }} .
-          docker push ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/tech-blog/app:${{ github.sha }}
-
+      # Migrations MUST run before the Docker build. The build runs `pnpm build`
+      # which prerenders server components against the live DB (DATABASE_URL is
+      # passed as a build-arg). If the schema is older than the code being
+      # built, prerender queries fail mid-build. On 2026-04-28 (PR #140), this
+      # plus the swallow-and-return-empty pattern in src/lib/queries/ baked an
+      # empty-state /posts HTML into the container image and shipped it. See
+      # issue #141 for the swallow-pattern follow-up. The invariant here is:
+      # all migrations must be backwards-compatible with the previous container
+      # (N-1 compat), so running them before the new build does not break the
+      # currently-serving revision.
       - name: Run Payload migrations
         env:
           DATABASE_URL: ${{ secrets.SUPABASE_SESSION_URL }}
@@ -76,6 +77,15 @@ jobs:
           SQL
           pnpm payload migrate
         timeout-minutes: 5
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            --build-arg "NEXT_PUBLIC_SERVER_URL=${{ vars.NEXT_PUBLIC_SERVER_URL }}" \
+            --build-arg DATABASE_URL=${{ secrets.SUPABASE_SESSION_URL }} \
+            --build-arg PAYLOAD_SECRET=${{ secrets.PAYLOAD_SECRET }} \
+            -t ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/tech-blog/app:${{ github.sha }} .
+          docker push ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/tech-blog/app:${{ github.sha }}
 
       - name: Deploy to Cloud Run
         uses: google-github-actions/deploy-cloudrun@v2

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -112,6 +112,46 @@ DROP INDEX IF EXISTS idx_posts_status_publishedAt;
 EOF
 ```
 
+## N-1 Backwards-Compatibility Contract
+
+**Every migration in this repository MUST be backwards-compatible with the previous container revision.**
+
+### Why
+
+The deploy pipeline (`.github/workflows/deploy.yml`) runs migrations *before* the new Docker image builds and deploys. Between the migration applying and Cloud Run cutting traffic to the new revision, the **old** container is still serving every request — against the **new** schema. If the migration breaks the old container's queries, prod goes down for the duration of the build (~1–3 minutes).
+
+This is a deliberate trade. The alternative ordering (build → migrate → deploy, our prior setup) put the *new* code on the *old* schema during the build's prerender phase, which caused the 2026-04-28 incident (PR #140 → empty `/posts` baked into the container image; see #141).
+
+### What "backwards-compatible" means
+
+A migration is N-1 compatible if **the previous container revision continues to serve every route correctly while the new schema is live but the new code is not yet deployed**. Concretely:
+
+- ✅ **Safe**: `ADD COLUMN ... NULL` (additive nullable column — old SELECTs ignore it)
+- ✅ **Safe**: `ADD COLUMN ... NOT NULL DEFAULT '...'` (new column with default — old INSERTs that omit it succeed via the default)
+- ✅ **Safe**: `CREATE INDEX CONCURRENTLY` (online index build — no locking)
+- ✅ **Safe**: `ALTER TABLE ... ADD CONSTRAINT ... NOT VALID` (deferred validation)
+- ⚠️ **Requires two-PR sequencing**: `DROP COLUMN`, `RENAME`, type changes (e.g. `varchar → uuid`)
+- ⚠️ **Requires two-PR sequencing**: removing an enum variant the old code still writes
+- ❌ **Never safe in one PR**: dropping a table or column the old code reads from; renaming a primary key; making a previously-nullable column NOT NULL without backfilling first
+
+### Two-PR sequencing pattern (for the ⚠️ cases)
+
+When a change is not N-1 safe in one step, split it across two PRs:
+
+1. **PR 1 (additive)**: add the new shape (column/table/enum). Old code ignores it. Code reads/writes the *old* shape, optionally also writing the new one. Deploy. Backfill if needed.
+2. **PR 2 (cutover)**: switch reads to the new shape, drop the old. Old container from PR 1 still serves correctly because both shapes existed.
+
+Worked example: `migrations/20260428_010142_add_media_preview.ts` (PR 1: add `preview_color` + `preview_ascii` columns; old `lqip` column kept and dual-read) — the PR 2 follow-up will drop `lqip` once all docs are backfilled and the new code path is proven.
+
+### Author checklist (copy into the PR body for every migration)
+
+- [ ] Migration is one of the ✅-Safe shapes above, OR is part of a documented two-PR sequence
+- [ ] Old container's queries still succeed against the new schema (mentally walk through every `SELECT`/`INSERT`/`UPDATE` from `src/lib/queries/`)
+- [ ] If a column type changes or a column is dropped, there is a corresponding "PR 2 cutover" issue filed
+- [ ] Migration includes a `down()` that reverses cleanly (we don't autorollback, but the option matters)
+
+If you cannot tick every box, do not merge — split into two PRs.
+
 ## Best Practices
 
 1. **Always backup** before running migrations in production
@@ -119,6 +159,7 @@ EOF
 3. **Validate results** with `validate-indexes.sql` script
 4. **Monitor performance** after deployment
 5. **Document custom migrations** with inline comments
+6. **Honor the N-1 contract above** — non-additive migrations require two-PR sequencing
 
 ## References
 


### PR DESCRIPTION
## Summary

- Reorders `.github/workflows/deploy.yml` so `Run Payload migrations` runs before `Build Docker image`.
- Adds an inline comment explaining why and citing the incident.

## Why

PR #140 deployed an empty `/posts` and `/` to prod on 2026-04-28. The build log of run 25028518004 shows:

```
01:18:34Z [ERROR] [PAYLOAD_FIND_FAILED] Failed to fetch published posts
  message: 'Failed query: select "id", "alt", ..., "preview_color", "preview_ascii", ...'
```

The Docker build's `pnpm build` prerendered `/` and `/posts` against the live DB while the new migration adding `preview_color`/`preview_ascii` had not yet been applied. The schema lagged the code by one deploy. Combined with the swallow-and-return-empty pattern in `src/lib/queries/posts.ts:59-67` (tracked separately in #141), the build proceeded silently and shipped an empty-state HTML in the container image.

## Fix

Migrate first, then build. Migrations in this repo are required to be backwards-compatible with the previous container (N-1 compat), per the dual-read pattern documented in `migrations/20260428_010142_add_media_preview.ts:14-19`, so running migrations against the still-serving old revision is safe.

## Test plan

- [ ] CI passes on this PR (no functional CI runs against deploy.yml itself; YAML lint is the only signal pre-merge)
- [ ] Manual: after merge, watch the next deploy run; verify `Run Payload migrations` step runs before `Build Docker image`
- [ ] Manual: verify the next deploy renders posts on `/posts` (this PR alone won't fix the currently-stuck cache from PR #140 — that needs either a wait for natural ISR revalidation or a touch-to-revalidate via Payload admin)
- [ ] No need to test the failure case here; #141's tests cover the prerender-failure-fails-build behavior once the swallows are removed

## Related

- Incident: PR #140 (`feat(media): content-aware ASCII halftone preview`)
- Follow-up: #141 (`fix(queries): re-throw data-layer errors instead of swallowing into degraded states`) — together these two changes mean future migration-vs-build ordering bugs would fail the build loudly even if someone re-introduces an out-of-order step
- RCA finding ranked #2 by leverage; #1 (the swallow re-throw) is in #141