### PR TITLE
feat(adp): T2/#156 components + pattern-search

### DIFF
--- a/src/components/agentic-patterns/HubGrid.tsx
+++ b/src/components/agentic-patterns/HubGrid.tsx
@@ -1,0 +1,107 @@
+// ---------------------------------------------------------------------------
+// HubGrid
+// ---------------------------------------------------------------------------
+// Renders the 5-layer pattern hub. Server component (no client JS).
+//
+// Layer titles use <h2>. Topology gets sub-tier dividers ("Single-agent (N)"
+// / "Multi-agent (N)") rendered as <h3> — counts are derived dynamically from
+// getTopologyPatterns(...) so they stay correct when patterns are added or
+// retired (NEVER hardcoded "10" / "3").
+//
+// PatternCard headingLevel is set by context:
+// - Under a flat layer section (parent <h2>): card heading is <h3>
+// - Under a topology sub-tier (parent <h3>): card heading is <h4>
+//
+// HubGrid is intentionally pure server: filtering coordination lives in the
+// client wrapper introduced by issue #157 (HubFilterableContent), which
+// composes HubSearchBar + a filter-aware variant of this grid.
+
+import { LAYERS } from "@/data/agentic-design-patterns/layers";
+import { getPatternsByLayer, getTopologyPatterns } from "@/data/agentic-design-patterns/index";
+import type { Layer, Pattern } from "@/data/agentic-design-patterns/types";
+import { PatternCard } from "./PatternCard";
+
+function LayerSectionTitle({ layer }: { layer: Layer }) {
+  return (
+    <header className="flex flex-col gap-1">
+      <h2 className="font-mono text-2xl font-semibold tracking-tight text-text-primary">
+        Layer {layer.number} — {layer.title}
+      </h2>
+      <p className="text-sm text-text-tertiary italic">{layer.question}</p>
+      <p className="max-w-prose text-base leading-6 text-text-secondary [text-wrap:pretty]">
+        {layer.description}
+      </p>
+    </header>
+  );
+}
+
+interface CardGridProps {
+  patterns: Pattern[];
+  headingLevel: 3 | 4;
+}
+
+function CardGrid({ patterns, headingLevel }: CardGridProps) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {patterns.map((p) => (
+        <PatternCard key={p.slug} pattern={p} headingLevel={headingLevel} />
+      ))}
+    </div>
+  );
+}
+
+interface SubTierProps {
+  title: string;
+  patterns: Pattern[];
+}
+
+function SubTier({ title, patterns }: SubTierProps) {
+  // Dynamic count — NEVER hardcoded. Pulled from the live patterns array.
+  const count = patterns.length;
+  return (
+    <div className="flex flex-col gap-4">
+      <h3 className="font-mono text-lg font-semibold tracking-tight text-text-secondary">
+        {title} <span className="text-text-tertiary font-normal">({count})</span>
+      </h3>
+      {/* Cards under sub-tier are <h4> because parent heading is <h3>. */}
+      <CardGrid patterns={patterns} headingLevel={4} />
+    </div>
+  );
+}
+
+function TopologyLayer({ layer }: { layer: Layer }) {
+  const singleAgent = getTopologyPatterns("single-agent");
+  const multiAgent = getTopologyPatterns("multi-agent");
+  return (
+    <section className="flex flex-col gap-8">
+      <LayerSectionTitle layer={layer} />
+      <SubTier title="Single-agent" patterns={singleAgent} />
+      <SubTier title="Multi-agent" patterns={multiAgent} />
+    </section>
+  );
+}
+
+function FlatLayer({ layer }: { layer: Layer }) {
+  const patterns = getPatternsByLayer(layer.id);
+  return (
+    <section className="flex flex-col gap-6">
+      <LayerSectionTitle layer={layer} />
+      {/* Cards under a flat layer are <h3> because parent heading is <h2>. */}
+      <CardGrid patterns={patterns} headingLevel={3} />
+    </section>
+  );
+}
+
+export function HubGrid() {
+  return (
+    <div className="flex flex-col gap-16">
+      {LAYERS.map((layer) =>
+        layer.id === "topology" ? (
+          <TopologyLayer key={layer.id} layer={layer} />
+        ) : (
+          <FlatLayer key={layer.id} layer={layer} />
+        ),
+      )}
+    </div>
+  );
+}

--- a/src/components/agentic-patterns/HubHero.tsx
+++ b/src/components/agentic-patterns/HubHero.tsx
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------------------
+// HubHero
+// ---------------------------------------------------------------------------
+// Hub-page title band. Server component. Emits the hub's single <h1>.
+//
+// Pattern count is derived dynamically from getCatalogPatternCount() — never
+// hardcoded. When patterns are added/retired, the eyebrow line updates with
+// the next deploy.
+//
+// Composes LivingCatalogBadge for the "Updated [month YYYY]" pill so the
+// reader gets an immediate signal that this is a maintained reference.
+
+import { getCatalogDateModified, getCatalogPatternCount } from "@/data/agentic-design-patterns/index";
+import { LivingCatalogBadge } from "./LivingCatalogBadge";
+
+export function HubHero() {
+  const count = getCatalogPatternCount();
+  const lastUpdated = getCatalogDateModified();
+
+  return (
+    <header className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <LivingCatalogBadge isoDate={lastUpdated} />
+        <span className="font-mono text-xs uppercase tracking-[0.1em] text-text-tertiary">
+          Reference
+        </span>
+      </div>
+      <h1 className="font-mono text-4xl font-semibold tracking-tight text-text-primary [text-wrap:balance] sm:text-5xl">
+        Agentic Design Patterns
+      </h1>
+      <p className="max-w-prose text-lg leading-7 text-text-secondary [text-wrap:pretty]">
+        A field-aware reference covering {count} patterns for building agentic systems —
+        organized by the question each pattern answers, not by the year it was named.
+      </p>
+    </header>
+  );
+}

--- a/src/components/agentic-patterns/HubSearchBar.tsx
+++ b/src/components/agentic-patterns/HubSearchBar.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+// ---------------------------------------------------------------------------
+// HubSearchBar
+// ---------------------------------------------------------------------------
+// The ONLY client component in the agentic-patterns suite.
+//
+// In this issue (#156) HubSearchBar is intentionally SELF-CONTAINED:
+//   - manages its own input state
+//   - handles the `/` keyboard shortcut to focus the input
+//   - debounces query updates and emits an ARIA live region announcement
+//   - DOES NOT have any callback prop (no onResults, onChange, onFilter, ...)
+// Filter-state coordination with the grid lives in the wrapper component
+// introduced by issue #157 (HubFilterableContent). Adding any callback prop
+// here would couple this issue to that one prematurely.
+//
+// React 19 + hydration:
+//   - Initial query state MUST be '' on first render (server === client).
+//   - URL/localStorage hydration goes inside useEffect to avoid SSR
+//     hydration mismatch.
+// useTransition is used for the announcement update — it doesn't require
+// Suspense and lets the typing path stay urgent while the live-region
+// announcement update is non-urgent.
+
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { searchPatterns } from "@/lib/pattern-search";
+import { PATTERNS } from "@/data/agentic-design-patterns/index";
+import { LAYERS } from "@/data/agentic-design-patterns/layers";
+
+const DEBOUNCE_MS = 150;
+
+/**
+ * The `/` shortcut should focus the search input — UNLESS the user is already
+ * typing in another input/textarea/contenteditable element. Otherwise the `/`
+ * keystroke gets swallowed mid-sentence anywhere on the page, which is a
+ * universally hated UX.
+ */
+function shouldHandleSlashShortcut(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return true;
+  if (target.isContentEditable) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return false;
+  return true;
+}
+
+export function HubSearchBar() {
+  // Initial state MUST be empty string on first render. Hydrating from URL or
+  // localStorage happens inside useEffect (see below) so SSR === first client
+  // render and React 19 doesn't warn about a hydration mismatch.
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [, startTransition] = useTransition();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Hydrate from `?q=` if present — runs after first paint to keep SSR happy.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const q = params.get("q");
+    if (q && q !== query) {
+      setQuery(q);
+      setDebouncedQuery(q);
+    }
+    // We intentionally only hydrate once on mount; ignore subsequent renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Debounce the query → debouncedQuery transition. The text input itself
+  // updates synchronously (urgent) so typing feels instant; the result count
+  // (driven by debouncedQuery) follows along after the user pauses.
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      startTransition(() => {
+        setDebouncedQuery(query);
+      });
+    }, DEBOUNCE_MS);
+    return () => window.clearTimeout(handle);
+  }, [query]);
+
+  // Global `/` shortcut — focus the input unless the user is already typing.
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== "/") return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (!shouldHandleSlashShortcut(e.target)) return;
+      e.preventDefault();
+      inputRef.current?.focus();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  // Memoize the LAYERS lookup map so search runs on every keystroke don't
+  // rebuild it. Same for the catalog reference itself.
+  const layerLabels = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const l of LAYERS) {
+      out[l.id] = `Layer ${l.number} — ${l.title}`;
+    }
+    return out;
+  }, []);
+
+  const matchCount = useMemo(() => {
+    if (debouncedQuery.trim().length === 0) return PATTERNS.length;
+    return searchPatterns(PATTERNS, debouncedQuery, layerLabels).length;
+  }, [debouncedQuery, layerLabels]);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => setQuery(e.target.value),
+    [],
+  );
+
+  const announcement = `${matchCount} ${matchCount === 1 ? "pattern" : "patterns"} found`;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label htmlFor="hub-search" className="sr-only">
+        Search patterns
+      </label>
+      <div className="relative">
+        <input
+          ref={inputRef}
+          id="hub-search"
+          type="search"
+          value={query}
+          onChange={handleChange}
+          aria-label="Search patterns"
+          aria-describedby="hub-search-hint"
+          placeholder="Search patterns…"
+          className="w-full rounded-sm border border-border bg-surface px-4 py-2.5 pr-16 font-mono text-base text-text-primary placeholder:text-text-tertiary focus-ring"
+        />
+        <kbd
+          aria-hidden="true"
+          className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 rounded-sm border border-border bg-background px-1.5 py-0.5 font-mono text-xs text-text-tertiary"
+        >
+          /
+        </kbd>
+      </div>
+      <p id="hub-search-hint" className="text-xs text-text-tertiary">
+        Press <kbd className="rounded-sm border border-border bg-surface px-1 font-mono text-[0.65rem]">/</kbd>{" "}
+        to focus. Searches name, alternative names, summary, and layer.
+      </p>
+      {/*
+        ARIA live region — announces the result count to assistive tech.
+        - aria-live="polite" (NOT "assertive") so it doesn't interrupt
+        - aria-atomic so the entire message is read on each update
+        - role="status" pairs with aria-live for broader AT support
+      */}
+      <p
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {announcement}
+      </p>
+    </div>
+  );
+}

--- a/src/components/agentic-patterns/LivingCatalogBadge.tsx
+++ b/src/components/agentic-patterns/LivingCatalogBadge.tsx
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------------
+// LivingCatalogBadge
+// ---------------------------------------------------------------------------
+// Small "Updated [month YYYY]" pill that signals the catalog is a living
+// reference (not a one-shot publication). Used at the top of the hub page.
+//
+// Pure presentation. Accepts an ISO date string (YYYY-MM-DD) and formats it
+// as "Updated [Month YYYY]". Server-safe — no client JS.
+//
+// v1: chip styling duplicated with framework chips and reference type badges
+// (see ReferencesSection / RelatedPatternsRow). Future: extract <Chip>.
+
+interface LivingCatalogBadgeProps {
+  /** ISO date string, e.g. "2026-05-03". */
+  isoDate: string;
+}
+
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+function formatIsoToMonthYear(iso: string): string {
+  // Parse YYYY-MM-DD without timezone drift (Date constructor would shift
+  // by local TZ; we want literal calendar fields from the ISO string).
+  const match = iso.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return iso;
+  const year = match[1];
+  const monthIdx = parseInt(match[2], 10) - 1;
+  const monthName = MONTHS[monthIdx] ?? match[2];
+  return `${monthName} ${year}`;
+}
+
+export function LivingCatalogBadge({ isoDate }: LivingCatalogBadgeProps) {
+  const formatted = formatIsoToMonthYear(isoDate);
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-sm border border-border bg-surface px-2.5 py-1 font-mono text-xs font-medium tracking-[0.05em] text-text-tertiary"
+    >
+      <span aria-hidden="true" className="inline-block h-1.5 w-1.5 rounded-full bg-accent" />
+      <time dateTime={isoDate}>Updated {formatted}</time>
+    </span>
+  );
+}

--- a/src/components/agentic-patterns/PatternBody.tsx
+++ b/src/components/agentic-patterns/PatternBody.tsx
@@ -1,0 +1,225 @@
+// ---------------------------------------------------------------------------
+// PatternBody
+// ---------------------------------------------------------------------------
+// Composes the 8 satellite-page content slots for a pattern. Server component.
+//
+// Slots (each conditionally rendered — empty arrays / missing fields are
+// suppressed so the satellite never shows an empty header):
+//   1. Summary       (bodySummary paragraphs)
+//   2. Diagram       (mermaidSource via <MermaidDiagram />)
+//   3. When to use   (whenToUse bullets)
+//   4. When NOT to   (whenNotToUse bullets)
+//   5. Real-world    (realWorldExamples — text + sourceUrl)
+//   6. Reader gotcha (readerGotcha — only present sometimes)
+//   7. Sketch        (implementationSketch — fenced code)
+//   8. Frameworks    (frameworks chips + SDK availability badge)
+//
+// Slot headings are <h2>; sub-headings inside a slot are <h3>.
+//
+// Pseudocode banner appears only when sdkAvailability is 'python-only' or
+// 'no-sdk' — readers landing on a pattern with no first-party TS SDK get an
+// upfront callout that the sketch is illustrative.
+//
+// Server/client boundary: MermaidDiagram is 'use client'. We pass ONLY the
+// `{ source: string }` prop — no functions, no closures, no JSX with
+// server-only state. Adding any non-serializable prop fails the Next 16 build
+// with "functions cannot be passed to client components".
+
+import type { Framework, Pattern, SdkAvailability } from "@/data/agentic-design-patterns/types";
+import { MermaidDiagram } from "@/components/MermaidDiagram";
+
+interface PatternBodyProps {
+  pattern: Pattern;
+}
+
+const FRAMEWORK_LABELS: Record<Framework, string> = {
+  langchain: "LangChain",
+  langgraph: "LangGraph",
+  "crew-ai": "CrewAI",
+  "google-adk": "Google ADK",
+  autogen: "AutoGen",
+  "vercel-ai-sdk": "Vercel AI SDK",
+  "pydantic-ai": "Pydantic AI",
+  "openai-agents": "OpenAI Agents",
+  mastra: "Mastra",
+  smolagents: "smolagents",
+};
+
+const SDK_LABELS: Record<SdkAvailability, string> = {
+  "first-party-ts": "First-party TS SDK",
+  "community-ts": "Community TS SDK",
+  "python-only": "Python only",
+  "no-sdk": "No SDK",
+};
+
+const PSEUDOCODE_BANNER_SET: ReadonlySet<SdkAvailability> = new Set([
+  "python-only",
+  "no-sdk",
+]);
+
+function SlotHeading({ id, children }: { id: string; children: React.ReactNode }) {
+  return (
+    <h2
+      id={id}
+      className="font-mono text-xl font-semibold tracking-tight text-text-primary"
+    >
+      {children}
+    </h2>
+  );
+}
+
+export function PatternBody({ pattern }: PatternBodyProps) {
+  const showPseudocodeBanner = PSEUDOCODE_BANNER_SET.has(pattern.sdkAvailability);
+
+  return (
+    <div className="flex flex-col gap-12">
+      {/* 1. Summary */}
+      {pattern.bodySummary.length > 0 && (
+        <section aria-labelledby="summary-heading">
+          <SlotHeading id="summary-heading">Summary</SlotHeading>
+          <div className="mt-4 flex flex-col gap-4">
+            {pattern.bodySummary.map((para, idx) => (
+              <p
+                key={idx}
+                className="max-w-prose text-base leading-7 text-text-secondary [text-wrap:pretty]"
+              >
+                {para}
+              </p>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* 2. Diagram */}
+      {pattern.mermaidSource && (
+        <section aria-labelledby="diagram-heading">
+          <SlotHeading id="diagram-heading">Diagram</SlotHeading>
+          <figure className="mt-4">
+            {/* IMPORTANT: only `{ source: string }` is passed across the
+                server/client boundary. No functions or closures. */}
+            <MermaidDiagram source={pattern.mermaidSource} />
+            {pattern.mermaidAlt && (
+              <figcaption className="mt-2 text-sm text-text-tertiary italic">
+                {pattern.mermaidAlt}
+              </figcaption>
+            )}
+          </figure>
+        </section>
+      )}
+
+      {/* 3. When to use */}
+      {pattern.whenToUse.length > 0 && (
+        <section aria-labelledby="when-to-use-heading">
+          <SlotHeading id="when-to-use-heading">When to use</SlotHeading>
+          <ul className="mt-4 list-disc pl-6 text-base leading-7 text-text-secondary">
+            {pattern.whenToUse.map((item, idx) => (
+              <li key={idx} className="[text-wrap:pretty]">{item}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* 4. When NOT to use */}
+      {pattern.whenNotToUse.length > 0 && (
+        <section aria-labelledby="when-not-to-use-heading">
+          <SlotHeading id="when-not-to-use-heading">When not to use</SlotHeading>
+          <ul className="mt-4 list-disc pl-6 text-base leading-7 text-text-secondary">
+            {pattern.whenNotToUse.map((item, idx) => (
+              <li key={idx} className="[text-wrap:pretty]">{item}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* 5. Real-world examples */}
+      {pattern.realWorldExamples.length > 0 && (
+        <section aria-labelledby="real-world-heading">
+          <SlotHeading id="real-world-heading">Real-world examples</SlotHeading>
+          <ul className="mt-4 flex flex-col gap-3">
+            {pattern.realWorldExamples.map((ex, idx) => (
+              <li key={idx} className="text-base leading-7 text-text-secondary [text-wrap:pretty]">
+                {ex.text}{" "}
+                <a
+                  href={ex.sourceUrl}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  className="text-accent underline underline-offset-4 hover:text-accent-muted"
+                >
+                  source
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* 6. Reader gotcha */}
+      {pattern.readerGotcha && (
+        <section aria-labelledby="gotcha-heading">
+          <SlotHeading id="gotcha-heading">Reader gotcha</SlotHeading>
+          <div className="mt-4 rounded-sm border border-border bg-surface p-4">
+            <p className="text-base leading-7 text-text-secondary [text-wrap:pretty]">
+              {pattern.readerGotcha.text}{" "}
+              <a
+                href={pattern.readerGotcha.sourceUrl}
+                rel="noopener noreferrer"
+                target="_blank"
+                className="text-accent underline underline-offset-4 hover:text-accent-muted"
+              >
+                source
+              </a>
+            </p>
+          </div>
+        </section>
+      )}
+
+      {/* 7. Implementation sketch */}
+      {pattern.implementationSketch && (
+        <section aria-labelledby="sketch-heading">
+          <SlotHeading id="sketch-heading">Implementation sketch</SlotHeading>
+          {showPseudocodeBanner && (
+            <div
+              role="note"
+              className="mt-4 rounded-sm border border-border-subtle bg-surface px-4 py-3 text-sm text-text-tertiary"
+            >
+              <span className="font-mono uppercase tracking-[0.05em] text-text-secondary">
+                Pseudocode:
+              </span>{" "}
+              No first-party TypeScript SDK is available for this pattern
+              ({SDK_LABELS[pattern.sdkAvailability]}). The sketch below is illustrative.
+            </div>
+          )}
+          <pre className="mt-4 overflow-x-auto rounded-sm border border-border bg-surface p-4 text-sm leading-6">
+            <code className="font-mono text-text-primary">{pattern.implementationSketch}</code>
+          </pre>
+        </section>
+      )}
+
+      {/* 8. Frameworks + SDK availability */}
+      {pattern.frameworks.length > 0 && (
+        <section aria-labelledby="frameworks-heading">
+          <SlotHeading id="frameworks-heading">Frameworks</SlotHeading>
+          <div className="mt-4 flex flex-col gap-3">
+            <div>
+              <h3 className="font-mono text-sm font-semibold uppercase tracking-[0.05em] text-text-tertiary">
+                SDK availability
+              </h3>
+              <p className="mt-1 text-sm text-text-secondary">
+                {SDK_LABELS[pattern.sdkAvailability]}
+              </p>
+            </div>
+            <ul className="flex flex-wrap gap-2">
+              {pattern.frameworks.map((fw) => (
+                <li key={fw}>
+                  <span className="inline-flex items-center rounded-sm border border-border bg-surface px-2.5 py-1 font-mono text-sm text-text-secondary">
+                    {FRAMEWORK_LABELS[fw]}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/agentic-patterns/PatternCard.tsx
+++ b/src/components/agentic-patterns/PatternCard.tsx
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------------------
+// PatternCard
+// ---------------------------------------------------------------------------
+// Hub grid card for a single agentic pattern. Server component (no client JS).
+//
+// Visual parity with PostCard:
+// - Uses card-trace + card-scanline utilities (animated chrome on hover)
+// - Heading className matches PostCard verbatim — including font-mono, the
+//   text-wrap and tracking tokens. Without font-mono the title falls back to
+//   the body serif and breaks visual parity with PostCard.
+// - Layer/refs corner uses the frame-label utility (NOT inline span styling).
+//
+// Heading level is configurable: <h3> when the card sits under a flat layer
+// section (parent <h2>), <h4> when under a topology sub-tier (parent <h3>).
+//
+// v1: chip styling duplicated across components (frame-label, framework chips,
+// related chips, reference type badges). Acceptable as v1 — future refactor
+// extracts a <Chip> primitive.
+
+import { Link } from "next-view-transitions";
+import type { Pattern } from "@/data/agentic-design-patterns/types";
+
+interface PatternCardProps {
+  /** Pattern object — passed whole, not destructured at the boundary. */
+  pattern: Pattern;
+  /** Heading level — 3 under flat layer sections, 4 under topology sub-tiers. */
+  headingLevel: 3 | 4;
+}
+
+export function PatternCard({ pattern, headingLevel }: PatternCardProps) {
+  const Heading = headingLevel === 3 ? "h3" : "h4";
+  const href = `/agentic-design-patterns/${pattern.slug}`;
+  const refsCount = pattern.references.length;
+  // Corner label: "REFS · N" tells the reader at a glance how grounded the
+  // pattern is. Empty references render the pattern name itself as fallback
+  // (avoids rendering "REFS · 0" which reads as a defect).
+  const cornerLabel = refsCount > 0 ? `REFS · ${refsCount}` : pattern.name.toUpperCase();
+
+  return (
+    <Link
+      href={href}
+      className="group card-trace card-scanline relative block rounded-sm border border-border bg-surface p-6 transition-colors hover:border-border-hover hover:bg-hover-bg hover:shadow-sm focus-ring"
+    >
+      <span className="frame-label" aria-hidden="true">
+        {cornerLabel}
+      </span>
+      <Heading className="font-mono text-lg font-semibold tracking-tight text-text-primary [text-wrap:balance]">
+        {pattern.name}
+      </Heading>
+      {pattern.oneLineSummary && (
+        <p className="mt-2 max-w-prose text-base leading-6 text-text-secondary [text-wrap:pretty]">
+          {pattern.oneLineSummary}
+        </p>
+      )}
+      <p className="mt-3 text-sm font-medium text-accent group-hover:text-accent-muted transition-colors">
+        Open pattern →
+      </p>
+    </Link>
+  );
+}

--- a/src/components/agentic-patterns/PatternHeader.tsx
+++ b/src/components/agentic-patterns/PatternHeader.tsx
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------------
+// PatternHeader
+// ---------------------------------------------------------------------------
+// Satellite-page header for an individual pattern. Server component.
+//
+// Emits the satellite page's single <h1> (the pattern name). The layer
+// eyebrow is a non-heading styled span — DO NOT promote it to a heading
+// (Lighthouse a11y enforces one <h1> per page).
+//
+// Renders alternative names inline as a comma-separated synonym list, since
+// these are how readers find the pattern under names from other sources.
+
+import type { LayerId, Pattern } from "@/data/agentic-design-patterns/types";
+import { LAYERS } from "@/data/agentic-design-patterns/layers";
+
+interface PatternHeaderProps {
+  pattern: Pattern;
+}
+
+function getLayerLabel(layerId: LayerId): string {
+  const layer = LAYERS.find((l) => l.id === layerId);
+  if (!layer) return layerId;
+  return `Layer ${layer.number} — ${layer.title}`;
+}
+
+export function PatternHeader({ pattern }: PatternHeaderProps) {
+  const layerLabel = getLayerLabel(pattern.layerId);
+  const altNames = pattern.alternativeNames ?? [];
+
+  return (
+    <header className="flex flex-col gap-3">
+      {/* Eyebrow: layer attribution. Styled span (NOT a heading). */}
+      <span
+        className="font-mono text-xs font-semibold uppercase tracking-[0.1em] text-text-tertiary"
+      >
+        {layerLabel}
+      </span>
+      <h1 className="font-mono text-3xl font-semibold tracking-tight text-text-primary [text-wrap:balance]">
+        {pattern.name}
+      </h1>
+      {altNames.length > 0 && (
+        <p className="text-sm text-text-tertiary">
+          <span className="font-mono uppercase tracking-[0.05em]">Also known as:</span>{" "}
+          <span className="italic">{altNames.join(", ")}</span>
+        </p>
+      )}
+      {pattern.oneLineSummary && (
+        <p className="max-w-prose text-lg leading-7 text-text-secondary [text-wrap:pretty]">
+          {pattern.oneLineSummary}
+        </p>
+      )}
+    </header>
+  );
+}

--- a/src/components/agentic-patterns/PrevNextNav.tsx
+++ b/src/components/agentic-patterns/PrevNextNav.tsx
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------------
+// PrevNextNav
+// ---------------------------------------------------------------------------
+// Layer-scoped (and topology-tier-scoped) prev/next navigation at the bottom
+// of a satellite page. Server component.
+//
+// Uses getAdjacentPatterns from the data layer — that helper handles the
+// scope rules (same layer; for topology, same sub-tier). When a pattern is
+// at an edge (or alone in its scope, e.g. 12-factor-agent in methodology),
+// the missing side renders as a disabled placeholder so the visual rhythm
+// stays balanced.
+
+import { Link } from "next-view-transitions";
+import type { Pattern } from "@/data/agentic-design-patterns/types";
+import { getAdjacentPatterns } from "@/data/agentic-design-patterns/index";
+
+interface PrevNextNavProps {
+  pattern: Pattern;
+}
+
+interface NavLinkProps {
+  pattern: Pattern;
+  direction: "prev" | "next";
+}
+
+function NavLink({ pattern, direction }: NavLinkProps) {
+  const isPrev = direction === "prev";
+  return (
+    <Link
+      href={`/agentic-design-patterns/${pattern.slug}`}
+      className={`group flex flex-col gap-1 rounded-sm border border-border bg-surface p-4 transition-colors hover:border-border-hover hover:bg-hover-bg focus-ring ${
+        isPrev ? "items-start text-left" : "items-end text-right"
+      }`}
+    >
+      <span className="font-mono text-xs uppercase tracking-[0.1em] text-text-tertiary">
+        {isPrev ? "← Previous" : "Next →"}
+      </span>
+      <span className="font-mono text-base font-semibold text-text-primary group-hover:text-accent">
+        {pattern.name}
+      </span>
+    </Link>
+  );
+}
+
+function NavPlaceholder({ direction }: { direction: "prev" | "next" }) {
+  // Aria-hidden so screen-reader users don't get confusing empty slots.
+  // Visual-only spacer to keep layout balanced when one side has no peer.
+  const isPrev = direction === "prev";
+  return (
+    <div
+      aria-hidden="true"
+      className={`hidden flex-col gap-1 rounded-sm border border-dashed border-border-subtle bg-transparent p-4 sm:flex ${
+        isPrev ? "items-start" : "items-end"
+      }`}
+    >
+      <span className="font-mono text-xs uppercase tracking-[0.1em] text-text-tertiary opacity-40">
+        {isPrev ? "← Previous" : "Next →"}
+      </span>
+      <span className="font-mono text-base text-text-tertiary opacity-40">—</span>
+    </div>
+  );
+}
+
+export function PrevNextNav({ pattern }: PrevNextNavProps) {
+  const { prev, next } = getAdjacentPatterns(pattern.slug);
+
+  // If both sides are null (only happens for sole-occupant tiers like
+  // 12-factor-agent in methodology), don't render the nav at all.
+  if (prev === null && next === null) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label="Adjacent patterns"
+      className="grid grid-cols-1 gap-3 sm:grid-cols-2"
+    >
+      {prev ? <NavLink pattern={prev} direction="prev" /> : <NavPlaceholder direction="prev" />}
+      {next ? <NavLink pattern={next} direction="next" /> : <NavPlaceholder direction="next" />}
+    </nav>
+  );
+}

--- a/src/components/agentic-patterns/ReferencesSection.tsx
+++ b/src/components/agentic-patterns/ReferencesSection.tsx
@@ -1,0 +1,105 @@
+// ---------------------------------------------------------------------------
+// ReferencesSection
+// ---------------------------------------------------------------------------
+// Primary authority signal for a pattern. Type-badged citation list with
+// authors, year, and venue. Server component.
+//
+// Behavior:
+// - Returns null when the references array is empty (renders nothing —
+//   the surrounding satellite layout has nothing to slot in).
+// - Wraps each reference title in <cite> for semantic correctness (cite is
+//   the HTML element for the title of a creative work).
+// - Type badges (paper / essay / docs / book / spec) use the same chip shape
+//   as framework chips and related-pattern chips. v1: duplicated styling.
+//   Future: extract <Chip>.
+
+import type { Pattern, Reference, ReferenceType } from "@/data/agentic-design-patterns/types";
+
+interface ReferencesSectionProps {
+  pattern: Pattern;
+}
+
+const TYPE_LABELS: Record<ReferenceType, string> = {
+  paper: "PAPER",
+  essay: "ESSAY",
+  docs: "DOCS",
+  book: "BOOK",
+  spec: "SPEC",
+};
+
+function ReferenceItem({ reference }: { reference: Reference }) {
+  const venueParts: string[] = [];
+  if (reference.venue) venueParts.push(reference.venue);
+  if (reference.doi) venueParts.push(`DOI: ${reference.doi}`);
+
+  return (
+    <li className="flex flex-col gap-1.5 border-b border-border-subtle py-3 last:border-b-0">
+      <div className="flex flex-wrap items-baseline gap-2">
+        <span
+          className="inline-flex items-center rounded-sm border border-border bg-surface px-1.5 py-0.5 font-mono text-[0.625rem] font-semibold uppercase tracking-[0.1em] text-text-tertiary"
+          aria-label={`Reference type: ${reference.type}`}
+        >
+          {TYPE_LABELS[reference.type]}
+        </span>
+        <a
+          href={reference.url}
+          rel="noopener noreferrer"
+          target="_blank"
+          className="text-base font-medium text-accent underline underline-offset-4 hover:text-accent-muted"
+        >
+          <cite className="not-italic">{reference.title}</cite>
+        </a>
+      </div>
+      <div className="text-sm text-text-secondary">
+        <span>{reference.authors}</span>
+        <span className="mx-1.5 text-text-tertiary">·</span>
+        <span>{reference.year}</span>
+        {venueParts.length > 0 && (
+          <>
+            <span className="mx-1.5 text-text-tertiary">·</span>
+            <span className="italic">{venueParts.join(" · ")}</span>
+          </>
+        )}
+        {reference.pages && (
+          <>
+            <span className="mx-1.5 text-text-tertiary">·</span>
+            <span>pp. {reference.pages[0]}–{reference.pages[1]}</span>
+          </>
+        )}
+        {reference.accessedAt && (
+          <>
+            <span className="mx-1.5 text-text-tertiary">·</span>
+            <span>accessed <time dateTime={reference.accessedAt}>{reference.accessedAt}</time></span>
+          </>
+        )}
+      </div>
+      {reference.note && (
+        <p className="text-sm text-text-tertiary [text-wrap:pretty]">{reference.note}</p>
+      )}
+    </li>
+  );
+}
+
+export function ReferencesSection({ pattern }: ReferencesSectionProps) {
+  // Conditional render: an empty references array means the satellite shows
+  // no references slot at all (rather than an empty header).
+  if (pattern.references.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-labelledby="references-heading">
+      <h2
+        id="references-heading"
+        className="font-mono text-xl font-semibold tracking-tight text-text-primary"
+      >
+        References
+      </h2>
+      <ol className="mt-4 list-none">
+        {pattern.references.map((reference, idx) => (
+          <ReferenceItem key={`${reference.url}-${idx}`} reference={reference} />
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/src/components/agentic-patterns/RelatedPatternsRow.tsx
+++ b/src/components/agentic-patterns/RelatedPatternsRow.tsx
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------------
+// RelatedPatternsRow
+// ---------------------------------------------------------------------------
+// Cross-link chip row of 2-4 related patterns. Server component.
+//
+// Resolves slugs via getPattern at render-time. Unresolved slugs are skipped
+// silently rather than rendering broken chips — the data layer's CI guard
+// (helpers.test.ts: "any non-empty relatedSlugs entry resolves to an existing
+// slug") is the authoritative gate. Returns null when nothing resolves so an
+// empty header isn't left behind.
+//
+// v1: chip styling duplicated with framework chips and reference type badges.
+// Future: extract <Chip>.
+
+import { Link } from "next-view-transitions";
+import type { Pattern } from "@/data/agentic-design-patterns/types";
+import { getPattern } from "@/data/agentic-design-patterns/index";
+
+interface RelatedPatternsRowProps {
+  pattern: Pattern;
+}
+
+export function RelatedPatternsRow({ pattern }: RelatedPatternsRowProps) {
+  const related = pattern.relatedSlugs
+    .map((slug) => getPattern(slug))
+    .filter((p): p is Pattern => p !== undefined);
+
+  if (related.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-labelledby="related-patterns-heading">
+      <h2
+        id="related-patterns-heading"
+        className="font-mono text-xl font-semibold tracking-tight text-text-primary"
+      >
+        Related patterns
+      </h2>
+      <ul className="mt-4 flex flex-wrap gap-2">
+        {related.map((rel) => (
+          <li key={rel.slug}>
+            <Link
+              href={`/agentic-design-patterns/${rel.slug}`}
+              className="inline-flex items-center rounded-sm border border-border bg-surface px-3 py-1.5 font-mono text-sm text-text-secondary transition-colors hover:border-border-hover hover:bg-hover-bg hover:text-text-primary focus-ring"
+            >
+              {rel.name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/lib/pattern-search.ts
+++ b/src/lib/pattern-search.ts
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------------------
+// pattern-search
+// ---------------------------------------------------------------------------
+// Pure search function over the Pattern catalog. Used by HubSearchBar to
+// compute the result count, and by the filter wrapper introduced in #157
+// to filter the visible cards.
+//
+// Search rules:
+//   - Empty / whitespace-only query → returns ALL patterns (acts as identity)
+//   - Match against name, alternativeNames, oneLineSummary, AND layer label
+//   - Case-insensitive
+//   - Prefix matches OR substring matches (both qualify)
+//
+// Layer-label matching means typing "topology" or even "control flow" pulls
+// up every pattern in that layer — readers don't need to know each pattern
+// name to discover relevant ones.
+//
+// Determinism: the function preserves input order. Callers control sorting.
+
+import type { LayerId, Pattern } from "@/data/agentic-design-patterns/types";
+
+/**
+ * Map of layer id → human-readable label (e.g. "Layer 1 — Topology / Control Flow").
+ * Passed in from the caller so this lib stays free of UI-shaped strings.
+ */
+export type LayerLabelMap = Partial<Record<LayerId, string>>;
+
+function matchesQuery(haystack: string, needleLower: string): boolean {
+  const hay = haystack.toLowerCase();
+  // Prefix match short-circuit (cheaper than substring scan when query is
+  // a common prefix); falls back to substring on miss.
+  return hay.startsWith(needleLower) || hay.includes(needleLower);
+}
+
+/**
+ * Return the subset of `patterns` matching `query`.
+ *
+ * @param patterns - the full catalog (or any pre-filtered subset)
+ * @param query - user-supplied query; empty/whitespace returns all
+ * @param layerLabels - optional map id → label so layer text is searchable
+ */
+export function searchPatterns(
+  patterns: Pattern[],
+  query: string,
+  layerLabels: LayerLabelMap = {},
+): Pattern[] {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) {
+    return patterns;
+  }
+  const needle = trimmed.toLowerCase();
+
+  return patterns.filter((p) => {
+    if (matchesQuery(p.name, needle)) return true;
+
+    if (p.alternativeNames) {
+      for (const alt of p.alternativeNames) {
+        if (matchesQuery(alt, needle)) return true;
+      }
+    }
+
+    if (p.oneLineSummary && matchesQuery(p.oneLineSummary, needle)) return true;
+
+    const layerLabel = layerLabels[p.layerId];
+    if (layerLabel && matchesQuery(layerLabel, needle)) return true;
+
+    return false;
+  });
+}

--- a/tests/unit/lib/pattern-search.test.ts
+++ b/tests/unit/lib/pattern-search.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { searchPatterns, type LayerLabelMap } from "@/lib/pattern-search";
+import type { Pattern } from "@/data/agentic-design-patterns/types";
+
+// ---------------------------------------------------------------------------
+// Test fixtures — minimal valid Pattern objects.
+// We use literal stub values rather than the live PATTERNS array so this
+// test stays robust to catalog edits (pattern stubs evolve in #158+).
+// ---------------------------------------------------------------------------
+
+function makePattern(overrides: Partial<Pattern>): Pattern {
+  return {
+    slug: overrides.slug ?? "test-pattern",
+    name: overrides.name ?? "Test Pattern",
+    layerId: overrides.layerId ?? "topology",
+    topologySubtier: overrides.layerId === undefined || overrides.layerId === "topology" ? "single-agent" : undefined,
+    oneLineSummary: overrides.oneLineSummary ?? "",
+    bodySummary: [],
+    mermaidSource: "",
+    mermaidAlt: "",
+    whenToUse: [],
+    whenNotToUse: [],
+    realWorldExamples: [],
+    implementationSketch: "",
+    sdkAvailability: "no-sdk",
+    relatedSlugs: [],
+    frameworks: [],
+    references: [],
+    addedAt: "2026-05-03",
+    dateModified: "2026-05-03",
+    ...overrides,
+  };
+}
+
+const FIXTURES: Pattern[] = [
+  makePattern({
+    slug: "prompt-chaining",
+    name: "Prompt Chaining",
+    oneLineSummary: "Chain LLM calls so output of one feeds the next",
+    layerId: "topology",
+  }),
+  makePattern({
+    slug: "rag",
+    name: "RAG",
+    alternativeNames: ["Retrieval-Augmented Generation"],
+    oneLineSummary: "Inject retrieved context before generation",
+    layerId: "topology",
+  }),
+  makePattern({
+    slug: "guardrails",
+    name: "Guardrails",
+    oneLineSummary: "Validate inputs and outputs before they reach the model",
+    layerId: "quality",
+    topologySubtier: undefined,
+  }),
+  makePattern({
+    slug: "memory-management",
+    name: "Memory Management",
+    oneLineSummary: "Decide what to keep, summarize, or evict across turns",
+    layerId: "state",
+    topologySubtier: undefined,
+  }),
+];
+
+const LAYER_LABELS: LayerLabelMap = {
+  topology: "Layer 1 — Topology / Control Flow",
+  quality: "Layer 2 — Quality & Control Gates",
+  state: "Layer 3 — State & Context",
+  interfaces: "Layer 4 — Interfaces & Transport",
+  methodology: "Layer 5 — Methodology",
+};
+
+// ---------------------------------------------------------------------------
+// Tests — required: empty, prefix, substring (over summary),
+// case-insensitive, no-match.
+// ---------------------------------------------------------------------------
+
+describe("searchPatterns", () => {
+  it("returns all patterns when the query is empty (or whitespace only)", () => {
+    expect(searchPatterns(FIXTURES, "", LAYER_LABELS)).toHaveLength(FIXTURES.length);
+    expect(searchPatterns(FIXTURES, "   ", LAYER_LABELS)).toHaveLength(FIXTURES.length);
+  });
+
+  it("matches by prefix on pattern name", () => {
+    // "Prom" is a prefix of "Prompt Chaining"
+    const results = searchPatterns(FIXTURES, "Prom", LAYER_LABELS);
+    expect(results.map((p) => p.slug)).toEqual(["prompt-chaining"]);
+  });
+
+  it("matches by substring inside oneLineSummary", () => {
+    // "summarize" appears mid-string in memory-management's summary
+    const results = searchPatterns(FIXTURES, "summarize", LAYER_LABELS);
+    expect(results.map((p) => p.slug)).toEqual(["memory-management"]);
+  });
+
+  it("is case-insensitive across all searched fields", () => {
+    // Mixed-case query against differently-cased name and alt name
+    const results = searchPatterns(FIXTURES, "rEtRiEvAl", LAYER_LABELS);
+    expect(results.map((p) => p.slug)).toEqual(["rag"]);
+  });
+
+  it("returns an empty array when nothing matches", () => {
+    expect(searchPatterns(FIXTURES, "zxzxzxzx-no-match", LAYER_LABELS)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- 10 React components for the agentic-design-patterns hub + satellite routes (`src/components/agentic-patterns/`)
- 1 pure search library (`src/lib/pattern-search.ts`) with 5 unit tests
- Mostly server components — only `HubSearchBar` carries `'use client'`

## What's in this PR

| Component | Role |
|---|---|
| `LivingCatalogBadge` | "Updated [Month YYYY]" pill |
| `PatternCard` | hub grid card; `card-trace` + `card-scanline` + `frame-label`; PostCard heading parity |
| `PatternHeader` | satellite `<h1>` + layer eyebrow + alt names |
| `ReferencesSection` | type-badged `<cite>` citation list (returns null when empty) |
| `RelatedPatternsRow` | cross-link chip row (returns null when empty) |
| `PrevNextNav` | layer-scoped (and topology-tier-scoped) adjacent nav |
| `HubHero` | hub `<h1>` with dynamic catalog count |
| `HubGrid` | 5 layer sections; topology sub-tier dividers with dynamic `(N)` counts |
| `PatternBody` | 8-slot satellite composition; conditional rendering; pseudocode banner gated on `sdkAvailability` |
| `HubSearchBar` | the only `'use client'`; `/`-keyed; debounced; `aria-live="polite"`; **NO callback prop in this PR — wiring lives in #157** |

## Heading hierarchy (mandatory)

- **Hub:** 1 `<h1>` (HubHero); layer titles `<h2>`; topology sub-tier titles `<h3>`; PatternCard `<h3>` under flat sections, `<h4>` under sub-tiers (controlled by `headingLevel: 3 | 4` prop)
- **Satellite:** 1 `<h1>` (PatternHeader); slot headings `<h2>`; sub-headings `<h3>`

## Self-review

- [x] exactly 1 `'use client'` (HubSearchBar)
- [x] PatternCard heading className matches PostCard verbatim (`font-mono text-lg font-semibold tracking-tight text-text-primary` with `[text-wrap:balance]`)
- [x] HubSearchBar exports NO callback prop (`onResults` / `onChange` / `onFilter` deferred to #157's `HubFilterableContent`)
- [x] HubGrid topology counts derived from `getTopologyPatterns(...)` — never hardcoded
- [x] HubHero pattern count derived from `getCatalogPatternCount()` — never hardcoded
- [x] PatternBody passes only `{ source: string }` to MermaidDiagram (no functions / closures across the RSC boundary)
- [x] ReferencesSection returns `null` when `references[]` empty; uses `<cite>` for titles
- [x] HubSearchBar initial state is `''`; URL `?q=` hydration happens inside `useEffect`
- [x] HubSearchBar `/` shortcut ignores when focus is in input/textarea/select/contenteditable
- [x] `<input type="search">` with explicit `aria-label`; live region uses `aria-live="polite"`

## Tests

```
pnpm vitest run tests/unit/lib/pattern-search.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Full suite: `pnpm test:unit` → **290 passed (290)**.
Typecheck: `pnpm typecheck` → 0 errors.
Lint: `pnpm lint` → 0 errors (existing warnings only, none in new files).

## Test plan

- [ ] CI green (typecheck, vitest, lint)
- [ ] Reviewer spot-checks PatternCard hover chrome matches PostCard side-by-side
- [ ] Reviewer confirms HubSearchBar has no callback prop (acceptance gate for #156)
- [ ] Lighthouse heading-order audit on hub + satellite once routes exist (#157)

Closes #156.