### PR TITLE
fix(ThemeAwareHero): propagate display utilities to inner img

### DIFF
--- a/src/components/ImageWithAsciiPreview.tsx
+++ b/src/components/ImageWithAsciiPreview.tsx
@@ -22,6 +22,25 @@ interface ImageWithAsciiPreviewProps {
 }
 
 /**
+ * Tailwind utility tokens whose effect is `display: …` — including their
+ * variant-prefixed forms (`dark:hidden`, `md:flex`, etc.). We propagate
+ * these to the inner <img> so `getComputedStyle(<img>).display` reflects
+ * theme visibility, not just the wrapper's. The wrapper keeps the same
+ * tokens too, so the entire stack (background + ASCII + image) hides
+ * together — propagation only adds the inner-element invariant the
+ * theme-aware-hero E2E spec asserts on the <img>.
+ */
+const DISPLAY_TOKEN_RE =
+  /^(?:[a-z][\w-]*:)?(?:hidden|block|inline|inline-block|flex|inline-flex|grid|inline-grid|contents|table|table-cell|table-row|flow-root|list-item)$/
+
+function partitionDisplayClasses(className: string): string {
+  return className
+    .split(/\s+/)
+    .filter((tok) => tok && DISPLAY_TOKEN_RE.test(tok))
+    .join(" ")
+}
+
+/**
  * Validates and splits an ASCII halftone string into one row per array
  * element, preserving original character order (row-major). Returns null
  * when the input is missing or wrong length so the caller can omit the
@@ -74,6 +93,13 @@ export function ImageWithAsciiPreview({
   // CSS uses to drive both the ASCII fade-out and the image fade-in.
   const wrapperClass = `ascii-preview-wrapper ${className}`.trim()
 
+  // The E2E theme-aware-hero spec asserts `display` on the inner <img>, not
+  // the wrapper. Without forwarding `hidden` / `dark:hidden` / `dark:block`
+  // to the <img>, hiding the wrapper leaves the descendant <img> reporting
+  // `display: block` to getComputedStyle. Propagate just the display tokens.
+  const imgDisplayClass = partitionDisplayClasses(className)
+  const imgClass = `ascii-preview-img ${imgDisplayClass}`.trim()
+
   return (
     <div
       className={wrapperClass}
@@ -101,7 +127,7 @@ export function ImageWithAsciiPreview({
       <AsciiPreviewImage
         src={src}
         alt={alt}
-        className="ascii-preview-img"
+        className={imgClass}
         sizes={sizes}
         style={style}
         fetchPriority={fetchPriority}

--- a/tests/unit/components/ImageWithAsciiPreview.test.tsx
+++ b/tests/unit/components/ImageWithAsciiPreview.test.tsx
@@ -155,6 +155,49 @@ describe("ImageWithAsciiPreview", () => {
     expect(img?.getAttribute("alt")).toBe("A neural network diagram")
   })
 
+  it("propagates dark:hidden from className to the inner <img>", () => {
+    const { container } = render(
+      <ImageWithAsciiPreview
+        src="/media/test.png"
+        alt="alt"
+        className="dark:hidden"
+        preview={{ color: "#1e2530", ascii: VALID_ASCII }}
+      />,
+    )
+    const wrapper = container.querySelector(".ascii-preview-wrapper") as HTMLElement
+    const img = container.querySelector("img") as HTMLImageElement
+    expect(wrapper.className).toContain("dark:hidden")
+    expect(img.className).toContain("dark:hidden")
+  })
+
+  it("propagates 'hidden dark:block' (off-by-default variant) to the inner <img>", () => {
+    const { container } = render(
+      <ImageWithAsciiPreview
+        src="/media/test.png"
+        alt="alt"
+        className="hidden dark:block"
+        preview={{ color: "#1e2530", ascii: VALID_ASCII }}
+      />,
+    )
+    const img = container.querySelector("img") as HTMLImageElement
+    expect(img.className).toContain("hidden")
+    expect(img.className).toContain("dark:block")
+  })
+
+  it("does not propagate non-display utilities (e.g. object-cover) to the inner <img>", () => {
+    const { container } = render(
+      <ImageWithAsciiPreview
+        src="/media/test.png"
+        alt="alt"
+        className="object-cover dark:hidden"
+        preview={{ color: "#1e2530", ascii: VALID_ASCII }}
+      />,
+    )
+    const img = container.querySelector("img") as HTMLImageElement
+    expect(img.className).toContain("dark:hidden")
+    expect(img.className).not.toContain("object-cover")
+  })
+
   it("flips data-loaded to 'true' on the wrapper when the image fires onLoad", () => {
     const { container } = render(
       <ImageWithAsciiPreview


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  parent["ThemeAwareHero<br/>className='dark:hidden'<br/>(or 'hidden dark:block')"]
  parent --> wrap["ImageWithAsciiPreview<br/>(outer div wrapper)"]
  wrap -- "before #140<br/>display tokens reach <img>" --> imgOk["<img> hidden in off-theme<br/>getComputedStyle.display = 'none' ✅"]
  wrap -- "after #140 (broken)<br/>tokens stop at wrapper" --> imgBroken["<img> always display:block<br/>spec assertion fails ❌"]
  wrap -- "this PR (fix)<br/>partitionDisplayClasses → inner img" --> imgFixed["<img> hidden in off-theme<br/>contract restored ✅"]
```

## Summary

- PR #140 routed hero variants through `ImageWithAsciiPreview`, which puts `dark:hidden` / `hidden dark:block` on the wrapper but not the inner `<img>`. `getComputedStyle(<img>).display` still returns `block`, breaking the spec contract from before #140 and the 3 E2E tests in `theme-aware-hero.spec.ts`.
- Fix: parse the incoming `className`, partition out display tokens (`hidden`, `*:hidden`, `*:block`, plus the rest of Tailwind's display family), and forward only those to the inner `<img>`. Non-display utilities (e.g. `object-cover`) stay wrapper-only.
- Why partition (not blanket forward): wrapper-only utilities like `object-cover` are meant for the wrapper's child layout; copying every class to the inner `<img>` would re-introduce styling regressions. The partition is narrow and the regex covers exactly Tailwind's `display:` utility set.

## Screenshots

N/A — not UI. The fix is a CSS-class plumbing change with no visual diff in either theme; the existing visual contract (off-theme variant hidden, on-theme visible, View Transitions crossfade unchanged) is preserved by definition because the wrapper's display tokens still apply.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (37 pre-existing warnings unchanged)
- [x] `npx vitest run` — 219/219 pass (216 before + 3 new tests covering propagation, layout-only filtering, and `hidden dark:block` variant)
- [ ] CI E2E Shard 4/4 — `theme-aware-hero.spec.ts` (lines 60, 87, 147) should turn green; this is the regression-of-record from issue #144
- [ ] No new failures elsewhere in E2E shards

## Plan reference

Closes #144 — out of plan; clearing the standing E2E flake on `main` so we can promote E2E shards to required status checks afterward.