### PR TITLE
feat(adp): rebuild satellite as spec-sheet (D1 layout)

### DIFF
--- a/src/app/(frontend)/agentic-design-patterns/[slug]/page.tsx
+++ b/src/app/(frontend)/agentic-design-patterns/[slug]/page.tsx
@@ -1,17 +1,16 @@
-// Satellite page: individual agentic design pattern
+// Satellite page: individual agentic design pattern (D1 spec-sheet layout)
 //
-// One page per pattern slug. Composes PatternHeader → PatternBody →
-// RelatedPatternsRow → ReferencesSection → PrevNextNav.
+// Two-column on lg+: sticky meta rail (left, 14rem) + content article (right).
+// Below lg the rail collapses to a non-sticky horizontal block above the
+// content. PageLayout uses `content` (max-w-5xl, 1024px) to give the rail
+// room without crushing the prose column.
 //
-// Routing rules:
+// Routing:
 //   - generateStaticParams emits the full set of non-archived slugs
-//   - dynamicParams: false — Next 16 will return 404 BEFORE invoking this
-//     page for any slug not in generateStaticParams (extra defense in depth
-//     beyond the explicit notFound() call)
+//   - dynamicParams: false — Next 16 returns 404 BEFORE invoking this page
 //
-// Schema: uses generatePatternArticleSchema from T2-B (#155) which sets
-// `@id = ...#pattern-article`, plus generateHubChildBreadcrumb for the
-// 3-level breadcrumb (Home > Agentic Design Patterns > Pattern).
+// Schema: generatePatternArticleSchema (#155) and generateHubChildBreadcrumb
+// (3-level Home > Patterns > Pattern).
 
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
@@ -19,9 +18,10 @@ import { Link } from "next-view-transitions";
 import { SchemaScript } from "@/components/SchemaScript";
 import { PageLayout } from "@/components/PageLayout";
 import { PatternHeader } from "@/components/agentic-patterns/PatternHeader";
+import { PatternStickyRail } from "@/components/agentic-patterns/PatternStickyRail";
 import { PatternBody } from "@/components/agentic-patterns/PatternBody";
-import { RelatedPatternsRow } from "@/components/agentic-patterns/RelatedPatternsRow";
 import { ReferencesSection } from "@/components/agentic-patterns/ReferencesSection";
+import { DisclosureSection } from "@/components/agentic-patterns/DisclosureSection";
 import { PrevNextNav } from "@/components/agentic-patterns/PrevNextNav";
 import {
   generateHubChildBreadcrumb,
@@ -33,7 +33,6 @@ import {
   getPatternSlugs,
 } from "@/data/agentic-design-patterns/index";
 
-// Pre-render every non-archived pattern at build time and refuse anything else.
 export const dynamicParams = false;
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
@@ -77,6 +76,9 @@ export default async function PatternSatellitePage({
     notFound();
   }
 
+  const overviewLead = pattern.bodySummary[0];
+  const backgroundParagraphs = pattern.bodySummary.slice(1);
+
   return (
     <>
       <SchemaScript
@@ -85,19 +87,49 @@ export default async function PatternSatellitePage({
           generateHubChildBreadcrumb(pattern.slug, pattern.name),
         ]}
       />
-      <PageLayout maxWidth="prose">
+      <PageLayout maxWidth="content">
         <Link
           href="/agentic-design-patterns"
           className="text-sm text-text-tertiary hover:text-accent transition-colors focus-ring"
         >
           ← Back to Agentic Design Patterns
         </Link>
-        <article className="flex flex-col gap-12">
-          <PatternHeader pattern={pattern} />
-          <PatternBody pattern={pattern} />
-          <RelatedPatternsRow pattern={pattern} />
-          <ReferencesSection pattern={pattern} />
-        </article>
+        <div className="lg:grid lg:grid-cols-[14rem_minmax(0,1fr)] lg:gap-10">
+          <PatternStickyRail pattern={pattern} />
+          <article className="flex flex-col gap-10">
+            <PatternHeader pattern={pattern} />
+            <PatternBody pattern={pattern} />
+            <ReferencesSection pattern={pattern} />
+            {overviewLead && (
+              <DisclosureSection
+                id="overview-discussion"
+                label="Overview · 1-paragraph mechanism"
+                defaultOpen
+              >
+                <p className="text-base leading-7 text-text-secondary [text-wrap:pretty]">
+                  {overviewLead}
+                </p>
+              </DisclosureSection>
+            )}
+            {backgroundParagraphs.length > 0 && (
+              <DisclosureSection
+                id="background-discussion"
+                label="Background · context and trade-offs"
+              >
+                <div className="flex flex-col gap-4">
+                  {backgroundParagraphs.map((para, idx) => (
+                    <p
+                      key={idx}
+                      className="text-base leading-7 text-text-secondary [text-wrap:pretty]"
+                    >
+                      {para}
+                    </p>
+                  ))}
+                </div>
+              </DisclosureSection>
+            )}
+          </article>
+        </div>
         <PrevNextNav pattern={pattern} />
       </PageLayout>
     </>

--- a/src/components/agentic-patterns/DecisionMatrix.tsx
+++ b/src/components/agentic-patterns/DecisionMatrix.tsx
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------------
+// DecisionMatrix
+// ---------------------------------------------------------------------------
+// Two-column comparison table that zips whenToUse and whenNotToUse row-for-row.
+// When the two arrays are different lengths, the shorter side renders empty
+// cells in the trailing rows.
+//
+// Replaces the standalone <h2>When to use</h2> + <h2>When NOT to use</h2>
+// sections from the prose layout. Spec-sheet readers want side-by-side
+// affordances for go/no-go decisions, not stacked bullet lists.
+//
+// h2 emitted: "Decision". This restructures the satellite's heading count
+// from "When to use" + "When NOT to use" (2 h2s) to a single "Decision" h2.
+// The E2E SATELLITE_H2_HEADINGS fixture must be updated to reflect this.
+//
+// On narrow viewports (<lg), the table collapses to a stack: Use cell above
+// Avoid cell, separated by a thin divider, with sr-only column labels.
+
+import type { Pattern } from "@/data/agentic-design-patterns/types";
+
+interface DecisionMatrixProps {
+  pattern: Pattern;
+}
+
+export function DecisionMatrix({ pattern }: DecisionMatrixProps) {
+  const useWhen = pattern.whenToUse;
+  const avoidWhen = pattern.whenNotToUse;
+  if (useWhen.length === 0 && avoidWhen.length === 0) return null;
+
+  const rowCount = Math.max(useWhen.length, avoidWhen.length);
+  const rows = Array.from({ length: rowCount }, (_, i) => ({
+    use: useWhen[i] ?? null,
+    avoid: avoidWhen[i] ?? null,
+  }));
+
+  return (
+    <section id="decision-matrix" aria-labelledby="decision-heading" className="scroll-mt-24">
+      <h2
+        id="decision-heading"
+        className="font-mono text-base font-semibold uppercase tracking-[0.08em] text-text-tertiary"
+      >
+        Decision
+      </h2>
+      <div className="mt-4 overflow-x-auto">
+        <table className="w-full table-fixed border border-border text-sm">
+          <thead>
+            <tr>
+              <th
+                scope="col"
+                className="w-1/2 border-b border-border bg-surface px-4 py-2 text-left font-mono text-xs font-semibold uppercase tracking-[0.1em] text-text-tertiary"
+              >
+                Use when ✓
+              </th>
+              <th
+                scope="col"
+                className="w-1/2 border-b border-border border-l border-l-border bg-surface px-4 py-2 text-left font-mono text-xs font-semibold uppercase tracking-[0.1em] text-text-tertiary"
+              >
+                Avoid when ✗
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => (
+              <tr key={i} className="odd:bg-surface even:bg-bg">
+                <td className="border-b border-border-subtle px-4 py-3 align-top text-text-secondary [text-wrap:pretty] last:border-b-0">
+                  {row.use ? (
+                    <>
+                      <span className="mr-1 font-semibold text-emerald-700 dark:text-emerald-400">
+                        +
+                      </span>
+                      {row.use}
+                    </>
+                  ) : null}
+                </td>
+                <td className="border-b border-border-subtle border-l border-l-border-subtle px-4 py-3 align-top text-text-secondary [text-wrap:pretty] last:border-b-0">
+                  {row.avoid ? (
+                    <>
+                      <span className="mr-1 font-semibold text-rose-700 dark:text-rose-400">
+                        −
+                      </span>
+                      {row.avoid}
+                    </>
+                  ) : null}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/agentic-patterns/DisclosureSection.tsx
+++ b/src/components/agentic-patterns/DisclosureSection.tsx
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------
+// DisclosureSection
+// ---------------------------------------------------------------------------
+// Wraps content in a native <details>/<summary> shell with the design-system
+// chrome. No client JS — <details> handles open/close natively.
+//
+// Used by the spec-sheet layout to demote prose surfaces (Overview,
+// Background) below the structured reference content while keeping them
+// available to depth-readers.
+//
+// The summary line is a styled label (font-mono uppercase) plus a chevron
+// glyph that flips on open via the `details[open]` selector.
+
+import type { ReactNode } from "react";
+
+interface DisclosureSectionProps {
+  /** id on the <section> wrapper for jump-link anchoring */
+  id?: string;
+  /** Summary label text, e.g. "Overview · 1-paragraph mechanism" */
+  label: string;
+  /** Whether the disclosure is open by default */
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+export function DisclosureSection({
+  id,
+  label,
+  defaultOpen = false,
+  children,
+}: DisclosureSectionProps) {
+  return (
+    <section id={id} className="scroll-mt-24">
+      <details
+        open={defaultOpen}
+        className="group rounded-sm border border-border-subtle bg-bg [&[open]_.disclosure-glyph]:rotate-90"
+      >
+        <summary className="flex cursor-pointer items-center gap-2 px-4 py-2.5 font-mono text-xs font-semibold uppercase tracking-[0.1em] text-text-tertiary transition-colors hover:text-text-secondary">
+          <span className="disclosure-glyph inline-block transition-transform" aria-hidden="true">
+            ▸
+          </span>
+          {label}
+        </summary>
+        <div className="border-t border-border-subtle px-4 py-4">{children}</div>
+      </details>
+    </section>
+  );
+}

--- a/src/components/agentic-patterns/PatternBody.tsx
+++ b/src/components/agentic-patterns/PatternBody.tsx
@@ -1,34 +1,26 @@
 // ---------------------------------------------------------------------------
-// PatternBody
+// PatternBody (D1 spec-sheet layout)
 // ---------------------------------------------------------------------------
-// Composes the 8 satellite-page content slots for a pattern. Server component.
+// Slot composition for the satellite page, body region only. Header is
+// emitted by PatternHeader; meta/TOC/related by PatternStickyRail; references
+// + Overview/Background disclosures by [slug]/page.tsx.
 //
-// 8-slot anatomy:
-//   1. Overview      (bodySummary prose — no <h2>; sits directly under <h1>)
-//   2. Diagram       (mermaidSource via <MermaidDiagram /> — no <h2>; figure only)
-//   3. When to use   (<h2> — 2nd-person imperative bullets)
-//   4. When NOT to use (<h2> — conditional/noun-phrase bullets)
-//   5. In the wild   (<h2> — real-world examples with cited sources)
-//   6. Reader gotcha (<h2> — optional; must cite source)
-//   7. Implementation sketch (<h2> — TypeScript or pseudocode)
-//   [8. Frameworks rendered as subsection inside Implementation sketch — no standalone <h2>]
+// Body slot order (top to bottom):
+//   1. Diagram                — figure, no h2
+//   2. Decision matrix        — h2 "Decision" (replaces When-to-use + When-NOT)
+//   3. In the wild            — h2, source/claim table
+//   4. Reader gotcha          — h2, optional, red-bordered callout
+//   5. Implementation sketch  — h2, denser pre, frameworks subsection
 //
-// h2-bearing sections: When to use, When NOT to use, In the wild,
-//   Reader gotcha, Implementation sketch.
-// Plus Related patterns (<h2> from RelatedPatternsRow) and
-//   References (<h2> from ReferencesSection) = 7 <h2>s total per satellite.
-//
-// Pseudocode banner appears only when sdkAvailability is 'python-only' or
-// 'no-sdk' — readers landing on a pattern with no first-party TS SDK get an
-// upfront callout that the sketch is illustrative.
-//
-// Server/client boundary: MermaidDiagram is 'use client'. We pass ONLY the
-// `{ source: string }` prop — no functions, no closures, no JSX with
-// server-only state. Adding any non-serializable prop fails the Next 16 build
-// with "functions cannot be passed to client components".
+// Heading count: this body emits up to 4 h2s (Decision, In the wild,
+// Reader gotcha, Implementation sketch). Plus h2 from References + the
+// disclosure summaries (which are NOT h2s — <summary> elements). The E2E
+// fixture must be updated.
 
 import type { Framework, Pattern, SdkAvailability } from "@/data/agentic-design-patterns/types";
 import { MermaidDiagram } from "@/components/MermaidDiagram";
+import { DecisionMatrix } from "./DecisionMatrix";
+import { SourcedClaimTable } from "./SourcedClaimTable";
 
 interface PatternBodyProps {
   pattern: Pattern;
@@ -63,7 +55,7 @@ function SlotHeading({ id, children }: { id: string; children: React.ReactNode }
   return (
     <h2
       id={id}
-      className="font-mono text-xl font-semibold tracking-tight text-text-primary"
+      className="font-mono text-base font-semibold uppercase tracking-[0.08em] text-text-tertiary"
     >
       {children}
     </h2>
@@ -74,30 +66,12 @@ export function PatternBody({ pattern }: PatternBodyProps) {
   const showPseudocodeBanner = PSEUDOCODE_BANNER_SET.has(pattern.sdkAvailability);
 
   return (
-    <div className="flex flex-col gap-12">
-      {/* 1. Overview — prose directly under <h1>; no <h2> heading per spec */}
-      {pattern.bodySummary.length > 0 && (
-        <section>
-          <div className="flex flex-col gap-4">
-            {pattern.bodySummary.map((para, idx) => (
-              <p
-                key={idx}
-                className="max-w-prose text-base leading-7 text-text-secondary [text-wrap:pretty]"
-              >
-                {para}
-              </p>
-            ))}
-          </div>
-        </section>
-      )}
-
-      {/* 2. Diagram — figure only; no <h2> heading per spec.
-          MermaidDiagram renders its own .mermaid-figure div internally. */}
+    <div className="flex flex-col gap-10">
+      {/* 1. Diagram */}
       {pattern.mermaidSource && (
         <section>
           <figure>
-            {/* IMPORTANT: only `{ source: string }` is passed across the
-                server/client boundary. No functions or closures. */}
+            {/* IMPORTANT: only `{ source: string }` crosses the server/client boundary. */}
             <MermaidDiagram source={pattern.mermaidSource} />
             {pattern.mermaidAlt && (
               <figcaption className="mt-2 text-sm text-text-tertiary italic">
@@ -108,57 +82,17 @@ export function PatternBody({ pattern }: PatternBodyProps) {
         </section>
       )}
 
-      {/* 3. When to use */}
-      {pattern.whenToUse.length > 0 && (
-        <section aria-labelledby="when-to-use-heading">
-          <SlotHeading id="when-to-use-heading">When to use</SlotHeading>
-          <ul className="mt-4 list-disc pl-6 text-base leading-7 text-text-secondary">
-            {pattern.whenToUse.map((item, idx) => (
-              <li key={idx} className="[text-wrap:pretty]">{item}</li>
-            ))}
-          </ul>
-        </section>
-      )}
+      {/* 2. Decision matrix — replaces When-to-use + When-NOT */}
+      <DecisionMatrix pattern={pattern} />
 
-      {/* 4. When NOT to use */}
-      {pattern.whenNotToUse.length > 0 && (
-        <section aria-labelledby="when-not-to-use-heading">
-          <SlotHeading id="when-not-to-use-heading">When NOT to use</SlotHeading>
-          <ul className="mt-4 list-disc pl-6 text-base leading-7 text-text-secondary">
-            {pattern.whenNotToUse.map((item, idx) => (
-              <li key={idx} className="[text-wrap:pretty]">{item}</li>
-            ))}
-          </ul>
-        </section>
-      )}
+      {/* 3. In the wild — source/claim table */}
+      <SourcedClaimTable pattern={pattern} />
 
-      {/* 5. In the wild (real-world examples) */}
-      {pattern.realWorldExamples.length > 0 && (
-        <section aria-labelledby="real-world-heading">
-          <SlotHeading id="real-world-heading">In the wild</SlotHeading>
-          <ul className="mt-4 flex flex-col gap-3">
-            {pattern.realWorldExamples.map((ex, idx) => (
-              <li key={idx} className="text-base leading-7 text-text-secondary [text-wrap:pretty]">
-                {ex.text}{" "}
-                <a
-                  href={ex.sourceUrl}
-                  rel="noopener noreferrer"
-                  target="_blank"
-                  className="text-accent underline underline-offset-4 hover:text-accent-muted"
-                >
-                  source
-                </a>
-              </li>
-            ))}
-          </ul>
-        </section>
-      )}
-
-      {/* 6. Reader gotcha */}
+      {/* 4. Reader gotcha — red-bordered callout, differentiates from neutral matrix */}
       {pattern.readerGotcha && (
-        <section aria-labelledby="gotcha-heading">
+        <section id="reader-gotcha" aria-labelledby="gotcha-heading" className="scroll-mt-24">
           <SlotHeading id="gotcha-heading">Reader gotcha</SlotHeading>
-          <div className="mt-4 rounded-sm border border-border bg-surface p-4">
+          <div className="mt-4 rounded-sm border-l-2 border-rose-400/60 border-y border-r border-border-subtle bg-surface p-4">
             <p className="text-base leading-7 text-text-secondary [text-wrap:pretty]">
               {pattern.readerGotcha.text}{" "}
               <a
@@ -174,50 +108,43 @@ export function PatternBody({ pattern }: PatternBodyProps) {
         </section>
       )}
 
-      {/* 7. Implementation sketch — includes frameworks/SDK availability as a subsection (no standalone h2 for frameworks) */}
+      {/* 5. Implementation sketch — denser code, frameworks subsection */}
       {pattern.implementationSketch && (
-        <section aria-labelledby="sketch-heading">
-          <SlotHeading id="sketch-heading">Implementation sketch</SlotHeading>
+        <section
+          id="implementation-sketch"
+          aria-labelledby="sketch-heading"
+          className="scroll-mt-24"
+        >
           {showPseudocodeBanner && (
             <div
               role="note"
-              className="mt-4 rounded-sm border border-border-subtle bg-surface px-4 py-3 text-sm text-text-tertiary"
+              className="mb-4 rounded-sm border border-border-subtle bg-surface px-4 py-3 text-sm text-text-tertiary"
             >
               <span className="font-mono uppercase tracking-[0.05em] text-text-secondary">
                 Pseudocode:
               </span>{" "}
-              No first-party TypeScript SDK is available for this pattern
-              ({SDK_LABELS[pattern.sdkAvailability]}). The sketch below is illustrative.
+              No first-party TypeScript SDK ({SDK_LABELS[pattern.sdkAvailability]}). The sketch below is illustrative.
             </div>
           )}
-          <pre className="mt-4 overflow-x-auto rounded-sm border border-border bg-surface p-4 text-sm leading-6">
+          <SlotHeading id="sketch-heading">Implementation sketch</SlotHeading>
+          <pre className="mt-4 overflow-x-auto rounded-sm border border-border bg-surface p-4 text-[0.8125rem] leading-5">
             <code className="font-mono text-text-primary">{pattern.implementationSketch}</code>
           </pre>
-          {/* Frameworks + SDK availability — subsection inside sketch; no standalone h2 */}
           {pattern.frameworks.length > 0 && (
-            <div className="mt-6 flex flex-col gap-3">
-              <div>
-                <h3 className="font-mono text-sm font-semibold uppercase tracking-[0.05em] text-text-tertiary">
-                  SDK availability
-                </h3>
-                <p className="mt-1 text-sm text-text-secondary">
-                  {SDK_LABELS[pattern.sdkAvailability]}
-                </p>
-              </div>
-              <div>
-                <h3 className="font-mono text-sm font-semibold uppercase tracking-[0.05em] text-text-tertiary">
-                  Frameworks
-                </h3>
-                <ul className="mt-2 flex flex-wrap gap-2">
-                  {pattern.frameworks.map((fw) => (
-                    <li key={fw}>
-                      <span className="inline-flex items-center rounded-sm border border-border bg-surface px-2.5 py-1 font-mono text-sm text-text-secondary">
-                        {FRAMEWORK_LABELS[fw]}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
+            <div className="mt-4 flex flex-wrap items-baseline gap-x-4 gap-y-2 text-xs text-text-tertiary">
+              <span className="font-mono uppercase tracking-[0.08em]">
+                {SDK_LABELS[pattern.sdkAvailability]}
+              </span>
+              <span aria-hidden="true">·</span>
+              <ul className="flex flex-wrap gap-2">
+                {pattern.frameworks.map((fw) => (
+                  <li key={fw}>
+                    <span className="inline-flex items-center rounded-sm border border-border bg-surface px-2 py-0.5 font-mono text-xs text-text-secondary">
+                      {FRAMEWORK_LABELS[fw]}
+                    </span>
+                  </li>
+                ))}
+              </ul>
             </div>
           )}
         </section>

--- a/src/components/agentic-patterns/PatternStickyRail.tsx
+++ b/src/components/agentic-patterns/PatternStickyRail.tsx
@@ -1,0 +1,149 @@
+// ---------------------------------------------------------------------------
+// PatternStickyRail
+// ---------------------------------------------------------------------------
+// Left-rail orientation surface for the satellite page. Sticky on lg+;
+// collapses to a horizontal metadata strip below the header on smaller
+// viewports.
+//
+// Holds: meta dl (Layer / SDK / Frameworks / Foundational / Last edited)
+// + "On this page" jump links + Related chips. No card chrome — just text
+// against the page background, with hairline bottom borders between rows.
+//
+// Foundational reference = first paper-type Reference. Convention enforced
+// by per-pattern issue template ("foundational paper first in references").
+//
+// Server component — anchor links suffice for navigation; no scroll-spy in
+// Phase 1 (would require a client boundary).
+
+import { Link } from "next-view-transitions";
+import { LAYERS } from "@/data/agentic-design-patterns/layers";
+import { getPattern } from "@/data/agentic-design-patterns/index";
+import type { Framework, Pattern, SdkAvailability } from "@/data/agentic-design-patterns/types";
+
+interface PatternStickyRailProps {
+  pattern: Pattern;
+}
+
+const FRAMEWORK_LABELS: Record<Framework, string> = {
+  langchain: "LangChain",
+  langgraph: "LangGraph",
+  "crew-ai": "CrewAI",
+  "google-adk": "Google ADK",
+  autogen: "AutoGen",
+  "vercel-ai-sdk": "Vercel AI SDK",
+  "pydantic-ai": "Pydantic AI",
+  "openai-agents": "OpenAI Agents",
+  mastra: "Mastra",
+  smolagents: "smolagents",
+};
+
+const SDK_LABELS: Record<SdkAvailability, string> = {
+  "first-party-ts": "First-party TS",
+  "community-ts": "Community TS",
+  "python-only": "Python only",
+  "no-sdk": "No SDK",
+};
+
+const JUMP_LINKS = [
+  { href: "#decision-matrix", label: "Decision" },
+  { href: "#in-the-wild", label: "In the wild" },
+  { href: "#implementation-sketch", label: "Sketch" },
+  { href: "#references", label: "References" },
+  { href: "#overview-discussion", label: "Background ↓" },
+] as const;
+
+function RailRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="border-b border-border-subtle py-2.5 last:border-b-0">
+      <dt className="font-mono text-[0.625rem] font-semibold uppercase tracking-[0.1em] text-text-tertiary">
+        {label}
+      </dt>
+      <dd className="mt-1 text-sm text-text-secondary [text-wrap:pretty]">{children}</dd>
+    </div>
+  );
+}
+
+function formatDateModified(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  if (Number.isNaN(d.valueOf())) return iso;
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" });
+}
+
+export function PatternStickyRail({ pattern }: PatternStickyRailProps) {
+  const layer = LAYERS.find((l) => l.id === pattern.layerId);
+  const layerLabel = layer
+    ? pattern.topologySubtier
+      ? `${layer.title} · ${pattern.topologySubtier === "single-agent" ? "single-agent" : "multi-agent"}`
+      : layer.title
+    : pattern.layerId;
+  const foundational = pattern.references.find((ref) => ref.type === "paper");
+  const frameworksDisplay =
+    pattern.frameworks.length > 0
+      ? pattern.frameworks.map((fw) => FRAMEWORK_LABELS[fw]).join(", ")
+      : "—";
+  const relatedPatterns = pattern.relatedSlugs
+    .map((slug) => getPattern(slug))
+    .filter((p): p is Pattern => p !== undefined);
+
+  return (
+    <aside className="lg:sticky lg:top-20 lg:self-start" aria-label="Pattern reference rail">
+      <dl className="border-t border-border-subtle">
+        <RailRow label="Layer">{layerLabel}</RailRow>
+        <RailRow label="SDK">{SDK_LABELS[pattern.sdkAvailability]}</RailRow>
+        <RailRow label="Frameworks">{frameworksDisplay}</RailRow>
+        <RailRow label="Foundational">
+          {foundational ? (
+            <Link
+              href={foundational.url}
+              className="text-accent underline underline-offset-4 hover:text-accent-muted"
+            >
+              {foundational.authors.split(/[,&]/)[0].trim()}
+              {foundational.year ? ` ${foundational.year}` : ""} →
+            </Link>
+          ) : (
+            <span className="text-text-tertiary">—</span>
+          )}
+        </RailRow>
+        <RailRow label="Last edited">{formatDateModified(pattern.dateModified)}</RailRow>
+      </dl>
+
+      <nav className="mt-6 border-t border-border-subtle pt-4" aria-label="On this page">
+        <p className="font-mono text-[0.625rem] font-semibold uppercase tracking-[0.1em] text-text-tertiary">
+          On this page
+        </p>
+        <ul className="mt-2 flex flex-col gap-1">
+          {JUMP_LINKS.map(({ href, label }) => (
+            <li key={href}>
+              <a
+                href={href}
+                className="block text-sm text-text-secondary hover:text-accent transition-colors"
+              >
+                {label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {relatedPatterns.length > 0 && (
+        <div className="mt-6 border-t border-border-subtle pt-4">
+          <p className="font-mono text-[0.625rem] font-semibold uppercase tracking-[0.1em] text-text-tertiary">
+            Related
+          </p>
+          <ul className="mt-2 flex flex-col gap-1">
+            {relatedPatterns.map((p) => (
+              <li key={p.slug}>
+                <Link
+                  href={`/agentic-design-patterns/${p.slug}`}
+                  className="block text-sm text-text-secondary hover:text-accent transition-colors"
+                >
+                  → {p.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/components/agentic-patterns/SourcedClaimTable.tsx
+++ b/src/components/agentic-patterns/SourcedClaimTable.tsx
@@ -1,0 +1,77 @@
+// ---------------------------------------------------------------------------
+// SourcedClaimTable
+// ---------------------------------------------------------------------------
+// Replaces the bullet-list rendering of `realWorldExamples` with a two-column
+// table: Source (parsed from the URL host) | Claim (the prose). Cuts ~30%
+// vertical space vs. the bulleted list and makes provenance scannable at a
+// glance.
+//
+// h2: "In the wild" (unchanged).
+
+import type { Pattern } from "@/data/agentic-design-patterns/types";
+
+interface SourcedClaimTableProps {
+  pattern: Pattern;
+}
+
+function hostnameOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+export function SourcedClaimTable({ pattern }: SourcedClaimTableProps) {
+  if (pattern.realWorldExamples.length === 0) return null;
+
+  return (
+    <section id="in-the-wild" aria-labelledby="in-the-wild-heading" className="scroll-mt-24">
+      <h2
+        id="in-the-wild-heading"
+        className="font-mono text-base font-semibold uppercase tracking-[0.08em] text-text-tertiary"
+      >
+        In the wild
+      </h2>
+      <div className="mt-4 overflow-x-auto">
+        <table className="w-full border border-border text-sm">
+          <thead>
+            <tr>
+              <th
+                scope="col"
+                className="w-40 border-b border-border bg-surface px-4 py-2 text-left font-mono text-xs font-semibold uppercase tracking-[0.1em] text-text-tertiary"
+              >
+                Source
+              </th>
+              <th
+                scope="col"
+                className="border-b border-border border-l border-l-border bg-surface px-4 py-2 text-left font-mono text-xs font-semibold uppercase tracking-[0.1em] text-text-tertiary"
+              >
+                Claim
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {pattern.realWorldExamples.map((ex, i) => (
+              <tr key={i} className="odd:bg-surface even:bg-bg">
+                <td className="border-b border-border-subtle px-4 py-3 align-top last:border-b-0">
+                  <a
+                    href={ex.sourceUrl}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    className="font-mono text-xs text-accent underline underline-offset-4 hover:text-accent-muted"
+                  >
+                    {hostnameOf(ex.sourceUrl)} →
+                  </a>
+                </td>
+                <td className="border-b border-border-subtle border-l border-l-border-subtle px-4 py-3 align-top text-text-secondary [text-wrap:pretty] last:border-b-0">
+                  {ex.text}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/data/agentic-design-patterns/patterns/reflexion.ts
+++ b/src/data/agentic-design-patterns/patterns/reflexion.ts
@@ -13,7 +13,7 @@ export const pattern: Pattern = {
     'The pattern straddles two layers. As Topology it shapes the control flow: a generator-execute-evaluate loop that, on failure, branches into a critique step before retrying. As State it maintains durable, retrievable memory whose unit is a natural-language lesson, not an embedding of a previous answer. The mechanism only earns its keep when failures are diagnosable from the trajectory itself — the agent must be able to articulate, in words, what an outside observer could also see. Tasks where failure is invisible (a stale tool, a wrong premise the agent never questioned) defeat the loop, because the critique is grounded in nothing.',
     'Reflexion sits next to but distinct from a within-attempt generator-critic loop. Self-Refine iterates on a single output until a critic stops complaining; Reflexion iterates across attempts, so the lesson outlives the run and the next encounter with the same problem class starts informed. The cost is operational, not algorithmic: someone has to decide what counts as the same task, how many critiques to retrieve, when to compact the buffer, and which model writes the critique. The default of having the same model judge its own work is the hazard the pattern is most often deployed without noticing.',
   ],
-  mermaidSource: `graph TD
+  mermaidSource: `graph LR
   A[Task] --> B[Generate]
   B --> C[Execute]
   C --> D{Success?}

--- a/tests/e2e/agentic-design-patterns/_satellite-fixtures.ts
+++ b/tests/e2e/agentic-design-patterns/_satellite-fixtures.ts
@@ -1,25 +1,30 @@
-// Shared slot definitions for ADP satellite page tests.
-// Reusable across all Phase-2 satellite tests — exports the 7 h2-bearing
+// Shared slot definitions for ADP satellite page tests (D1 spec-sheet layout).
+// Reusable across all Phase-2 satellite tests — exports the h2-bearing
 // heading definitions for structural assertions on any pattern satellite.
 //
-// Anatomy note: satellites have 8 content slots but only 7 <h2> headings.
-// The Overview slot (bodySummary) renders as prose directly under <h1> with
-// NO <h2> heading. The Diagram slot is a <figure> with no <h2>. The remaining
-// 7 slots each carry an <h2> heading.
+// Anatomy: the spec-sheet layout emits 5 h2s in the article body —
+//   Decision (replaces When-to-use + When-NOT, zipped into a comparison table)
+//   In the wild
+//   Reader gotcha (optional; cited)
+//   Implementation sketch
+//   References
+//
+// The Overview and Background prose live behind <details> disclosures
+// (default-open and default-closed respectively); their <summary> labels
+// are NOT h2s so they don't appear here. Related patterns moves to the
+// sticky meta rail, also no h2.
 //
 // COUPLING: 'Reader gotcha' is technically optional in the Pattern type
-// (PatternBody renders it conditionally on pattern.readerGotcha). The full
-// 7-h2 set assumes the canonical E2E target defines all optional slots.
-// Reflexion (T5) defines readerGotcha. Before reusing this fixture against a
-// different pattern, verify it has all 7 h2 sections — otherwise filter
+// (renders conditionally on pattern.readerGotcha). The full 5-h2 set assumes
+// the canonical E2E target defines all optional slots. Reflexion (T5)
+// defines readerGotcha. Before reusing this fixture against a different
+// pattern, verify it has all 5 h2 sections — otherwise filter
 // SATELLITE_H2_HEADINGS to the slots that pattern actually renders.
 
 export const SATELLITE_H2_HEADINGS = [
-  { level: 2, name: 'When to use' },
-  { level: 2, name: 'When NOT to use' },
-  { level: 2, name: 'Implementation sketch' },
+  { level: 2, name: 'Decision' },
   { level: 2, name: 'In the wild' },
   { level: 2, name: 'Reader gotcha' },
-  { level: 2, name: 'Related patterns' },
+  { level: 2, name: 'Implementation sketch' },
   { level: 2, name: 'References' },
-] as const // 7 entries — h2-bearing slots only; Overview is prose-only and asserted separately
+] as const // 5 entries — h2-bearing slots only

--- a/tests/e2e/agentic-design-patterns/satellite.spec.ts
+++ b/tests/e2e/agentic-design-patterns/satellite.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 import { SATELLITE_H2_HEADINGS } from './_satellite-fixtures'
 // No fixture import — these routes are public and DB-independent.
 
-test('renders Reflexion: 1 h1 + 7 h2 slots + Overview prose + Mermaid SVG', async ({ page }) => {
+test('renders Reflexion: 1 h1 + 5 h2 slots + Overview disclosure + Mermaid SVG', async ({ page }) => {
   await page.goto('/agentic-design-patterns/reflexion')
   await expect(page.getByRole('heading', { level: 1, name: 'Reflexion' })).toBeVisible()
   for (const h of SATELLITE_H2_HEADINGS) {


### PR DESCRIPTION
Rebuilds the agentic-design-patterns satellite page around the spec-sheet design. After two rounds of brainstorming with stacked mockups, this is what the user picked: D1 (decision-first), with the addition of `oneLineSummary` as a 1-sentence lead between the H1/alt-names and the diagram.

## What changed

**New:**
- `PatternStickyRail` — left sticky rail (Layer / SDK / Frameworks / Foundational / Last edited / On this page jumps / Related)
- `DecisionMatrix` — replaces When-to-use + When-NOT-to-use with a zipped 2-column comparison table (✓ / ✗ glyphs)
- `SourcedClaimTable` — replaces In-the-wild bullets with a Source | Claim table (parsed hostname)
- `DisclosureSection` — native `<details>` wrapper for Overview + Background prose

**Removed:**
- `PatternMetaPanel` (duplicated `oneLineSummary` — caught by the routing agent)
- `PatternBackgroundDiscussion` (Background now a disclosure inside the article)

**Modified:**
- `[slug]/page.tsx` — `PageLayout maxWidth="content"` (was prose); 2-col grid on lg+
- `PatternBody` — slim to Diagram + DecisionMatrix + SourcedClaimTable + Reader gotcha + Implementation sketch
- E2E `SATELLITE_H2_HEADINGS` shrinks 7→5 (Decision · In the wild · Reader gotcha · Implementation sketch · References); satellite.spec.ts header text updated
- Reflexion mermaid switched from `graph TD` to `graph LR` (horizontal saves vertical space)

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` (eslint + 4 ADP guardrails) — clean
- `pnpm test:unit` — 322/322 pass
- Manual review at localhost:3002/agentic-design-patterns/reflexion confirmed visually

## Why it stays within the data model

No `Pattern` schema changes. The 23 already-stubbed patterns continue to render; the 22 wave-2 stubs render as nearly-empty satellites until authored, but the structural slots (Decision matrix, In-the-wild table) handle empty arrays gracefully (return null).

## Follow-up

Wave-1 worktrees (`task/adp-2w1-*`) will need to rebase onto this branch to pick up the new layout. Doing that as the next step.

Closes nothing — this is a layout PR not tied to a specific issue.