### PR TITLE
feat(schema): pattern Article schema + hub child breadcrumb (ADP-1C)

### DIFF
--- a/src/lib/schema/agentic-patterns.ts
+++ b/src/lib/schema/agentic-patterns.ts
@@ -1,0 +1,122 @@
+// src/lib/schema/agentic-patterns.ts
+//
+// Schema generators for the agentic design patterns satellite pages.
+//
+// Two concerns intentionally separate from citation.ts:
+//   - The Reference type here has an explicit 'type' discriminator field,
+//     so mapping branches on that (not on field presence as citation.ts does).
+//   - This module is for Article schema; citation.ts is for BlogPosting schema.
+//     The two mappers serve different data shapes and should not be unified.
+//
+// Usage:
+//   import { generatePatternArticleSchema } from '@/lib/schema';
+//   <SchemaScript schema={generatePatternArticleSchema(pattern, baseUrl)} />
+
+import { SITE_CONFIG, AUTHOR_CONFIG } from "./config";
+import type { ArticleSchema, PatternCitationSchema } from "./types";
+import type { Pattern, Reference } from "@/data/agentic-design-patterns/types";
+
+// ---------------------------------------------------------------------------
+// Reference → citation mapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a single agentic design pattern Reference to a PatternCitationSchema.
+ *
+ * Type mapping (per issue #155 rule 1):
+ *   'paper'                    → ScholarlyArticle (with DOI identifier when present)
+ *   'book'                     → Book
+ *   'spec' | 'docs' | 'essay'  → WebPage
+ *
+ * Fields intentionally omitted from JSON-LD:
+ *   - Reference.note   — UI-only annotation; schema.org has no clean equivalent
+ *                        for a 1-line contextual note at the citation level.
+ *   - Reference.pages  — book chapter page range; schema.org Book does not have
+ *                        a top-level pagination slot. Skipped for v1; a future
+ *                        enhancement could model this as a Chapter sub-entity.
+ */
+export function referenceToPatternCitation(ref: Reference): PatternCitationSchema {
+  const base: PatternCitationSchema = {
+    "@type": mapRefTypeToSchemaType(ref.type),
+    name: ref.title,
+    url: ref.url,
+  };
+
+  if (ref.authors) {
+    base.author = { "@type": "Person", name: ref.authors };
+  }
+
+  if (ref.year) {
+    base.datePublished = String(ref.year);
+  }
+
+  // DOI identifier — only for ScholarlyArticle ('paper' type).
+  // propertyID must be uppercase 'DOI' per schema.org PropertyValue convention.
+  if (ref.type === "paper" && ref.doi) {
+    base.identifier = {
+      "@type": "PropertyValue",
+      propertyID: "DOI",
+      value: ref.doi,
+    };
+  }
+
+  return base;
+}
+
+function mapRefTypeToSchemaType(
+  type: Reference["type"]
+): PatternCitationSchema["@type"] {
+  switch (type) {
+    case "paper":
+      return "ScholarlyArticle";
+    case "book":
+      return "Book";
+    case "spec":
+    case "docs":
+    case "essay":
+      return "WebPage";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pattern → Article schema
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a schema.org Article JSON-LD object for an agentic design pattern
+ * satellite page.
+ *
+ * @param pattern  - The full Pattern object from the data catalog.
+ * @param baseUrl  - The base URL of the site (e.g. SITE_CONFIG.url). Callers
+ *                   should pass SITE_CONFIG.url; the parameter is accepted for
+ *                   testability without mocking the module.
+ *
+ * @id uses suffix #pattern-article (not #article) to avoid collision with the
+ * BlogPosting @id pattern used on /posts/* pages.
+ *
+ * author uses an @id reference to the canonical Person entity — not the full
+ * AUTHOR_CONFIG object — to enable entity de-duplication across pages when
+ * Google's parser resolves the graph.
+ */
+export function generatePatternArticleSchema(
+  pattern: Pattern,
+  baseUrl: string = SITE_CONFIG.url
+): ArticleSchema {
+  const url = `${baseUrl}/agentic-design-patterns/${pattern.slug}`;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "@id": `${url}#pattern-article`,
+    headline: pattern.name,
+    description: pattern.oneLineSummary,
+    url,
+    dateModified: pattern.dateModified,
+    // author is an @id reference — not the full AUTHOR_CONFIG object.
+    // This enables entity de-duplication: the parser resolves the reference
+    // back to the Person node emitted by generatePersonSchema() on the same
+    // or any other page.
+    author: { "@id": AUTHOR_CONFIG.id },
+    citation: pattern.references.map(referenceToPatternCitation),
+  };
+}

--- a/src/lib/schema/agentic-patterns.ts
+++ b/src/lib/schema/agentic-patterns.ts
@@ -34,6 +34,11 @@ import type { Pattern, Reference } from "@/data/agentic-design-patterns/types";
  *   - Reference.pages  — book chapter page range; schema.org Book does not have
  *                        a top-level pagination slot. Skipped for v1; a future
  *                        enhancement could model this as a Chapter sub-entity.
+ *   - Reference.venue  — display-only ("ICML 2024", "arXiv preprint"); could be
+ *                        modeled as publishedIn / sourceOrganization but values
+ *                        are free-form strings not entity URIs. Skipped for v1.
+ *   - Reference.accessedAt — useful for docs citations but no canonical
+ *                            schema.org slot at the citation level. Skipped for v1.
  */
 export function referenceToPatternCitation(ref: Reference): PatternCitationSchema {
   const base: PatternCitationSchema = {

--- a/src/lib/schema/breadcrumb.ts
+++ b/src/lib/schema/breadcrumb.ts
@@ -2,17 +2,19 @@
 //
 // Generates BreadcrumbList schema for navigation breadcrumbs.
 //
-// Two variants:
-//   generateBreadcrumbSchema(slug, title) — for blog posts: Home > Posts > [Post Title]
-//   generatePageBreadcrumbSchema(path, title) — for static pages: Home > [Page Title]
+// Three variants:
+//   generateBreadcrumbSchema(slug, title)         — blog posts: Home > Posts > [Post Title]
+//   generatePageBreadcrumbSchema(path, title)     — static pages: Home > [Page Title]
+//   generateHubChildBreadcrumb(slug, name)        — pattern satellites: Home > Agentic Design Patterns > [Pattern Name]
 //
 // BreadcrumbList does not have an @id because breadcrumbs are positional
 // navigation metadata, not entities that other schemas reference back to.
 //
 // Usage:
-//   import { generateBreadcrumbSchema, generatePageBreadcrumbSchema } from '@/lib/schema';
+//   import { generateBreadcrumbSchema, generatePageBreadcrumbSchema, generateHubChildBreadcrumb } from '@/lib/schema';
 //   <SchemaScript schema={generateBreadcrumbSchema(post.slug, post.title)} />
 //   <SchemaScript schema={generatePageBreadcrumbSchema("about", "About")} />
+//   <SchemaScript schema={generateHubChildBreadcrumb(pattern.slug, pattern.name)} />
 
 import { SITE_CONFIG } from "./config";
 import type { BreadcrumbListSchema } from "./types";
@@ -66,6 +68,45 @@ export function generatePageBreadcrumbSchema(
         position: 2,
         name: title,
         item: `${SITE_CONFIG.url}/${path}`,
+      },
+    ],
+  };
+}
+
+/**
+ * Generates a 3-level BreadcrumbList for agentic design pattern satellite pages.
+ * Breadcrumb path: Home > Agentic Design Patterns > [Pattern Name]
+ *
+ * Parameter order: slug first, then name — matches callsite in issue #157.
+ *
+ * @param slug  - The pattern's kebab-case slug (e.g. "prompt-chaining")
+ * @param name  - The pattern's display name (e.g. "Prompt Chaining")
+ */
+export function generateHubChildBreadcrumb(
+  slug: string,
+  name: string
+): BreadcrumbListSchema {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: SITE_CONFIG.url,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Agentic Design Patterns",
+        item: `${SITE_CONFIG.url}/agentic-design-patterns`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name,
+        item: `${SITE_CONFIG.url}/agentic-design-patterns/${slug}`,
       },
     ],
   };

--- a/src/lib/schema/index.ts
+++ b/src/lib/schema/index.ts
@@ -9,9 +9,10 @@
 export { generateWebSiteSchema } from "./website";
 export { generatePersonSchema } from "./person";
 export { generateBlogPostingSchema } from "./blog-posting";
-export { generateBreadcrumbSchema, generatePageBreadcrumbSchema } from "./breadcrumb";
+export { generateBreadcrumbSchema, generatePageBreadcrumbSchema, generateHubChildBreadcrumb } from "./breadcrumb";
 export { generateCollectionPageSchema } from "./collection-page";
 export { mapReferenceToCitation } from "./citation";
+export { generatePatternArticleSchema, referenceToPatternCitation } from "./agentic-patterns";
 
 // Type exports — available when page components need to type schema variables
 export type {
@@ -23,4 +24,6 @@ export type {
   CollectionPageSchema,
   CitationSchema,
   ImageObjectSchema,
+  ArticleSchema,
+  PatternCitationSchema,
 } from "./types";

--- a/src/lib/schema/types.ts
+++ b/src/lib/schema/types.ts
@@ -132,3 +132,47 @@ export interface CollectionPageSchema extends SchemaBase {
   url: string;
   isPartOf: { "@id": string };
 }
+
+// -------------------------------------------------------------------------
+// PatternCitationSchema — embedded citation shape for agentic pattern pages.
+// Diverges from CitationSchema intentionally: the Reference type in
+// agentic-design-patterns/types.ts is structured (explicit 'type' field)
+// so we branch on that, not on field presence.
+//
+// Schema.org types used:
+//   ScholarlyArticle — research papers (with DOI identifier)
+//   Book             — book references
+//   WebPage          — specs, docs, essays (online references without a
+//                      canonical academic or book identity)
+// -------------------------------------------------------------------------
+
+export interface PatternCitationSchema {
+  "@type": "ScholarlyArticle" | "Book" | "WebPage";
+  name: string;
+  url: string;
+  author?: { "@type": "Person"; name: string };
+  datePublished?: string;
+  identifier?: {
+    "@type": "PropertyValue";
+    propertyID: "DOI";
+    value: string;
+  };
+}
+
+// -------------------------------------------------------------------------
+// ArticleSchema — top-level schema for agentic pattern satellite pages.
+// Uses @id suffix #pattern-article to avoid future collision with the
+// BlogPosting @id pattern (${url}#article).
+// author is an @id reference to the canonical Person entity (not inline).
+// -------------------------------------------------------------------------
+
+export interface ArticleSchema extends SchemaBase {
+  "@type": "Article";
+  "@id": string;
+  headline: string;
+  description?: string;
+  url: string;
+  dateModified?: string;
+  author: { "@id": string };
+  citation?: PatternCitationSchema[];
+}

--- a/tests/unit/lib/schema/agentic-patterns.test.ts
+++ b/tests/unit/lib/schema/agentic-patterns.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 // Mock the schema config module to avoid the NEXT_PUBLIC_SERVER_URL env check
 // that fires at import time in src/lib/site-url.ts.

--- a/tests/unit/lib/schema/agentic-patterns.test.ts
+++ b/tests/unit/lib/schema/agentic-patterns.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+
+// Mock the schema config module to avoid the NEXT_PUBLIC_SERVER_URL env check
+// that fires at import time in src/lib/site-url.ts.
+vi.mock("@/lib/schema/config", () => ({
+  SITE_CONFIG: {
+    url: "https://detached-node.com",
+    name: "detached-node",
+    description: "Test description",
+    websiteId: "https://detached-node.com/#website",
+  },
+  AUTHOR_CONFIG: {
+    name: "detached-node",
+    url: "https://detached-node.com/about",
+    id: "https://detached-node.com/#author",
+    sameAs: ["https://github.com/detached-node"],
+    description: "Writing on agentic AI workflows.",
+  },
+}));
+
+import {
+  generatePatternArticleSchema,
+  referenceToPatternCitation,
+} from "@/lib/schema/agentic-patterns";
+import { SITE_CONFIG, AUTHOR_CONFIG } from "@/lib/schema/config";
+import type { Pattern, Reference } from "@/data/agentic-design-patterns/types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const BASE_URL = "https://test.example.com";
+
+/** Minimal valid Reference for each ReferenceType */
+const paperRef: Reference = {
+  title: "ReAct: Synergizing Reasoning and Acting in Language Models",
+  url: "https://arxiv.org/abs/2210.03629",
+  authors: "Shinn et al.",
+  year: 2022,
+  type: "paper",
+  doi: "10.48550/arXiv.2210.03629",
+};
+
+const paperRefNoDoi: Reference = {
+  title: "Paper without DOI",
+  url: "https://example.com/paper",
+  authors: "Anonymous",
+  year: 2021,
+  type: "paper",
+};
+
+const bookRef: Reference = {
+  title: "Deep Learning",
+  url: "https://www.deeplearningbook.org/",
+  authors: "Goodfellow et al.",
+  year: 2016,
+  type: "book",
+  pages: [10, 50],
+};
+
+const specRef: Reference = {
+  title: "OpenAPI Specification",
+  url: "https://spec.openapis.org/oas/v3.1.0",
+  authors: "OpenAPI Initiative",
+  year: 2021,
+  type: "spec",
+};
+
+const docsRef: Reference = {
+  title: "LangChain Documentation",
+  url: "https://docs.langchain.com/",
+  authors: "LangChain",
+  year: 2023,
+  type: "docs",
+  accessedAt: "2024-01-01",
+};
+
+const essayRef: Reference = {
+  title: "Building Effective Agents",
+  url: "https://anthropic.com/research/building-effective-agents",
+  authors: "Anthropic",
+  year: 2024,
+  type: "essay",
+  note: "Foundational framing for the pattern taxonomy",
+};
+
+/** 5-reference fixture — one of each ReferenceType */
+const fiveRefs: Reference[] = [paperRef, bookRef, specRef, docsRef, essayRef];
+
+const minimalPattern: Pattern = {
+  slug: "test-pattern",
+  name: "Test Pattern",
+  layerId: "topology",
+  topologySubtier: "single-agent",
+  oneLineSummary: "A minimal test pattern for schema generation.",
+  bodySummary: ["First paragraph.", "Second paragraph."],
+  mermaidSource: "graph TD\n  A --> B",
+  mermaidAlt: "A flows to B",
+  whenToUse: ["When testing."],
+  whenNotToUse: ["When not testing."],
+  realWorldExamples: [{ text: "Example", sourceUrl: "https://example.com" }],
+  implementationSketch: "// sketch",
+  sdkAvailability: "no-sdk",
+  relatedSlugs: [],
+  frameworks: [],
+  references: fiveRefs,
+  addedAt: "2026-01-01",
+  dateModified: "2026-05-03",
+};
+
+// ---------------------------------------------------------------------------
+// referenceToPatternCitation
+// ---------------------------------------------------------------------------
+
+describe("referenceToPatternCitation", () => {
+  describe("paper type", () => {
+    it("maps to ScholarlyArticle", () => {
+      const citation = referenceToPatternCitation(paperRef);
+      expect(citation["@type"]).toBe("ScholarlyArticle");
+    });
+
+    it("includes identifier with uppercase DOI propertyID when doi is present", () => {
+      const citation = referenceToPatternCitation(paperRef);
+      expect(citation.identifier).toBeDefined();
+      expect(citation.identifier!["@type"]).toBe("PropertyValue");
+      expect(citation.identifier!.propertyID).toBe("DOI"); // uppercase — schema.org convention
+      expect(citation.identifier!.value).toBe(paperRef.doi);
+    });
+
+    it("omits identifier when doi is absent", () => {
+      const citation = referenceToPatternCitation(paperRefNoDoi);
+      expect(citation.identifier).toBeUndefined();
+    });
+
+    it("includes name, url, author, datePublished", () => {
+      const citation = referenceToPatternCitation(paperRef);
+      expect(citation.name).toBe(paperRef.title);
+      expect(citation.url).toBe(paperRef.url);
+      expect(citation.author).toEqual({ "@type": "Person", name: paperRef.authors });
+      expect(citation.datePublished).toBe(String(paperRef.year));
+    });
+  });
+
+  describe("book type", () => {
+    it("maps to Book", () => {
+      const citation = referenceToPatternCitation(bookRef);
+      expect(citation["@type"]).toBe("Book");
+    });
+
+    it("does not include DOI identifier", () => {
+      const citation = referenceToPatternCitation(bookRef);
+      expect(citation.identifier).toBeUndefined();
+    });
+
+    it("includes name, url, author, datePublished", () => {
+      const citation = referenceToPatternCitation(bookRef);
+      expect(citation.name).toBe(bookRef.title);
+      expect(citation.url).toBe(bookRef.url);
+      expect(citation.author).toEqual({ "@type": "Person", name: bookRef.authors });
+      expect(citation.datePublished).toBe(String(bookRef.year));
+    });
+
+    it("does NOT surface pages field (UI-only / no clean Book.pagination slot)", () => {
+      const citation = referenceToPatternCitation(bookRef);
+      // pages is intentionally omitted from JSON-LD output
+      expect("pages" in citation).toBe(false);
+    });
+  });
+
+  describe("spec type", () => {
+    it("maps to WebPage", () => {
+      const citation = referenceToPatternCitation(specRef);
+      expect(citation["@type"]).toBe("WebPage");
+    });
+
+    it("does not include identifier", () => {
+      const citation = referenceToPatternCitation(specRef);
+      expect(citation.identifier).toBeUndefined();
+    });
+  });
+
+  describe("docs type", () => {
+    it("maps to WebPage", () => {
+      const citation = referenceToPatternCitation(docsRef);
+      expect(citation["@type"]).toBe("WebPage");
+    });
+  });
+
+  describe("essay type", () => {
+    it("maps to WebPage", () => {
+      const citation = referenceToPatternCitation(essayRef);
+      expect(citation["@type"]).toBe("WebPage");
+    });
+
+    it("does NOT surface note field (UI-only — schema.org has no citation-level note equivalent)", () => {
+      const citation = referenceToPatternCitation(essayRef);
+      expect("note" in citation).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generatePatternArticleSchema
+// ---------------------------------------------------------------------------
+
+describe("generatePatternArticleSchema", () => {
+  it("emits @context and @type Article", () => {
+    const schema = generatePatternArticleSchema(minimalPattern, BASE_URL);
+    expect(schema["@context"]).toBe("https://schema.org");
+    expect(schema["@type"]).toBe("Article");
+  });
+
+  it("uses #pattern-article suffix for @id (not #article)", () => {
+    const schema = generatePatternArticleSchema(minimalPattern, BASE_URL);
+    expect(schema["@id"]).toBe(
+      `${BASE_URL}/agentic-design-patterns/${minimalPattern.slug}#pattern-article`
+    );
+    expect(schema["@id"]).not.toMatch(/#article$/);
+  });
+
+  it("sets headline from pattern.name", () => {
+    const schema = generatePatternArticleSchema(minimalPattern, BASE_URL);
+    expect(schema.headline).toBe(minimalPattern.name);
+  });
+
+  it("sets description from pattern.oneLineSummary", () => {
+    const schema = generatePatternArticleSchema(minimalPattern, BASE_URL);
+    expect(schema.description).toBe(minimalPattern.oneLineSummary);
+  });
+
+  it("sets url correctly", () => {
+    const schema = generatePatternArticleSchema(minimalPattern, BASE_URL);
+    expect(schema.url).toBe(
+      `${BASE_URL}/agentic-design-patterns/${minimalPattern.slug}`
+    );
+  });
+
+  it("sets dateModified from pattern.dateModified", () => {
+    const schema = generatePatternArticleSchema(minimalPattern, BASE_URL);
+    expect(schema.dateModified).toBe(minimalPattern.dateModified);
+  });
+
+  it("author is an @id reference to AUTHOR_CONFIG.id — NOT the full object", () => {
+    const schema = generatePatternArticleSchema(minimalPattern, BASE_URL);
+    expect(schema.author).toEqual({ "@id": AUTHOR_CONFIG.id });
+    // Must NOT embed full author object
+    expect("name" in schema.author).toBe(false);
+    expect("url" in schema.author).toBe(false);
+  });
+
+  it("citation array length matches references length (5-reference fixture)", () => {
+    const schema = generatePatternArticleSchema(minimalPattern, BASE_URL);
+    expect(schema.citation).toHaveLength(fiveRefs.length); // 5
+  });
+
+  it("citation array covers all 5 ReferenceTypes in correct schema.org types", () => {
+    const schema = generatePatternArticleSchema(minimalPattern, BASE_URL);
+    const citations = schema.citation!;
+
+    const types = citations.map((c) => c["@type"]);
+    expect(types[0]).toBe("ScholarlyArticle"); // paper
+    expect(types[1]).toBe("Book");             // book
+    expect(types[2]).toBe("WebPage");          // spec
+    expect(types[3]).toBe("WebPage");          // docs
+    expect(types[4]).toBe("WebPage");          // essay
+  });
+
+  it("uses SITE_CONFIG.url as default baseUrl when not provided", () => {
+    const schema = generatePatternArticleSchema(minimalPattern);
+    expect(schema.url).toContain(SITE_CONFIG.url);
+    expect(schema["@id"]).toContain(SITE_CONFIG.url);
+  });
+});

--- a/tests/unit/lib/schema/breadcrumb-hub.test.ts
+++ b/tests/unit/lib/schema/breadcrumb-hub.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock the schema config module to avoid the NEXT_PUBLIC_SERVER_URL env check
+// that fires at import time in src/lib/site-url.ts.
+vi.mock("@/lib/schema/config", () => ({
+  SITE_CONFIG: {
+    url: "https://detached-node.com",
+    name: "detached-node",
+    description: "Test description",
+    websiteId: "https://detached-node.com/#website",
+  },
+  AUTHOR_CONFIG: {
+    name: "detached-node",
+    url: "https://detached-node.com/about",
+    id: "https://detached-node.com/#author",
+    sameAs: ["https://github.com/detached-node"],
+    description: "Writing on agentic AI workflows.",
+  },
+}));
+
+import { generateHubChildBreadcrumb } from "@/lib/schema/breadcrumb";
+import { SITE_CONFIG } from "@/lib/schema/config";
+
+// ---------------------------------------------------------------------------
+// generateHubChildBreadcrumb
+// ---------------------------------------------------------------------------
+
+describe("generateHubChildBreadcrumb", () => {
+  const slug = "prompt-chaining";
+  const name = "Prompt Chaining";
+
+  it("returns @context and @type BreadcrumbList", () => {
+    const schema = generateHubChildBreadcrumb(slug, name);
+    expect(schema["@context"]).toBe("https://schema.org");
+    expect(schema["@type"]).toBe("BreadcrumbList");
+  });
+
+  it("returns exactly 3 itemListElement entries", () => {
+    const schema = generateHubChildBreadcrumb(slug, name);
+    expect(schema.itemListElement).toHaveLength(3);
+  });
+
+  it("first item is Home at SITE_CONFIG.url", () => {
+    const schema = generateHubChildBreadcrumb(slug, name);
+    const item = schema.itemListElement[0];
+    expect(item["@type"]).toBe("ListItem");
+    expect(item.position).toBe(1);
+    expect(item.name).toBe("Home");
+    expect(item.item).toBe(SITE_CONFIG.url);
+  });
+
+  it("second item is the hub (Agentic Design Patterns)", () => {
+    const schema = generateHubChildBreadcrumb(slug, name);
+    const item = schema.itemListElement[1];
+    expect(item["@type"]).toBe("ListItem");
+    expect(item.position).toBe(2);
+    expect(item.name).toBe("Agentic Design Patterns");
+    expect(item.item).toBe(`${SITE_CONFIG.url}/agentic-design-patterns`);
+  });
+
+  it("third item is the pattern satellite page", () => {
+    const schema = generateHubChildBreadcrumb(slug, name);
+    const item = schema.itemListElement[2];
+    expect(item["@type"]).toBe("ListItem");
+    expect(item.position).toBe(3);
+    expect(item.name).toBe(name);
+    expect(item.item).toBe(
+      `${SITE_CONFIG.url}/agentic-design-patterns/${slug}`
+    );
+  });
+
+  it("positions are 1-indexed and sequential", () => {
+    const schema = generateHubChildBreadcrumb(slug, name);
+    const positions = schema.itemListElement.map((i) => i.position);
+    expect(positions).toEqual([1, 2, 3]);
+  });
+
+  it("uses the passed slug in the satellite URL (not hardcoded)", () => {
+    const schema = generateHubChildBreadcrumb("multi-agent-debate", "Multi-Agent Debate");
+    expect(schema.itemListElement[2].item).toContain("multi-agent-debate");
+    expect(schema.itemListElement[2].name).toBe("Multi-Agent Debate");
+  });
+
+  it("parameter order is (slug, name) — slug drives URL, name drives label", () => {
+    const schema = generateHubChildBreadcrumb("my-slug", "My Name");
+    const leaf = schema.itemListElement[2];
+    expect(leaf.item).toContain("my-slug");
+    expect(leaf.name).toBe("My Name");
+  });
+});


### PR DESCRIPTION
## 1. Diagrams

```mermaid
graph TD
  subgraph "src/lib/schema/"
    AP["agentic-patterns.ts<br/>(new)"]
    BC["breadcrumb.ts<br/>(appended)"]
    IDX["index.ts<br/>(re-exports)"]
    TYP["types.ts<br/>(new interfaces)"]
  end

  subgraph "Input"
    P["Pattern (from T1 data scaffold)"]
    REF["Reference[]"]
  end

  subgraph "Output"
    AS["ArticleSchema<br/>@type: Article<br/>@id: …#pattern-article"]
    CIT["PatternCitationSchema[]<br/>paper→ScholarlyArticle+DOI<br/>book→Book<br/>spec/docs/essay→WebPage"]
    BL["BreadcrumbListSchema<br/>Home › ADP hub › Pattern"]
  end

  P --> AP
  REF --> AP
  AP -->|generatePatternArticleSchema| AS
  AP -->|referenceToPatternCitation| CIT
  AS --> CIT
  BC -->|generateHubChildBreadcrumb| BL
  AP --> IDX
  BC --> IDX
  TYP --> AP
  TYP --> BC
```

```mermaid
flowchart LR
  ref_type{"Reference.type"}
  ref_type -->|paper| SA["ScholarlyArticle<br/>+ identifier.propertyID: 'DOI'<br/>(when doi present)"]
  ref_type -->|book| B["Book<br/>(pages skipped — no<br/>clean Book.pagination slot)"]
  ref_type -->|spec / docs / essay| WP["WebPage"]
  note["Reference.note<br/>omitted — UI-only,<br/>no schema.org equivalent"]
```

## 2. Summary

- **Why:** ADP satellite pages need an `Article` JSON-LD with a typed `citation` array mapped from `Pattern.references[]`, and a 3-level breadcrumb (Home › Agentic Design Patterns › Pattern); the existing schema library only covers blog posts and static pages.
- **`@id` is `#pattern-article`** (not `#article`) to avoid future collision with the `BlogPosting` `@id` pattern on `/posts/*` pages.
- **`author` is an `{ "@id": AUTHOR_CONFIG.id }` reference** — not the full object — enabling entity de-duplication when Google resolves the graph across pages.

## 3. Screenshots

N/A — not UI. This PR adds schema-generation utilities and their tests; no user-visible component or page is touched.

## 4. Test plan

- [x] `pnpm typecheck` — clean (zero errors)
- [x] `pnpm test:unit -- tests/unit/lib/schema/` — 316 tests pass (285 pre-existing + 31 new)
- [x] 5-reference fixture exercises all 5 `ReferenceType` values (`paper`, `book`, `spec`, `docs`, `essay`) and verifies citation array length matches references length
- [x] DOI presence/absence cases both tested (`paper` with and without `doi`)
- [x] `@id` suffix verified as `#pattern-article` (not `#article`)
- [x] `author` shape verified as `{ "@id": … }` — name/url absence asserted
- [x] Breadcrumb: 3 items, positions 1-2-3, second item is hub URL, third is pattern satellite URL
- [x] Parameter order `(slug, name)` verified — slug drives URL, name drives label

## 5. Plan reference

Part of Plan 2, Task ADP-1C. Closes #155. See `docs/plans/` (implementation plan on `feat/agentic-design-patterns`).