### PR TITLE
ci: add manual backfill-previews workflow_dispatch action

### DIFF
--- a/.github/workflows/backfill-previews.yml
+++ b/.github/workflows/backfill-previews.yml
@@ -96,12 +96,12 @@ jobs:
       # post pages so direct landings (RSS, social, search) get fresh HTML
       # instead of stale yellow-fallback prerenders for up to an hour.
       - name: Verify previews and warm post pages
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.dry_run != true }}
         env:
           PROD_URL: ${{ vars.NEXT_PUBLIC_SERVER_URL }}
         run: |
           echo "Asserting all media docs have populated previews…"
-          missing=$(curl -fsS "$PROD_URL/api/media?limit=200&depth=0&select%5Bpreview%5D=true" \
+          missing=$(curl -fsS "$PROD_URL/api/media?limit=0&depth=0&select%5Bpreview%5D=true" \
             | jq '[.docs[] | select((.preview.ascii // "") | length != 288)] | length')
           if [ "$missing" -ne 0 ]; then
             echo "::error::$missing media doc(s) still lack a populated 288-char preview.ascii"
@@ -114,7 +114,7 @@ jobs:
           curl -fsS -o /dev/null -w "%{http_code} %{url_effective}\n" "$PROD_URL/" || true
 
           echo "Warming individual post pages…"
-          curl -fsS "$PROD_URL/api/posts?where%5Bstatus%5D%5Bequals%5D=published&limit=200&depth=0&select%5Bslug%5D=true" \
+          curl -fsS "$PROD_URL/api/posts?where%5Bstatus%5D%5Bequals%5D=published&limit=0&depth=0&select%5Bslug%5D=true" \
             | jq -r '.docs[].slug' \
             | while read -r slug; do
                 curl -fsS -o /dev/null -w "%{http_code} /posts/$slug\n" "$PROD_URL/posts/$slug" || true

--- a/.github/workflows/backfill-previews.yml
+++ b/.github/workflows/backfill-previews.yml
@@ -52,6 +52,24 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
+      # Defense in depth: the script's assertNonProductionDatabase guard is
+      # bypassed below for production. To prevent a future fork from accidentally
+      # pointing this workflow at an unexpected host (e.g. someone copies this
+      # file, swaps the script ref, but forgets to update DATABASE_URL), assert
+      # that the resolved DB hostname matches the expected Supabase pattern
+      # before invoking the bypass.
+      - name: Assert DB host is the expected prod host
+        env:
+          DATABASE_URL: ${{ secrets.SUPABASE_SESSION_URL }}
+        run: |
+          host=$(node -e 'console.log(new URL(process.env.DATABASE_URL).hostname)')
+          case "$host" in
+            *.supabase.co|*.supabase.com|*.pooler.supabase.com)
+              echo "OK: $host" ;;
+            *)
+              echo "::error::Unexpected DB host: $host"; exit 1 ;;
+          esac
+
       - name: Run backfill
         env:
           DATABASE_URL: ${{ secrets.SUPABASE_SESSION_URL }}
@@ -59,24 +77,45 @@ jobs:
           NEXT_PUBLIC_SERVER_URL: ${{ vars.NEXT_PUBLIC_SERVER_URL }}
           I_KNOW_THIS_IS_NOT_PROD: '1'
           DRY_RUN_INPUT: ${{ inputs.dry_run }}
+        # Fail-safe shell branch: any value of DRY_RUN_INPUT that is not exactly
+        # "false" (e.g. "", "True", "1", malformed runner serialization) defaults
+        # to dry-run. Matches the L14 comment "Author must explicitly set
+        # dry_run=false to write".
         run: |
-          if [ "$DRY_RUN_INPUT" = "true" ]; then
-            echo "::notice::Running in DRY RUN mode (no writes)."
-            pnpm tsx scripts/backfill-previews.ts --dry-run
-          else
+          if [ "$DRY_RUN_INPUT" = "false" ]; then
             echo "::warning::Running LIVE — will update Media docs in production."
             pnpm tsx scripts/backfill-previews.ts
+          else
+            echo "::notice::Running in DRY RUN mode (no writes)."
+            pnpm tsx scripts/backfill-previews.ts --dry-run
           fi
 
-      - name: Trigger ISR warm-up
+      # After a live backfill: (a) verify every Media doc has a populated
+      # 288-char preview.ascii — fail loudly if not, since the script swallows
+      # per-doc decode errors as `failed++` and exits 0; (b) warm individual
+      # post pages so direct landings (RSS, social, search) get fresh HTML
+      # instead of stale yellow-fallback prerenders for up to an hour.
+      - name: Verify previews and warm post pages
         if: ${{ inputs.dry_run == false }}
         env:
           PROD_URL: ${{ vars.NEXT_PUBLIC_SERVER_URL }}
         run: |
-          # Backfill updates Media docs but does not touch any Post, so the
-          # revalidate-post hook never fires. Hit /posts and / once to force a
-          # fresh prerender with the new previews instead of waiting up to an
-          # hour for natural ISR. Failures here are non-fatal.
+          echo "Asserting all media docs have populated previews…"
+          missing=$(curl -fsS "$PROD_URL/api/media?limit=200&depth=0&select%5Bpreview%5D=true" \
+            | jq '[.docs[] | select((.preview.ascii // "") | length != 288)] | length')
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::$missing media doc(s) still lack a populated 288-char preview.ascii"
+            exit 1
+          fi
+          echo "All media docs verified."
+
           echo "Warming /posts and /…"
           curl -fsS -o /dev/null -w "%{http_code} %{url_effective}\n" "$PROD_URL/posts" || true
           curl -fsS -o /dev/null -w "%{http_code} %{url_effective}\n" "$PROD_URL/" || true
+
+          echo "Warming individual post pages…"
+          curl -fsS "$PROD_URL/api/posts?where%5Bstatus%5D%5Bequals%5D=published&limit=200&depth=0&select%5Bslug%5D=true" \
+            | jq -r '.docs[].slug' \
+            | while read -r slug; do
+                curl -fsS -o /dev/null -w "%{http_code} /posts/$slug\n" "$PROD_URL/posts/$slug" || true
+              done

--- a/.github/workflows/backfill-previews.yml
+++ b/.github/workflows/backfill-previews.yml
@@ -1,0 +1,82 @@
+name: Backfill Media Previews
+
+# One-shot, manually-triggered workflow that runs scripts/backfill-previews.ts
+# against the production database. Idempotent — skips Media docs whose
+# preview.ascii is already 288 chars long. Safe to re-run.
+#
+# Why this exists:
+#   PR #140 added preview.color and preview.ascii fields with a beforeChange
+#   hook that fires on create + re-upload. Existing Media docs uploaded
+#   before #140 stay NULL on these fields and render the broken yellow
+#   placeholder fallback. This workflow backfills them.
+#
+# Operational notes:
+#   - Defaults to dry-run. Author must explicitly set dry_run=false to write.
+#   - Sets I_KNOW_THIS_IS_NOT_PROD=1 so the script's assertNonProductionDatabase
+#     guard allows the prod DB host (mirrors scripts/seed-test-db.ts:16).
+#   - Reuses the same DATABASE_URL secret (SUPABASE_SESSION_URL) and
+#     PAYLOAD_SECRET as deploy.yml. The script fetches Media files via their
+#     public GCS URLs, so no GCS auth is needed for reads.
+#   - Concurrency-locked so two clicks from the Actions UI cannot stomp on
+#     each other.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (true = no writes; false = live backfill)'
+        type: boolean
+        required: true
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backfill-previews-production
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run backfill
+        env:
+          DATABASE_URL: ${{ secrets.SUPABASE_SESSION_URL }}
+          PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
+          NEXT_PUBLIC_SERVER_URL: ${{ vars.NEXT_PUBLIC_SERVER_URL }}
+          I_KNOW_THIS_IS_NOT_PROD: '1'
+          DRY_RUN_INPUT: ${{ inputs.dry_run }}
+        run: |
+          if [ "$DRY_RUN_INPUT" = "true" ]; then
+            echo "::notice::Running in DRY RUN mode (no writes)."
+            pnpm tsx scripts/backfill-previews.ts --dry-run
+          else
+            echo "::warning::Running LIVE — will update Media docs in production."
+            pnpm tsx scripts/backfill-previews.ts
+          fi
+
+      - name: Trigger ISR warm-up
+        if: ${{ inputs.dry_run == false }}
+        env:
+          PROD_URL: ${{ vars.NEXT_PUBLIC_SERVER_URL }}
+        run: |
+          # Backfill updates Media docs but does not touch any Post, so the
+          # revalidate-post hook never fires. Hit /posts and / once to force a
+          # fresh prerender with the new previews instead of waiting up to an
+          # hour for natural ISR. Failures here are non-fatal.
+          echo "Warming /posts and /…"
+          curl -fsS -o /dev/null -w "%{http_code} %{url_effective}\n" "$PROD_URL/posts" || true
+          curl -fsS -o /dev/null -w "%{http_code} %{url_effective}\n" "$PROD_URL/" || true


### PR DESCRIPTION
## Summary

Adds `.github/workflows/backfill-previews.yml` — a manually-triggered workflow that runs `scripts/backfill-previews.ts` against the production DB. Idempotent, dry-run by default.

## Why

PR #140 added `preview.color` + `preview.ascii` fields with a hook that fires on **create + re-upload** only. The 9 Media docs that predate #140 are still NULL on those fields, AND they were never backfilled with the older \`lqip\` field either, so every hero image on prod currently renders the broken yellow fallback. Verified at 03:58 UTC: \`https://detached-node.dev/api/media\` returns 9 docs all with \`preview=null\` and \`lqip=null\`.

The script (\`scripts/backfill-previews.ts\`) was added in #140 but never invoked. This PR adds the operational mechanism to run it.

## How to use

1. Merge this PR.
2. Go to **Actions** → **Backfill Media Previews** → **Run workflow**.
3. First run: leave **Dry run** = `true`. Verify the log lists 9 pending docs.
4. Second run: set **Dry run** = `false`. ~9 docs × ~500ms (network + sharp encode) = under 10 seconds. Workflow then warms `/posts` + `/` to force a fresh prerender.

## Safety

- `workflow_dispatch` only — never auto-runs.
- Defaults to dry-run; author must explicitly toggle off.
- Concurrency-locked (`backfill-previews-production`) so two clicks can't stomp on each other.
- Reuses existing `SUPABASE_SESSION_URL` + `PAYLOAD_SECRET` GitHub secrets — no new secrets required.
- The script is idempotent: skips any doc whose `preview.ascii.length === 288`. Re-running is a no-op once complete.
- The `assertNonProductionDatabase` guard in the script is bypassed via `I_KNOW_THIS_IS_NOT_PROD=1` (mirrors the precedent in `scripts/seed-test-db.ts:16`). The bypass is intentional and operationally documented in the script's docstring.

## Reusability

Pattern is reusable: any future media-derived field (e.g. EXIF metadata, ML-derived tags, alt-text autosuggestions) gets the same workflow shape. Copy this file, swap the script reference and the warm-up paths.

## Test plan

- [ ] Workflow file is valid YAML (verified locally with `python3 -c 'import yaml; yaml.safe_load(...)'`)
- [ ] After merge, dry-run dispatch shows 9 pending docs
- [ ] After live dispatch, `curl https://detached-node.dev/api/media | jq` shows all 9 docs have `preview.ascii.length === 288` and a `preview.color` matching `#[0-9a-f]{6}`
- [ ] Hard-reload `https://detached-node.dev/posts` shows ASCII halftone placeholders, not yellow

## Related

- #138 (the active plan) — the script this workflow runs
- #140 (incident PR) — added the fields and the hook but never wired the backfill
- #141 (open) — re-throw queries instead of swallowing (orthogonal to this)