### PR TITLE
docs(agents): rewrite AGENTS.md against current state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,32 +1,64 @@
 # Repository Guidelines
 
-## Project Structure & Module Organization
-- Root planning docs: `PROJECT_BRIEF.md`, `CONTENT_MODEL.md`, `SITEMAP.md`.
-- App source: `src/app` (Next.js App Router).
+## Project Structure
+
+- Planning docs: `PROJECT_BRIEF.md`, `CONTENT_MODEL.md`, `SITEMAP.md`.
+- Reference docs: `docs/` (design system, deployment, testing guides).
+- App source: `src/app/` using Next.js App Router with two route groups:
+  - `(frontend)/` — public-facing blog pages.
+  - `(payload)/` — Payload CMS admin routes.
+- Components: `src/components/`.
 - Public assets: `public/`.
-- Keep new docs in the repository root unless a dedicated `docs/` folder is introduced.
 
 ## Build, Test, and Development Commands
-- `npm install` installs dependencies.
-- `npm run dev` starts the local dev server.
-- `npm run build` creates the production build.
-- `npm run start` serves the production build.
-- `npm run lint` runs Next.js linting.
+
+```
+pnpm install          # Install dependencies
+pnpm dev              # Start local dev server (localhost:3000)
+pnpm build            # Production build
+pnpm typecheck        # TypeScript type-check (no emit)
+pnpm lint             # ESLint + ADP validation scripts
+pnpm test:unit        # Run Vitest unit tests (once)
+pnpm test:unit:watch  # Run Vitest in watch mode
+pnpm test:e2e         # Run Playwright end-to-end tests
+```
 
 ## Coding Style & Naming Conventions
-- Use TypeScript for application code once the app is scaffolded.
-- Favor `kebab-case` for file names (e.g., `post-list.tsx`) and `PascalCase` for React components.
-- Keep indentation at 2 spaces for JSON/Markdown; follow default formatter rules once added.
 
-## Testing Guidelines
-- No tests are configured yet.
-- When tests are added, document the framework and command in `README.md` and align file naming with the framework defaults (e.g., `*.test.ts`).
+- TypeScript strict mode is canonical; see `tsconfig.json`.
+- File names: `kebab-case` (e.g., `post-list.tsx`).
+- Component names: `PascalCase`.
+- Indentation: 2 spaces.
+- Tailwind utility classes only; avoid inline styles.
+
+## Testing
+
+- Unit tests: Vitest + Testing Library (`*.test.ts` / `*.test.tsx`).
+- E2E tests: Playwright (`tests/` directory).
+- Run `pnpm test:unit` and `pnpm test:e2e` before opening a PR.
 
 ## Commit & Pull Request Guidelines
-- No commit conventions are established in this repository yet.
-- Suggested default: short, imperative commit messages (e.g., `Add initial Next.js scaffold`).
-- PRs should include a brief summary, testing notes, and screenshots for UI changes.
 
-## Security & Configuration Tips
-- Keep secrets out of the repo; use `.env.local` once the app exists.
-- If new config files are added, document required keys and defaults in `README.md`.
+This repo uses **conventional commits**. Active scopes:
+
+| Type        | When to use                              |
+|-------------|------------------------------------------|
+| `feat`      | New feature                              |
+| `fix`       | Bug fix                                  |
+| `chore`     | Maintenance, tooling, config             |
+| `docs`      | Documentation only                       |
+| `ci`        | CI/CD pipeline changes                   |
+| `test`      | Adding or updating tests                 |
+| `build(deps)` | Dependency bumps                       |
+| `refactor`  | Code restructure without behavior change |
+| `perf`      | Performance improvement                  |
+| `design`    | Visual / aesthetic changes               |
+
+Format: `type(scope): short imperative sentence (#issue)`.
+
+PR descriptions: include a summary, test plan, and screenshots for UI changes. Screenshots go via GitHub user-attachments paste (not committed to the repo).
+
+## Security
+
+- Keep secrets out of the repo; use `.env.local` for local overrides.
+- Required environment variables are documented in `docs/deployment.md`.


### PR DESCRIPTION
## Summary

- Replaced all Phase-0 falsehoods: removed "no tests configured", "once the app is scaffolded", "dedicated docs/ folder" hedge, "no commit conventions", and `npm run` commands throughout.
- Documented actual project structure: `docs/` directory exists; `src/app/` has `(frontend)/` and `(payload)/` route groups.
- Updated commands to `pnpm` with full test surface: `pnpm test:unit`, `pnpm test:e2e`, `pnpm typecheck`, `pnpm lint`.
- Documented Vitest + Playwright test stack.
- Added conventional commits table with all active scopes from `git log`.

## Onboarding flow

\`\`\`mermaid
flowchart LR
    A[New contributor] --> B[AGENTS.md\ncommands + conventions]
    B --> C[CLAUDE.md\narchitecture + design system]
    C --> D[docs/\ndeployment + design-system.md]
\`\`\`

## Test plan

- [x] \`grep -ciE 'no tests|once the app is scaffolded|dedicated docs/|no commit conventions|\bnpm run\b' AGENTS.md\` returns **0**
- [x] File mentions \`vitest\`, \`playwright\`, and \`conventional commits\`
- [x] \`wc -l AGENTS.md\` = 64 (≤ 70)
- [x] ESLint exits 0 on the file

## Screenshots

N/A — text-only contributor doc.

## References

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)