### PR TITLE
fix(ci): run E2E on Mergify queue drafts to unblock merge queue

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -30,7 +30,7 @@ jobs:
     name: E2E Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: (github.event_name == 'pull_request' && github.event.pull_request.draft != true) || (github.event_name == 'workflow_dispatch' && github.event.inputs.test_pattern == '')
+    if: (github.event_name == 'pull_request' && (github.event.pull_request.draft != true || startsWith(github.event.pull_request.head.ref, 'mergify/merge-queue/'))) || (github.event_name == 'workflow_dispatch' && github.event.inputs.test_pattern == '')
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- PR #225 added `E2E Shard 1/4`–`4/4` as required `check-success` contexts in `.mergify.yml` and branch protection.
- Mergify's merge queue creates internal DRAFT PRs (head refs like `mergify/merge-queue/<hash>`) for speculative checks; the e2e job's `if:` clause blanket-skipped all drafts, so shards never ran, `check-success` never resolved, and the queue deadlocked — Wave 1 PRs #252–#259 are stuck.
- This PR widens the `if:` to carve out Mergify queue drafts, allowing their shards to run while still skipping regular user drafts.

## Deadlock diagram

```mermaid
flowchart TD
    A[PR queued via @mergifyio queue] --> B[Mergify creates speculative DRAFT PR\nhead: mergify/merge-queue/abc123]
    B --> C[e2e-tests workflow triggered]
    C --> D{if: draft != true?}
    D -- "draft=true → SKIP" --> E[E2E shards never run]
    E --> F[check-success: E2E Shard 1/4–4/4 never posts]
    F --> G[Mergify: required checks not satisfied]
    G --> H[Queue stuck — Wave 1 #252–#259 deadlocked]

    subgraph "After this PR"
        D2{if: draft != true\n|| startsWith head.ref\nmergify/merge-queue/?}
        D2 -- "Mergify draft → RUN" --> I[E2E shards execute]
        I --> J[check-success resolves]
        J --> K[Mergify auto-merges]
    end
```

## Test plan

- [ ] This PR is **admin-merged** (its own queue draft still uses the old workflow — bootstrapping problem).
- [ ] After merge, the next PR that goes through the queue will have a Mergify draft that hits the fixed `if:` and runs all four E2E shards.
- [ ] Confirm shards post `E2E Shard 1/4`–`4/4` green on the next queue draft's checks page.
- [ ] Verify regular user DRAFT PRs still skip E2E (head ref won't start with `mergify/merge-queue/`).

## Screenshots

N/A — workflow YAML only.

## Plan reference

Out of plan — workflow fix to unblock Wave 1 deadlock from drift-audit issues #225 + #252–#259.