### PR TITLE
feat(adp): author Prompt Chaining pattern (#172)

### DIFF
--- a/src/data/agentic-design-patterns/changelog.ts
+++ b/src/data/agentic-design-patterns/changelog.ts
@@ -18,6 +18,13 @@ import type { ChangelogEntry } from './types'
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: '2026-05-03',
+    slug: 'prompt-chaining',
+    type: 'added',
+    note: 'Initial authoring of Prompt Chaining pattern (wave 1).',
+    author: 'julianken',
+  },
+  {
     // Phase 1A scaffold: type model, layers, 23 stubs, helpers, changelog.
     // Reflexion stub is added here; full authoring ships in Phase 1F (#158).
     // Date bumped to 2026-05-03 by #158 so lint-changelog matches the

--- a/src/data/agentic-design-patterns/patterns/prompt-chaining.ts
+++ b/src/data/agentic-design-patterns/patterns/prompt-chaining.ts
@@ -3,20 +3,139 @@ import type { Pattern } from '../types'
 export const pattern: Pattern = {
   slug: 'prompt-chaining',
   name: 'Prompt Chaining',
+  alternativeNames: ['Pipeline', 'Sequential Prompting', 'LLM Pipeline'],
   layerId: 'topology',
   topologySubtier: 'single-agent',
-  oneLineSummary: '', // TODO: fill in ≤ 90 chars
-  bodySummary: [],
-  mermaidSource: '',
-  mermaidAlt: '',
-  whenToUse: [],
-  whenNotToUse: [],
-  realWorldExamples: [],
-  implementationSketch: '',
-  sdkAvailability: 'no-sdk',
+  oneLineSummary: 'A fixed sequence of LLM calls, each consuming the previous step\'s output.',
+  bodySummary: [
+    'Prompt chaining decomposes a task into a fixed sequence of LLM calls in which each step\'s output becomes the next step\'s input. The decomposition is editorial: a human picks the seams, names the intermediate artifacts, and writes one prompt per stage so each prompt is small enough to be reliable on its own. Between stages the program holds the artifact in plain memory, and often runs a deterministic gate — a schema validator, a regex, a length check — that decides whether to advance, retry, or fail closed.',
+    'The pattern is the first thing the Anthropic taxonomy reaches for when a task can be split cleanly. The trade is latency for accuracy: two or three smaller prompts produce more dependable answers than one heroic prompt that has to plan, retrieve, draft, and proofread inside one inference. Structured output earns the chain its reliability — each stage emits JSON or some other parseable shape so the next stage receives an object, not a paragraph, and the seams stay machine-readable. Without the gates, errors at stage one quietly ride through the rest of the chain.',
+    'Prompt chaining sits underneath the more elaborate topologies. Routing picks a chain at runtime; parallelization fans out independent stages; orchestrator-workers and ReAct add a planner that the chain itself does not have. The chain is fixed at author time, which is why it ships the soonest and breaks the latest. The cost is editorial debt: when the task changes shape, the seams have to be redrawn by hand, because no part of the chain decides for itself whether the next call is the right one.',
+  ],
+  mermaidSource: `graph LR
+  A[Input] --> B[Stage 1 prompt]
+  B --> C{Schema gate}
+  C -->|pass| D[Stage 2 prompt]
+  C -->|fail| B
+  D --> E{Schema gate}
+  E -->|pass| F[Stage 3 prompt]
+  E -->|fail| D
+  F --> G[Output]`,
+  mermaidAlt: 'A left-to-right flowchart in which an Input feeds a Stage 1 prompt whose output passes through a schema gate that either advances to Stage 2 or loops back to retry, with the same gated structure repeating for Stage 2 and Stage 3 before producing the final Output.',
+  whenToUse: [
+    'Apply when the task decomposes cleanly into 2–5 fixed stages whose order is known up front (extract, normalize, draft, review).',
+    'Use where each stage produces a parseable artifact (JSON object, list, scored shortlist) so a deterministic gate can validate the handoff between calls.',
+    'Reach for it when accuracy outranks latency and a single monolithic prompt has started to drop instructions or hallucinate intermediate state.',
+    'Prefer it as the first agentic shape on a new problem — it ships in a day, runs deterministically, and exposes which stage is the real source of error before any planner is introduced.',
+  ],
+  whenNotToUse: [
+    'When the path through the work is data-dependent and changes per request, a fixed chain forces a wrong shape on the task — route or plan instead.',
+    'Without inter-stage validation, a chain becomes a longer monolith: each stage launders the previous stage\'s errors into the next, and end-to-end accuracy falls below the single-prompt baseline.',
+    'When stages are mutually independent, sequencing them wastes wall-clock time the parallelization pattern would recover.',
+  ],
+  realWorldExamples: [
+    {
+      text: 'Anthropic\'s public agent cookbook ships a runnable prompt-chain workflow that drafts marketing copy, gates the result with a programmatic check, then translates it — exactly the decomposition the essay describes.',
+      sourceUrl: 'https://github.com/anthropics/claude-cookbooks/blob/main/patterns/agents/basic_workflows.ipynb',
+    },
+    {
+      text: 'LangGraph documents prompt chaining as one of the canonical workflow shapes, modelled as a small graph of typed nodes whose edges carry the validated artifact between stages.',
+      sourceUrl: 'https://docs.langchain.com/oss/javascript/langgraph/use-graph-api',
+    },
+    {
+      text: 'OpenAI\'s Deep Research product runs a multi-stage pipeline that plans sub-questions, retrieves and reads sources for each, then synthesises a report — a long-running chain whose stages are visible to the user as a streaming progress trace.',
+      sourceUrl: 'https://openai.com/index/introducing-deep-research/',
+    },
+  ],
+  implementationSketch: `import { generateText, generateObject } from 'ai'
+import { openai } from '@ai-sdk/openai'
+import { z } from 'zod'
+
+const Outline = z.object({ topic: z.string(), sections: z.array(z.string()).min(3) })
+
+async function draftReport(brief: string): Promise<string> {
+  const { object: outline } = await generateObject({
+    model: openai('gpt-4o-mini'),
+    schema: Outline,
+    prompt: \`Produce an outline for: \${brief}\`,
+  })
+  if (outline.sections.length < 3) throw new Error('outline gate: too few sections')
+  const { text: draft } = await generateText({
+    model: openai('gpt-4o'),
+    prompt: \`Write the report. Topic: \${outline.topic}. Sections: \${outline.sections.join(', ')}\`,
+  })
+  const { text: polished } = await generateText({
+    model: openai('gpt-4o-mini'),
+    prompt: \`Edit for tone and clarity. Return only the edited text.\\n\\n\${draft}\`,
+  })
+  return polished
+}
+
+export {}
+`,
+  sdkAvailability: 'first-party-ts',
+  readerGotcha: {
+    text: 'Anthropic\'s essay names the failure mode bluntly: the trade is latency for accuracy, and the win evaporates when the chain has no programmatic gate between stages — a malformed JSON or an off-topic draft at stage one rides through and the chain returns a confidently wrong final artifact. The gate is the pattern; the chain without it is just a longer prompt.',
+    sourceUrl: 'https://www.anthropic.com/engineering/building-effective-agents',
+  },
   relatedSlugs: [],
-  frameworks: [],
-  references: [],
+  frameworks: ['langchain', 'langgraph', 'vercel-ai-sdk', 'mastra'],
+  references: [
+    {
+      title: 'AI Chains: Transparent and Controllable Human-AI Interaction by Chaining Large Language Model Prompts',
+      url: 'https://arxiv.org/abs/2110.01691',
+      authors: 'Wu et al.',
+      year: 2022,
+      venue: 'CHI 2022',
+      type: 'paper',
+      doi: '10.1145/3491102.3517582',
+      note: 'foundational paper — coined "AI chains" and introduced the prompt-chain idiom',
+    },
+    {
+      title: 'Building Effective Agents',
+      url: 'https://www.anthropic.com/engineering/building-effective-agents',
+      authors: 'Anthropic',
+      year: 2024,
+      type: 'essay',
+      note: 'names prompt chaining as the first workflow to reach for, with the latency-for-accuracy trade and the gate discipline',
+    },
+    {
+      title: 'Demonstrate-Search-Predict: Composing retrieval and language models for knowledge-intensive NLP',
+      url: 'https://arxiv.org/abs/2212.14024',
+      authors: 'Khattab et al.',
+      year: 2022,
+      venue: 'arXiv',
+      type: 'paper',
+      doi: '10.48550/arXiv.2212.14024',
+      note: 'shows the chain-of-prompts shape for retrieval-augmented question answering — predecessor to DSPy',
+    },
+    {
+      title: 'Agentic Design Patterns, Chapter 1: Prompt Chaining',
+      url: 'https://link.springer.com/book/10.1007/978-3-032-01402-3',
+      authors: 'Antonio Gulli',
+      year: 2026,
+      venue: 'Springer',
+      type: 'book',
+      pages: [1, 12],
+    },
+    {
+      title: 'LangGraph — Use the graph API (workflow building blocks)',
+      url: 'https://docs.langchain.com/oss/javascript/langgraph/use-graph-api',
+      authors: 'LangChain team',
+      year: 2026,
+      type: 'docs',
+      accessedAt: '2026-05-03',
+    },
+    {
+      title: 'Anthropic Cookbook — Basic Workflows (prompt chaining notebook)',
+      url: 'https://github.com/anthropics/claude-cookbooks/blob/main/patterns/agents/basic_workflows.ipynb',
+      authors: 'Anthropic',
+      year: 2024,
+      type: 'docs',
+      accessedAt: '2026-05-03',
+    },
+  ],
   addedAt: '2026-05-03',
   dateModified: '2026-05-03',
+  lastChangeNote: 'Initial authoring of Prompt Chaining pattern (wave 1).',
 }

--- a/src/data/agentic-design-patterns/references.lock.json
+++ b/src/data/agentic-design-patterns/references.lock.json
@@ -1,6 +1,20 @@
 {
   "version": 1,
   "doiToReference": {
+    "10.1145/3491102.3517582": {
+      "title": "AI Chains: Transparent and Controllable Human-AI Interaction by Chaining Large Language Model Prompts",
+      "year": 2022,
+      "firstAuthorSurname": "Wu",
+      "source": "crossref",
+      "verifiedAt": "2026-05-03"
+    },
+    "10.48550/arXiv.2212.14024": {
+      "title": "Demonstrate-Search-Predict: Composing retrieval and language models for knowledge-intensive NLP",
+      "year": 2022,
+      "firstAuthorSurname": "Khattab",
+      "source": "openalex",
+      "verifiedAt": "2026-05-03"
+    },
     "10.48550/arXiv.2303.11366": {
       "title": "Reflexion: Language Agents with Verbal Reinforcement Learning",
       "year": 2023,

--- a/tests/unit/data/agentic-design-patterns/changelog.test.ts
+++ b/tests/unit/data/agentic-design-patterns/changelog.test.ts
@@ -7,8 +7,11 @@ describe('CHANGELOG', () => {
     expect(Array.isArray(CHANGELOG)).toBe(true)
   })
 
-  it('has exactly 1 entry in Phase 1 (the scaffold launch)', () => {
-    expect(CHANGELOG).toHaveLength(1)
+  it('has at least 1 entry (Phase 1 scaffold launch + any Phase 2 authoring)', () => {
+    // Phase 1 shipped a single seed entry; Phase 2 prepends one entry per
+    // newly authored pattern. Both shapes must satisfy this assertion so
+    // wave-1 worktrees can land independently without colliding on this test.
+    expect(CHANGELOG.length).toBeGreaterThanOrEqual(1)
   })
 
   it('every entry has an ISO date', () => {
@@ -40,20 +43,27 @@ describe('CHANGELOG', () => {
     // entry's date is bumped to the Reflexion authoring date so lint-changelog's
     // "latest CHANGELOG date >= today" check passes alongside pattern.dateModified.
     // The note text is preserved verbatim per #152's AC (asserted below).
-    expect(CHANGELOG[0].date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
-    expect(CHANGELOG[0].date >= '2026-05-02').toBe(true)
+    // Phase 2 prepends new authoring entries, so the Reflexion seed is no
+    // longer guaranteed to be at index 0 — find it by slug.
+    const reflexionSeed = CHANGELOG.find((e) => e.slug === 'reflexion')
+    expect(reflexionSeed).toBeDefined()
+    expect(reflexionSeed!.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(reflexionSeed!.date >= '2026-05-02').toBe(true)
   })
 
   it('Phase 1 seed entry slug is reflexion', () => {
-    expect(CHANGELOG[0].slug).toBe('reflexion')
+    const reflexionSeed = CHANGELOG.find((e) => e.slug === 'reflexion')
+    expect(reflexionSeed).toBeDefined()
   })
 
   it('Phase 1 seed entry type is added', () => {
-    expect(CHANGELOG[0].type).toBe('added')
+    const reflexionSeed = CHANGELOG.find((e) => e.slug === 'reflexion')
+    expect(reflexionSeed?.type).toBe('added')
   })
 
   it('Phase 1 seed entry note matches issue AC verbatim', () => {
-    expect(CHANGELOG[0].note).toBe(
+    const reflexionSeed = CHANGELOG.find((e) => e.slug === 'reflexion')
+    expect(reflexionSeed?.note).toBe(
       'Catalog scaffold launched; Reflexion exemplar shipped in #158.',
     )
   })


### PR DESCRIPTION
Closes #172

## Summary
Replaces the Phase-1 stub at `src/data/agentic-design-patterns/patterns/prompt-chaining.ts` with a full authored Pattern object that matches the Reflexion editorial exemplar (voice, structure, citations).

## STYLE_PASS checklist

Pattern: prompt-chaining

- [x] 3–7 references in `references[]`, each with required fields (6 references)
- [x] All paper references have `doi` (Wu et al. CHI, Khattab et al. DSP)
- [x] All book references have `venue` and `pages` (Gulli ch. 1, pp. 1–12)
- [x] All vendor doc references have `accessedAt` (LangGraph + Anthropic Cookbook = 2026-05-03)
- [x] `bodySummary` prose is original — not a paraphrase of any single source (3 paragraphs, 268 words, third-person throughout — `\b(you|we|our|us)\b` returns zero matches)
- [x] `whenToUse` bullets open with imperative verbs (Apply / Use / Reach / Prefer)
- [x] `whenNotToUse` bullets open with conditional/noun-phrase openers (When / Without / When)
- [x] `realWorldExamples` entries cite real, verifiable public sources (Anthropic cookbook notebook, LangGraph docs, OpenAI Deep Research launch post)
- [x] `readerGotcha` cites a public source (Anthropic Building Effective Agents)
- [x] `mermaidSource` compiles without errors — original 3-stage gated pipeline diagram, labeled boxes only, no `fa:` shortcodes
- [x] `implementationSketch` compiles against SDK types (`tsx scripts/typecheck-sketches.ts` exits 0; `sdkAvailability: 'first-party-ts'`)
- [x] No affiliate query params in any outbound URL (`check-affiliate-links` clean across 20 URLs)
- [x] `relatedSlugs` deliberately left empty — cross-link consistency pass deferred until all wave-1 patterns land (per task brief)
- [x] `dateModified` is today's literal ISO date (`'2026-05-03'`)
- [x] `lastChangeNote` is a 1-line description and matches the CHANGELOG entry verbatim

## Verification gates
- `pnpm typecheck` — exit 0
- `pnpm lint` — exit 0
  - `typecheck-sketches: OK (compiled 2, skipped 0 pseudocode, total 23)`
  - `validate-references: OK (papers=5, verified=5)` — all 5 paper DOIs resolve via Crossref/OpenAlex
  - `check-affiliate-links: OK (checked 20 URLs)`
  - `lint-changelog: OK (checked 2 authored, skipped 21 stubs, 2 changelog entries)`
- `pnpm test:unit` — 322 / 322 passing

## Test infra change
The Phase-1 changelog test (`tests/unit/data/agentic-design-patterns/changelog.test.ts`) hard-coded `CHANGELOG.length === 1` and `CHANGELOG[0].slug === 'reflexion'`. Both assertions break the moment any wave-1 pattern prepends a changelog entry — every wave-1 worktree would hit this. The patch:
- Loosens the length assertion to `>= 1` with a comment explaining wave-1 prepends.
- Replaces the four `CHANGELOG[0]` accessors with `CHANGELOG.find(e => e.slug === 'reflexion')` so the seed-entry invariants (date, type, verbatim note text) still get enforced regardless of insert order.

The semantic intent of every original assertion is preserved verbatim (date format, date >= '2026-05-02', type === 'added', note string equality).

## References used
1. Wu, T. et al. (2022) — *AI Chains: Transparent and Controllable Human-AI Interaction by Chaining Large Language Model Prompts*. CHI 2022. DOI 10.1145/3491102.3517582 — foundational paper, coined "AI chains"
2. Anthropic (2024) — *Building Effective Agents* (essay) — names prompt chaining as the first workflow shape and the latency-for-accuracy trade
3. Khattab, O. et al. (2022) — *Demonstrate-Search-Predict* (arXiv 2212.14024). DOI 10.48550/arXiv.2212.14024 — chain-of-prompts shape for retrieval-augmented QA, predecessor to DSPy
4. Gulli, A. (2026) — *Agentic Design Patterns*, ch. 1: Prompt Chaining (Springer, pp. 1–12)
5. LangGraph docs — *Use the graph API* (workflow building blocks, accessed 2026-05-03)
6. Anthropic Cookbook — *Basic Workflows* prompt-chaining notebook (accessed 2026-05-03)

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:unit`
- [ ] Visual smoke: `pnpm dev` then load `/agentic-design-patterns/prompt-chaining` and verify the Mermaid diagram renders (deferred to reviewer / preview deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)