### PR TITLE
docs(tests): document auth-state regeneration in global-setup.ts

### DIFF
--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -29,6 +29,7 @@ async function globalSetup(config: FullConfig) {
   // Set up authentication
   console.log('🔐 Setting up authentication...')
 
+  // tests/.auth/ is git-ignored; this fixture regenerates admin.json on every test run.
   // Ensure .auth directory exists
   const authDir = path.dirname(STORAGE_STATE)
   if (!fs.existsSync(authDir)) {


### PR DESCRIPTION
## Summary

- Adds a one-line comment in `tests/global-setup.ts` at the auth-state regeneration site clarifying that `tests/.auth/` is git-ignored and `admin.json` is regenerated on every test run.
- No functional changes; comment-only.
- Pre-flight confirmed: `git ls-files tests/.auth/` returns empty; `.gitignore:59` already contains `/tests/.auth/`.

## Motivation

Future readers who see a local `tests/.auth/admin.json` might assume it is repo state (a stale working-tree artifact caused confusion in drift audit `nodes/07-tests.json`). The comment prevents that misreading.

## Test plan

- [x] `grep -F 'tests/.auth/' tests/global-setup.ts` returns ≥1 line (DONE WHEN satisfied)
- [x] `pnpm typecheck` passes (clean exit, no errors)
- [x] No files changed other than `tests/global-setup.ts`

## Screenshots

N/A — comment-only change.

## References

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)