### PR TITLE
chore(ci): add missing E2E shard contexts to .mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,3 +13,7 @@ queue_rules:
       - "check-success = Next.js Build"
       - "check-success = Analyze Bundle"
       - "check-success = CodeQL Analysis"
+      - "check-success = E2E Shard 1/4"
+      - "check-success = E2E Shard 2/4"
+      - "check-success = E2E Shard 3/4"
+      - "check-success = E2E Shard 4/4"


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    subgraph Before
        BP1[Branch Protection\n10 required contexts] -->|gate| PR[PR merge]
        MQ1[Mergify queue_conditions\n6 check-success lines] -->|gate| PR
        style MQ1 fill:#f99,stroke:#c00
    end
    subgraph After
        BP2[Branch Protection\n10 required contexts] -->|gate| PR2[PR merge]
        MQ2[Mergify queue_conditions\n10 check-success lines] -->|gate| PR2
        style MQ2 fill:#9f9,stroke:#090
    end
```

The gap is closed: Mergify now requires all 10 contexts that branch protection requires.

## Summary

- `.mergify.yml`'s `queue_conditions` block listed only 6 of the 10 contexts in branch protection — missing `E2E Shard 1/4` through `E2E Shard 4/4`.
- A PR with a failing E2E shard could satisfy Mergify's queue gate without passing all CI required by branch protection.
- Added the four missing `check-success` lines to close that latent gap.

## Screenshots

N/A — config-only diff.

## Test plan

- [x] DONE WHEN diff verified locally: `diff <(yq -r '.queue_rules[0].queue_conditions[]' .mergify.yml | grep '^check-success' | sort) <(gh api /repos/julianken/detached-node/branches/main/protection --jq '.required_status_checks.contexts[]' | sort | sed 's/^/check-success = /')` returned empty (zero lines).
- [ ] CI passes (ESLint, TypeScript, Vitest, Next.js Build, Analyze Bundle, CodeQL, E2E shards).

## Plan reference

Closes #225