### PR TITLE
fix(adp): wire rail jump links to existing anchor targets

### DIFF
--- a/src/components/agentic-patterns/PatternStickyRail.tsx
+++ b/src/components/agentic-patterns/PatternStickyRail.tsx
@@ -49,7 +49,7 @@ const JUMP_LINKS = [
   { href: "#in-the-wild", label: "In the wild" },
   { href: "#implementation-sketch", label: "Sketch" },
   { href: "#references", label: "References" },
-  { href: "#overview-discussion", label: "Background ↓" },
+  { href: "#background-discussion", label: "Background ↓" },
 ] as const;
 
 function RailRow({ label, children }: { label: string; children: React.ReactNode }) {

--- a/src/components/agentic-patterns/ReferencesSection.tsx
+++ b/src/components/agentic-patterns/ReferencesSection.tsx
@@ -88,7 +88,7 @@ export function ReferencesSection({ pattern }: ReferencesSectionProps) {
   }
 
   return (
-    <section aria-labelledby="references-heading">
+    <section id="references" aria-labelledby="references-heading" className="scroll-mt-24">
       <h2
         id="references-heading"
         className="font-mono text-xl font-semibold tracking-tight text-text-primary"


### PR DESCRIPTION
**Hotfix for two silently-broken jump links in the PatternStickyRail's \"On this page\" navigation.**

Reported by @julianken: clicking \"References\" in the sticky rail did nothing (looked broken). Reproduced with Playwright on \`/agentic-design-patterns/reflexion\` — root cause was a missing \`id\` attribute. While there, also caught a label-target mismatch on \"Background ↓\".

## Bug 1 — \`#references\` had no target

\`ReferencesSection.tsx\` had \`<section aria-labelledby=\"references-heading\">\` with the matching \`id\` on the \`<h2>\` heading. Per W3C, \`aria-labelledby\` doesn't make the section a navigation target — only an \`id\` attribute does. So clicking the rail's \`href=\"#references\"\` set the URL hash but the browser had nothing to scroll to.

Fix: \`<section id=\"references\" aria-labelledby=\"references-heading\" className=\"scroll-mt-24\">\`. Now matches the pattern used by the other 3 sections (Decision, In the wild, Implementation sketch) which all have both \`id\` and \`scroll-mt-24\`.

## Bug 2 — \"Background ↓\" jumped to Overview

\`PatternStickyRail.tsx:52\` had \`{ href: \"#overview-discussion\", label: \"Background ↓\" }\`. The Overview disclosure (default-open) has \`id=\"overview-discussion\"\`; the Background disclosure (default-closed) has \`id=\"background-discussion\"\`. Label-target mismatch from a copy-paste.

Fix: changed the \`href\` to \`#background-discussion\`.

## Verification

- Playwright reproduction: clicked References → URL goes to \`#references\`, page scrolls to References section, no console errors
- Playwright reproduction: clicked Background ↓ → URL goes to \`#background-discussion\`
- \`pnpm typecheck\` clean
- \`pnpm test:unit\` 322/322

Tracking the broader rail UX in the polish issue #219 (cross-link sweep, custom OG fonts, types.ts comment fix, Vercel preview audits).