### PR TITLE
fix(env): correct DATABASE_URL pooler comment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,11 @@
 # Supabase Postgres Configuration
 # Copy this file to .env.local and fill in the values
 
-# Supabase Postgres - Use Transaction Pooler (port 6543) for serverless/containerized deploys
-# Get your connection string from: Supabase Dashboard > Project Settings > Database > Connection string
-# Select "Transaction Pooler" mode for serverless compatibility
-DATABASE_URL=postgres://postgres.[PROJECT_REF]:[YOUR_PASSWORD]@aws-0-[REGION].pooler.supabase.com:6543/postgres
+# DATABASE_URL: Supabase Session Pooler (port 5432).
+# Required for Cloud Run + Payload migrations — Payload uses prepared statements
+# which the Transaction Pooler does not support.
+# Format: postgresql://postgres.<project-ref>:<password>@aws-0-<region>.pooler.supabase.com:5432/postgres
+DATABASE_URL=postgresql://postgres.[PROJECT_REF]:[YOUR_PASSWORD]@aws-0-[REGION].pooler.supabase.com:5432/postgres
 
 # Payload secret - Generate with: openssl rand -base64 32
 PAYLOAD_SECRET=your-32-char-or-longer-secret-here


### PR DESCRIPTION
## Summary

- Replaces Vercel-era Transaction Pooler (port 6543) guidance in `.env.example` with the correct Session Pooler (port 5432)
- Documents *why*: Payload uses prepared statements, which the Transaction Pooler does not support
- The example `DATABASE_URL` value now uses port 5432 and the `postgresql://` scheme consistent with Cloud Run usage

## Motivation

Drift audit 2026-05-04 (`nodes/05-infra-ci-build.json`, finding 1, BLOCKER). A new operator copying `.env.example` would mis-provision DB access by connecting to the wrong pooler mode, causing Payload migration failures on Cloud Run.

## Changes

- `.env.example` lines 4–8: replaced Transaction Pooler comment + example URL with Session Pooler equivalent

## Screenshots

N/A — text-only change.

## Plan reference

Closes #231