### PR TITLE
chore(deps): group ai-sdk + gcp-actions in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,17 @@ updates:
         patterns:
           - "tailwindcss"
           - "@tailwindcss/*"
+      ai-sdk:
+        patterns:
+          - "ai"
+          - "@ai-sdk/*"
+      dom-testing:
+        patterns:
+          - "jsdom"
+          - "happy-dom"
+      types:
+        patterns:
+          - "@types/*"
     labels:
       - "dependencies"
 
@@ -35,6 +46,13 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    groups:
+      gcp-actions:
+        patterns:
+          - "google-github-actions/*"
+      actions-core:
+        patterns:
+          - "actions/*"
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## Summary

- Adds `ai-sdk` group to npm ecosystem covering `ai` and `@ai-sdk/*` — prevents type-clash failures from companion packages being bumped separately (#221, #223)
- Adds `dom-testing` group covering `jsdom` and `happy-dom`, and `types` group covering `@types/*`
- Adds `groups:` block to the `github-actions` ecosystem with `gcp-actions` (`google-github-actions/*`) and `actions-core` (`actions/*`)

## Grouping consolidation

```mermaid
graph LR
  subgraph Before
    A[ai PR] --- B[at-ai-sdk/openai PR]
    C[jsdom PR] --- D[happy-dom PR]
    E[google-github-actions/auth PR]
    F[google-github-actions/setup-gcloud PR]
    G[actions/checkout PR]
  end
  subgraph After
    H[ai-sdk group PR]
    I[dom-testing group PR]
    J[gcp-actions group PR]
    K[actions-core group PR]
  end
```

## Screenshots

N/A — config-only change.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` exits 0
- [x] `yq '.updates[0].groups | keys'` returns `ai-sdk`, `dom-testing`, `types` (plus existing groups)
- [x] `yq '.updates[1].groups | keys'` returns `gcp-actions`, `actions-core`
- [ ] After merge: close PRs #221 and #223 to let Dependabot recreate them as one grouped PR (`ai-sdk`)
- [ ] Within one Monday cycle: verify `gh pr list --label dependencies --state open --repo julianken/detached-node` shows at most 1 grouped PR per family

## References

Closes #235