### PR TITLE
fix(ci): run E2E on .md-only PRs to satisfy branch protection

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,8 +5,6 @@ on:
     branches: [main]
     types: [opened, synchronize, ready_for_review]
     paths-ignore:
-      - '**.md'
-      - 'LICENSE'
       - '.github/dependabot.yml'
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Problem

Branch protection requires all 4 E2E shard contexts (`E2E Shard 1/4` through `E2E Shard 4/4`) to pass before any PR can merge. The `e2e-tests.yml` workflow had a `paths-ignore` rule that skipped E2E entirely for `.md`-only PRs and `LICENSE` changes. This created a second Mergify deadlock: the E2E shards never ran, so their required contexts were never reported, so the PRs could never satisfy branch protection.

### Deadlock diagram

```mermaid
flowchart TD
    A[.md-only PR opened] --> B{e2e-tests.yml\npaths-ignore match?}
    B -->|Yes — **.md matched| C[E2E workflow skipped\nNo shard contexts reported]
    C --> D[Branch protection waits\nfor E2E Shard 1–4/4]
    D --> E[Contexts never arrive]
    E --> F[PR permanently blocked\ncannot enter Mergify queue]
```

### Resolution

```mermaid
flowchart TD
    A[.md-only PR opened] --> B{e2e-tests.yml\npaths-ignore match?}
    B -->|No — **.md removed| C[E2E workflow runs\nAll 4 shards execute]
    C --> D[Branch protection satisfied]
    D --> E[PR enters Mergify queue]
    E --> F[Auto-merged on green]
```

## Change

Removed `**.md` and `LICENSE` from `paths-ignore` in `.github/workflows/e2e-tests.yml`. `.github/dependabot.yml` remains excluded — dependabot config changes have no runtime impact.

**Diff summary:** 2 lines deleted from `paths-ignore`, nothing else touched.

## Affected PRs

This unblocks Wave 1 `.md-only` PRs currently deadlocked in Mergify:
- #254 #255 #256 #259

## Test plan

- [ ] This PR itself changes a workflow file (not `.md`), so `paths-ignore` does not apply — E2E shards will run on this PR's head commit
- [ ] Verify all 4 `E2E Shard N/4` contexts appear in the checks list for this PR
- [ ] After this merges (admin merge required — Mergify queue is blocked by the very deadlock this PR fixes), re-queue #254 #255 #256 #259 and confirm E2E runs on each
- [ ] Confirm `.github/dependabot.yml` changes still skip E2E (paths-ignore entry retained)

> **Admin merge note:** This PR must be merged by an admin bypassing the Mergify queue, because the queue itself is blocked by the `.md` deadlock this fix resolves. Once merged, the queue can be restarted normally.

## Plan reference

Out of plan — workflow fix to unblock Wave 1 `.md`-only PRs (#254 #255 #256 #259) per drift-audit issues #225 #229 #234 #236 #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)