### PR TITLE
chore(footer): remove ticking epoch timestamp

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -588,20 +588,6 @@ main {
 }
 
 /* ──────────────────────────────────────────────
-   EPOCH PULSE
-   Brief accent-color flash on each timestamp tick.
-   ────────────────────────────────────────────── */
-
-@keyframes epoch-pulse {
-  0% { color: var(--accent-muted); }
-  100% { color: var(--text-tertiary); }
-}
-
-.epoch-pulse {
-  animation: epoch-pulse 400ms ease-out forwards;
-}
-
-/* ──────────────────────────────────────────────
    HERO GLOW
    Slow-drifting radial gradient behind hero content.
    GPU-accelerated via transform on pseudo-element.

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -12,47 +12,14 @@ function getSection(pathname: string): string {
   return (segment || 'HOME').toUpperCase();
 }
 
-// External epoch store — avoids setState-in-effect and ref-during-render
-let epochCurrent = '----------';
-let epochPrev = '----------';
-let epochSnapshot = { current: epochCurrent, prev: epochPrev };
-
-function subscribeEpoch(callback: () => void) {
-  epochCurrent = String(Math.floor(Date.now() / 1000));
-  epochSnapshot = { current: epochCurrent, prev: epochPrev };
-  const id = setInterval(() => {
-    epochPrev = epochCurrent;
-    epochCurrent = String(Math.floor(Date.now() / 1000));
-    epochSnapshot = { current: epochCurrent, prev: epochPrev };
-    callback();
-  }, 1000);
-  return () => clearInterval(id);
-}
-
-function getEpochSnapshot() {
-  return epochSnapshot;
-}
-
-const serverSnapshot = { current: '----------', prev: '----------' };
-
 export function StatusBar() {
   const mounted = useSyncExternalStore(() => () => {}, () => true, () => false);
-  const { current: epoch, prev } = useSyncExternalStore(subscribeEpoch, getEpochSnapshot, () => serverSnapshot);
   const { resolvedTheme, toggle } = useThemeToggle();
   const { level: contrast, cycle: cycleContrast } = useContrast();
   const { level: brightness, cycle: cycleBrightness } = useBrightness();
   const pathname = usePathname();
 
   const themeLabel = mounted ? (resolvedTheme === 'dark' ? 'DARK' : 'LIGHT') : '----';
-
-  const digits = epoch.split('').map((digit, i) => {
-    const changed = digit !== prev[i];
-    return (
-      <span key={`${i}-${digit}`} className={changed ? 'epoch-pulse' : undefined}>
-        {digit}
-      </span>
-    );
-  });
 
   return (
     <footer className="border-t border-border px-4 py-2 font-mono text-xs tracking-wider text-text-tertiary">
@@ -84,8 +51,6 @@ export function StatusBar() {
             >
               BRT:{mounted ? brightness.toUpperCase() : '----'}
             </button>
-            <span>{'//'}</span>
-            <span className="inline-flex">{digits}</span>
           </span>
         </div>
         <span className="shrink-0 text-text-tertiary">&copy; DETACHED-NODE</span>


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  before["Footer (before)<br/>HOME // DARK // CTR // BRT // 1714326012"]
  after["Footer (after)<br/>HOME // DARK // CTR // BRT"]
  before -.removes ticking epoch.-> after
```

## Summary

- The 10-digit Unix-epoch counter and its per-tick `epoch-pulse` flash no longer earn their cost in motion budget — Julian asked for it gone.
- Drops the entire `useSyncExternalStore` epoch plumbing, the digit diff, and the orphaned `epoch-pulse` keyframe + class.
- Net delta: `-49` lines, no behavior change beyond the removal.

## Screenshots

Footer at 1280×820 after removal — `HOME // DARK // CTR:NORM // BRT:NORM    © DETACHED-NODE`, no ticking digits.

<img width="1280" height="820" alt="Footer with timestamp removed" src="https://github.com/user-attachments/assets/b75d9b3f-1024-418f-aa49-c2a6f0128956" />

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (37 pre-existing warnings unchanged)
- [x] `npx vitest run` — 216/216 pass
- [x] Browser drive at 1280×820 against `localhost:3000` — footer reads `HOME // DARK // CTR:NORM // BRT:NORM    © DETACHED-NODE`, no ticking digits

## Plan reference

Closes #146 — out of plan; user-driven UX cleanup.