### PR TITLE
feat(adp): author RAG pattern (#176)

### DIFF
--- a/src/data/agentic-design-patterns/changelog.ts
+++ b/src/data/agentic-design-patterns/changelog.ts
@@ -18,6 +18,13 @@ import type { ChangelogEntry } from './types'
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: '2026-05-03',
+    slug: 'rag',
+    type: 'added',
+    note: 'Authored RAG pattern (vanilla retrieve-and-generate; agentic variant remains separate).',
+    author: 'julianken',
+  },
+  {
     // Phase 1A scaffold: type model, layers, 23 stubs, helpers, changelog.
     // Reflexion stub is added here; full authoring ships in Phase 1F (#158).
     // Date bumped to 2026-05-03 by #158 so lint-changelog matches the

--- a/src/data/agentic-design-patterns/patterns/rag.ts
+++ b/src/data/agentic-design-patterns/patterns/rag.ts
@@ -3,20 +3,138 @@ import type { Pattern } from '../types'
 export const pattern: Pattern = {
   slug: 'rag',
   name: 'RAG',
+  alternativeNames: ['Retrieval-Augmented Generation', 'Retrieve-and-Generate'],
   layerId: 'topology',
   topologySubtier: 'single-agent',
-  oneLineSummary: '', // TODO: fill in ≤ 90 chars
-  bodySummary: [],
-  mermaidSource: '',
-  mermaidAlt: '',
-  whenToUse: [],
-  whenNotToUse: [],
-  realWorldExamples: [],
-  implementationSketch: '',
-  sdkAvailability: 'no-sdk',
+  oneLineSummary: 'Retrieve passages from an external store and condition the model on them.',
+  bodySummary: [
+    'Retrieval-Augmented Generation pairs a frozen language model with an external store of documents the model was never trained on. At query time the system embeds the question, scores it against a precomputed index of chunked text, and selects the top handful of passages by cosine similarity or hybrid sparse-dense ranking. Those passages are concatenated into the prompt as evidence the model is told to ground its answer in. The model then generates a response that, in the well-tuned case, cites or quotes the retrieved snippets rather than fabricating from parametric memory.',
+    "The pattern's leverage is that knowledge can change without retraining: swap the index, update a chunk, redeploy nothing. The cost is that retrieval becomes the silent tail that dominates accuracy. Chunk size, overlap, embedding model, distance metric, top-k, prompt template, and reranker each have a budget of free parameters and each interacts with the others. Even the embedding's distance function is load-bearing: a passage that should rank first under cosine often ranks fifth under dot-product on the same vectors. Most production RAG quality work is retrieval engineering wearing a generation costume.",
+    "The vanilla pattern is single-pass and stateless: one query in, one prompt out. That makes it cheap and easy to debug — every retrieved chunk and every token in the augmented prompt is inspectable without a stacktrace. It also makes it fragile to multi-hop questions where the answer depends on combining facts from multiple documents, ambiguous queries that require clarification, or domains where the relevant chunk is not lexically close to the user's phrasing. The agentic variant, in which the model rewrites queries, retrieves iteratively, and decides when to stop, addresses those gaps but is documented separately as a different pattern.",
+  ],
+  mermaidSource: `graph TD
+  A[User query] --> B[Embed query]
+  B --> C[Vector + keyword index]
+  C --> D[Top-k passages]
+  D --> E[Augmented prompt]
+  A --> E
+  E --> F[Generator LLM]
+  F --> G[Grounded answer]`,
+  mermaidAlt: 'A flowchart in which a User query is embedded and scored against a vector and keyword index, the top-k passages are concatenated with the original query into an augmented prompt, and a generator LLM produces a grounded answer.',
+  whenToUse: [
+    'Apply when the answer must be grounded in a corpus that changes faster than you can retrain or fine-tune (product manuals, internal wikis, regulatory filings, customer ticket history).',
+    "Use where the user's question is well-formed and self-contained — a single retrieval step is enough to surface the relevant passage.",
+    'Reach for it when hallucination cost is high and you need an inspectable audit trail: every cited claim points back to a specific chunk in a specific document.',
+    'Prefer it when the corpus is large enough that fitting it in the context window is wasteful or impossible, but small enough that the index fits in a single vector store.',
+  ],
+  whenNotToUse: [
+    'When the question requires combining facts across multiple documents that no single chunk surfaces — single-pass retrieval will miss the bridge and the answer will look confidently wrong.',
+    "When the corpus is small enough to fit in the model's context window: long-context prompting is simpler, has no retrieval failure mode, and benchmarks competitively for under ~100k tokens.",
+    "Without a way to evaluate retrieval quality independently of generation quality, the system's failures are unattributable and tuning becomes superstition.",
+  ],
+  realWorldExamples: [
+    {
+      text: 'Perplexity issues a search for every conversational turn, retrieves a few pages of results, and conditions its answer on those passages with inline citations — a consumer-facing RAG product whose UI exposes the retrieved sources next to each claim.',
+      sourceUrl: 'https://docs.perplexity.ai/docs/getting-started/overview',
+    },
+    {
+      text: "Glean indexes an enterprise's documents, chats, and tickets behind permissions-aware vector search, then answers employee questions by quoting the matching passages with links back to the source system.",
+      sourceUrl: 'https://www.glean.com/product/assistant',
+    },
+    {
+      text: "Anthropic's Contextual Retrieval writeup documents a production RAG variant that prepends a one-paragraph chunk-context preamble before embedding, raising recall on their own evals by reducing the rate at which a relevant chunk goes unretrieved.",
+      sourceUrl: 'https://www.anthropic.com/engineering/contextual-retrieval',
+    },
+  ],
+  implementationSketch: `import { generateText, embed } from 'ai'
+import { openai } from '@ai-sdk/openai'
+
+type Chunk = { id: string; text: string; embedding: number[] }
+declare const store: {
+  search(query: number[], k: number): Promise<Chunk[]>
+}
+
+async function ragAnswer(question: string, k = 5): Promise<string> {
+  const { embedding } = await embed({
+    model: openai.embedding('text-embedding-3-small'),
+    value: question,
+  })
+  const passages = await store.search(embedding, k)
+  const context = passages.map((p, i) => \`[\${i + 1}] \${p.text}\`).join('\\n\\n')
+  const { text } = await generateText({
+    model: openai('gpt-4o'),
+    system: 'Answer using only the numbered passages. Cite the bracketed index for each claim. If the passages do not support an answer, say so.',
+    prompt: \`Passages:\\n\${context}\\n\\nQuestion: \${question}\`,
+  })
+  return text
+}
+
+export {}
+`,
+  sdkAvailability: 'first-party-ts',
+  readerGotcha: {
+    text: "Embedding a chunk in isolation strips the surrounding context that disambiguates it — \"the company reported $X\" loses meaning when severed from the document that names the company. Anthropic's Contextual Retrieval evaluation shows that prepending a short LLM-written context to each chunk before embedding cuts the failed-retrieval rate substantially; the cheap fix that practitioners most often skip.",
+    sourceUrl: 'https://www.anthropic.com/engineering/contextual-retrieval',
+  },
   relatedSlugs: [],
-  frameworks: [],
-  references: [],
+  frameworks: ['langchain', 'langgraph', 'vercel-ai-sdk', 'mastra'],
+  references: [
+    {
+      title: 'Retrieval-Augmented Generation for Large Language Models: A Survey',
+      url: 'https://arxiv.org/abs/2312.10997',
+      authors: 'Gao et al.',
+      year: 2023,
+      type: 'paper',
+      doi: '10.48550/arXiv.2312.10997',
+      note: 'taxonomy of naive, advanced, and modular RAG; canonical academic survey of the pattern',
+    },
+    {
+      title: 'Dense Passage Retrieval for Open-Domain Question Answering',
+      url: 'https://aclanthology.org/2020.emnlp-main.550/',
+      authors: 'Karpukhin et al.',
+      year: 2020,
+      venue: 'EMNLP 2020',
+      type: 'paper',
+      doi: '10.18653/v1/2020.emnlp-main.550',
+      note: 'the dense-retriever architecture most production RAG stacks descend from',
+    },
+    {
+      title: 'KILT: a Benchmark for Knowledge Intensive Language Tasks',
+      url: 'https://aclanthology.org/2021.naacl-main.200/',
+      authors: 'Petroni et al.',
+      year: 2021,
+      venue: 'NAACL 2021',
+      type: 'paper',
+      doi: '10.18653/v1/2021.naacl-main.200',
+      note: 'shared evaluation suite for knowledge-intensive tasks Lewis et al. introduced for RAG',
+    },
+    {
+      title: 'Introducing Contextual Retrieval',
+      url: 'https://www.anthropic.com/engineering/contextual-retrieval',
+      authors: 'Anthropic',
+      year: 2024,
+      type: 'essay',
+      note: 'production RAG variant that prepends chunk-level context before embedding',
+    },
+    {
+      title: 'Agentic Design Patterns, Chapter 14: Knowledge Retrieval (RAG)',
+      url: 'https://link.springer.com/book/10.1007/978-3-032-01402-3',
+      authors: 'Antonio Gulli',
+      year: 2026,
+      venue: 'Springer',
+      type: 'book',
+      pages: [277, 320],
+    },
+    {
+      title: 'Build a Retrieval Augmented Generation (RAG) App',
+      url: 'https://docs.langchain.com/oss/python/langchain/rag',
+      authors: 'LangChain team',
+      year: 2024,
+      type: 'docs',
+      accessedAt: '2026-05-03',
+    },
+  ],
   addedAt: '2026-05-03',
   dateModified: '2026-05-03',
+  lastChangeNote: 'Authored RAG pattern (vanilla retrieve-and-generate; agentic variant remains separate).',
 }

--- a/src/data/agentic-design-patterns/references.lock.json
+++ b/src/data/agentic-design-patterns/references.lock.json
@@ -1,6 +1,20 @@
 {
   "version": 1,
   "doiToReference": {
+    "10.18653/v1/2020.emnlp-main.550": {
+      "title": "Dense Passage Retrieval for Open-Domain Question Answering",
+      "year": 2020,
+      "firstAuthorSurname": "Karpukhin",
+      "source": "crossref",
+      "verifiedAt": "2026-05-03"
+    },
+    "10.18653/v1/2021.naacl-main.200": {
+      "title": "KILT: a Benchmark for Knowledge Intensive Language Tasks",
+      "year": 2021,
+      "firstAuthorSurname": "Petroni",
+      "source": "crossref",
+      "verifiedAt": "2026-05-03"
+    },
     "10.48550/arXiv.2303.11366": {
       "title": "Reflexion: Language Agents with Verbal Reinforcement Learning",
       "year": 2023,
@@ -19,6 +33,13 @@
       "title": "CRITIC: Large Language Models Can Self-Correct with Tool-Interactive Critiquing",
       "year": 2023,
       "firstAuthorSurname": "Gou",
+      "source": "openalex",
+      "verifiedAt": "2026-05-03"
+    },
+    "10.48550/arXiv.2312.10997": {
+      "title": "Retrieval-Augmented Generation for Large Language Models: A Survey",
+      "year": 2023,
+      "firstAuthorSurname": "Gao",
       "source": "openalex",
       "verifiedAt": "2026-05-03"
     }

--- a/tests/unit/data/agentic-design-patterns/changelog.test.ts
+++ b/tests/unit/data/agentic-design-patterns/changelog.test.ts
@@ -7,8 +7,8 @@ describe('CHANGELOG', () => {
     expect(Array.isArray(CHANGELOG)).toBe(true)
   })
 
-  it('has exactly 1 entry in Phase 1 (the scaffold launch)', () => {
-    expect(CHANGELOG).toHaveLength(1)
+  it('has at least 1 entry (the Phase 1 scaffold launch is preserved)', () => {
+    expect(CHANGELOG.length).toBeGreaterThanOrEqual(1)
   })
 
   it('every entry has an ISO date', () => {
@@ -39,21 +39,27 @@ describe('CHANGELOG', () => {
     // T1 (#152) seeded the entry as '2026-05-02'. Per issue #158 step 6, the
     // entry's date is bumped to the Reflexion authoring date so lint-changelog's
     // "latest CHANGELOG date >= today" check passes alongside pattern.dateModified.
-    // The note text is preserved verbatim per #152's AC (asserted below).
-    expect(CHANGELOG[0].date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
-    expect(CHANGELOG[0].date >= '2026-05-02').toBe(true)
+    // The note text is preserved verbatim per #152's AC (asserted below). Phase 2
+    // prepends new entries, so we look up the seed entry by slug rather than index.
+    const seed = CHANGELOG.find((e) => e.slug === 'reflexion')
+    expect(seed).toBeDefined()
+    expect(seed!.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(seed!.date >= '2026-05-02').toBe(true)
   })
 
   it('Phase 1 seed entry slug is reflexion', () => {
-    expect(CHANGELOG[0].slug).toBe('reflexion')
+    const seed = CHANGELOG.find((e) => e.slug === 'reflexion')
+    expect(seed).toBeDefined()
   })
 
   it('Phase 1 seed entry type is added', () => {
-    expect(CHANGELOG[0].type).toBe('added')
+    const seed = CHANGELOG.find((e) => e.slug === 'reflexion')
+    expect(seed!.type).toBe('added')
   })
 
   it('Phase 1 seed entry note matches issue AC verbatim', () => {
-    expect(CHANGELOG[0].note).toBe(
+    const seed = CHANGELOG.find((e) => e.slug === 'reflexion')
+    expect(seed!.note).toBe(
       'Catalog scaffold launched; Reflexion exemplar shipped in #158.',
     )
   })


### PR DESCRIPTION
## Summary

Authors the **RAG** pattern (vanilla retrieve-and-generate; Layer 1 / single-agent topology). The agentic / iterative-retrieval variant remains a separate pattern (`agentic-rag`, wave 4).

Closes #176

- Three-paragraph `bodySummary` (283 words) frames RAG as a frozen LM bolted to an external store, names the load-bearing knobs (chunk size, embedding model, distance metric, reranker), and sets up the agentic variant as a separate pattern
- Original Mermaid flowchart of query -> embed -> index -> top-k -> augmented prompt -> generator
- ~15-line implementation sketch using `@ai-sdk/openai` (`embed` + `generateText`) with a `declare const store` stub vector-store interface; compiles under the lint chain
- Six references: Gao 2023 survey (foundational academic synthesis), Karpukhin 2020 DPR (the dense-retriever architecture), Petroni 2021 KILT (eval suite), Anthropic Contextual Retrieval (production essay), Gulli ch. 14, LangChain RAG tutorial
- Three real-world examples: Perplexity (consumer RAG with citations), Glean (enterprise permissions-aware RAG), Anthropic Contextual Retrieval writeup
- `readerGotcha` covers the chunk-context-stripping failure mode, cited from the Anthropic writeup
- `relatedSlugs` left empty per the issue (siblings are still stubs)
- `sdkAvailability: 'first-party-ts'`

### Notes for reviewer

- The Lewis et al. 2020 RAG paper has no DOI in Crossref / OpenAlex / Semantic Scholar (NeurIPS 2020 didn't mint one and arXiv didn't backfill the DataCite record), so `validate-references.ts` cannot verify it. The Gao et al. 2023 survey serves as the primary academic citation in its place; KILT (Petroni et al. 2021, NAACL) cites Lewis as its companion paper and has a working ACL DOI.
- The Phase 1 changelog tests assumed `CHANGELOG[0]` was the Reflexion seed entry. Phase 2 prepends new entries, so the seed-entry assertions are rewritten to look up the entry by slug.

## STYLE_PASS checklist

Pattern: rag

- [x] 3-7 references in `references[]`, each with required fields (6 entries)
- [x] All paper references have `doi`
- [x] All book references have `venue` and `pages`
- [x] All vendor doc references have `accessedAt`
- [x] `bodySummary` prose is original — not a paraphrase of any single source (`pnpm exec tsx scripts/check-pattern-overlap.ts`: no overlapping pairs above threshold)
- [x] `whenToUse` bullets open with imperative verbs ("Apply when...", "Use where...", "Reach for it when...", "Prefer it when...")
- [x] `whenNotToUse` bullets open with conditional/noun-phrase openers ("When...", "Without...")
- [x] `realWorldExamples` entries cite real, verifiable public sources
- [x] `readerGotcha` cites a public source
- [x] `mermaidSource` uses labeled boxes only — no icon shortcodes
- [x] `implementationSketch` compiles against SDK types (`pnpm lint` passes)
- [x] No affiliate query params in any outbound URL (`check-affiliate-links: OK (checked 20 URLs)`)
- [x] `relatedSlugs` empty — all siblings are still stubs
- [x] `dateModified` is `'2026-05-03'` (literal)
- [x] `lastChangeNote` is a 1-line description of this PR's change

## Verification

- `pnpm typecheck` exits 0
- `pnpm lint` passes (`typecheck-sketches: OK (compiled 2)`, `validate-references: OK (papers=6, verified=6)`, `check-affiliate-links: OK (checked 20 URLs)`, `lint-changelog: OK`)
- `pnpm test:unit` 322/322 pass

## References

```
[paper]  Gao et al. (2023) — Retrieval-Augmented Generation for Large Language Models: A Survey
         arXiv:2312.10997. DOI: 10.48550/arXiv.2312.10997
         (taxonomy of naive, advanced, and modular RAG)

[paper]  Karpukhin et al. (2020) — Dense Passage Retrieval for Open-Domain Question Answering
         EMNLP 2020. DOI: 10.18653/v1/2020.emnlp-main.550
         (the dense-retriever architecture most production RAG stacks descend from)

[paper]  Petroni et al. (2021) — KILT: a Benchmark for Knowledge Intensive Language Tasks
         NAACL 2021. DOI: 10.18653/v1/2021.naacl-main.200
         (shared evaluation suite Lewis et al. introduced for RAG)

[essay]  Anthropic (2024) — Introducing Contextual Retrieval
         (production RAG variant that prepends chunk-level context before embedding)

[book]   Gulli, A. (2026) — Agentic Design Patterns, ch. 14: Knowledge Retrieval (RAG)
         Springer. pp. 277-320.

[docs]   LangChain team (2024) — Build a Retrieval Augmented Generation (RAG) App
         accessed 2026-05-03.
```

## Test plan

- [ ] `pnpm dev` and load `/agentic-design-patterns/rag` — confirm Mermaid diagram renders and Real-World Examples links resolve
- [ ] Confirm References section renders all six entries with correct type badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)