### PR TITLE
fix(scripts): correct validate-indexes.sql identifier casing

### DIFF
--- a/migrations/20260213_072000_add_composite_indexes.ts
+++ b/migrations/20260213_072000_add_composite_indexes.ts
@@ -6,21 +6,21 @@ import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
  * This migration adds composite indexes to optimize common query patterns:
  *
  * Posts Collection:
- * - idx_posts_status_publishedAt: Optimize queries filtering by status and sorting by date
- * - idx_posts_featured_status_publishedAt: Optimize featured post queries (partial index)
- * - idx_posts_status_updatedAt: Optimize sitemap generation and admin list views
+ * - idx_posts_status_published_at: Optimize queries filtering by status and sorting by date
+ * - idx_posts_featured_status_published_at: Optimize featured post queries (partial index)
+ * - idx_posts_status_updated_at: Optimize sitemap generation and admin list views
  *
  * Pages Collection:
- * - idx_pages_status_updatedAt: Optimize published page queries with date sorting
+ * - idx_pages_status_updated_at: Optimize published page queries with date sorting
  *
  * These indexes complement the existing single-column indexes on slug, status,
- * publishedAt, and featured fields defined in the collection configs.
+ * published_at, and featured fields defined in the collection configs.
  *
  * Query Patterns Optimized:
- * 1. getPublishedPosts(): WHERE status = 'published' ORDER BY publishedAt DESC
+ * 1. getPublishedPosts(): WHERE status = 'published' ORDER BY published_at DESC
  * 2. getFeaturedPosts(): WHERE featured = true AND status = 'published'
- * 3. getPublishedPages(): WHERE status = 'published' ORDER BY updatedAt DESC
- * 4. Sitemap generation: WHERE status = 'published' ORDER BY updatedAt DESC
+ * 3. getPublishedPages(): WHERE status = 'published' ORDER BY updated_at DESC
+ * 4. Sitemap generation: WHERE status = 'published' ORDER BY updated_at DESC
  *
  * Expected Performance Impact:
  * - 10-100x faster queries on large datasets (10k+ rows)
@@ -36,7 +36,7 @@ import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
  * Test query performance with:
  *   EXPLAIN ANALYZE SELECT * FROM posts
  *   WHERE status = 'published'
- *   ORDER BY "publishedAt" DESC;
+ *   ORDER BY "published_at" DESC;
  */
 
 export async function up({ db }: MigrateUpArgs): Promise<void> {

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -72,10 +72,10 @@ pnpm payload migrate:rollback
 
 # Manual rollback (if needed)
 psql $DATABASE_URL << 'EOF'
-DROP INDEX IF EXISTS idx_pages_status_updatedAt;
-DROP INDEX IF EXISTS idx_posts_status_updatedAt;
-DROP INDEX IF EXISTS idx_posts_featured_status_publishedAt;
-DROP INDEX IF EXISTS idx_posts_status_publishedAt;
+DROP INDEX IF EXISTS idx_pages_status_updated_at;
+DROP INDEX IF EXISTS idx_posts_status_updated_at;
+DROP INDEX IF EXISTS idx_posts_featured_status_published_at;
+DROP INDEX IF EXISTS idx_posts_status_published_at;
 EOF
 ```
 

--- a/scripts/validate-indexes.sql
+++ b/scripts/validate-indexes.sql
@@ -33,53 +33,53 @@ ORDER BY tablename, indexname;
 SELECT
   indexname,
   CASE
-    WHEN indexname = 'idx_posts_status_publishedAt' THEN 'Expected: posts(status, publishedAt DESC)'
-    WHEN indexname = 'idx_posts_featured_status_publishedAt' THEN 'Expected: posts(featured, status, publishedAt DESC) WHERE featured = true'
-    WHEN indexname = 'idx_posts_status_updatedAt' THEN 'Expected: posts(status, updatedAt DESC)'
-    WHEN indexname = 'idx_pages_status_updatedAt' THEN 'Expected: pages(status, updatedAt DESC)'
+    WHEN indexname = 'idx_posts_status_published_at' THEN 'Expected: posts(status, published_at DESC)'
+    WHEN indexname = 'idx_posts_featured_status_published_at' THEN 'Expected: posts(featured, status, published_at DESC) WHERE featured = true'
+    WHEN indexname = 'idx_posts_status_updated_at' THEN 'Expected: posts(status, updated_at DESC)'
+    WHEN indexname = 'idx_pages_status_updated_at' THEN 'Expected: pages(status, updated_at DESC)'
     ELSE 'Other index'
   END AS expected_definition,
   indexdef AS actual_definition
 FROM pg_indexes
 WHERE indexname IN (
-  'idx_posts_status_publishedAt',
-  'idx_posts_featured_status_publishedAt',
-  'idx_posts_status_updatedAt',
-  'idx_pages_status_updatedAt'
+  'idx_posts_status_published_at',
+  'idx_posts_featured_status_published_at',
+  'idx_posts_status_updated_at',
+  'idx_pages_status_updated_at'
 );
 
 -- ==========================================
 -- 4. Test Query Plans - Published Posts
 -- ==========================================
--- This should use idx_posts_status_publishedAt
+-- This should use idx_posts_status_published_at
 EXPLAIN ANALYZE
 SELECT *
 FROM posts
 WHERE status = 'published'
-ORDER BY "publishedAt" DESC
+ORDER BY "published_at" DESC
 LIMIT 50;
 
 -- ==========================================
 -- 5. Test Query Plans - Featured Posts
 -- ==========================================
--- This should use idx_posts_featured_status_publishedAt
+-- This should use idx_posts_featured_status_published_at
 EXPLAIN ANALYZE
 SELECT *
 FROM posts
 WHERE featured = true
   AND status = 'published'
-ORDER BY "publishedAt" DESC
+ORDER BY "published_at" DESC
 LIMIT 3;
 
 -- ==========================================
 -- 6. Test Query Plans - Published Pages
 -- ==========================================
--- This should use idx_pages_status_updatedAt
+-- This should use idx_pages_status_updated_at
 EXPLAIN ANALYZE
 SELECT *
 FROM pages
 WHERE status = 'published'
-ORDER BY "updatedAt" DESC;
+ORDER BY "updated_at" DESC;
 
 -- ==========================================
 -- 7. Check for unused indexes
@@ -102,5 +102,5 @@ ORDER BY pg_relation_size(indexrelid) DESC;
 -- Section 1: Should show all indexes including the 4 new composite indexes
 -- Section 2: Should show index sizes (typically a few KB to MB depending on data volume)
 -- Section 3: Should return 4 rows confirming the composite indexes exist
--- Sections 4-6: Query plans should show "Index Scan using idx_..." or "Index Only Scan"
+-- Sections 4-6: Query plans should show "Index Scan using idx_posts_status_published_at" etc. or "Index Only Scan"
 -- Section 7: New indexes may show 0 scans initially - run again after traffic


### PR DESCRIPTION
## Summary

- Replace 4 camelCase index identifiers (`idx_posts_status_publishedAt`, `idx_posts_featured_status_publishedAt`, `idx_posts_status_updatedAt`, `idx_pages_status_updatedAt`) with their snake_case equivalents in `scripts/validate-indexes.sql` — these names never matched anything in a migrated DB, so the validation script always falsely reported all indexes missing.
- Fix 3 `ORDER BY` column refs in EXPLAIN ANALYZE blocks (`"publishedAt"` → `"published_at"`, `"updatedAt"` → `"updated_at"`) — the old refs caused `column "publishedAt" does not exist` errors before any index check could resolve.
- Fix 4 camelCase identifiers in the manual-rollback `DROP INDEX` block in `migrations/README.md` (the third drift site identified in cycle-2 expansion of issue #232).
- Sync the header docstring of `migrations/20260213_072000_add_composite_indexes.ts` to snake_case — migration body is untouched (N-1 contract lock).

## Validation flow

```mermaid
flowchart LR
    A[psql -f validate-indexes.sql] --> B{Section 3:\nindex name lookup}
    B -->|snake_case names match| C[4 rows returned]
    B -->|camelCase names — old| D[0 rows: false-negative]
    C --> E{Sections 4-6:\nEXPLAIN ANALYZE}
    E -->|published_at / updated_at| F[query plan shown]
    E -->|publishedAt / updatedAt — old| G[ERROR: column does not exist]
```

## Test plan

- [ ] `grep -F 'publishedAt' scripts/validate-indexes.sql migrations/README.md migrations/20260213_072000_add_composite_indexes.ts` returns 0 lines
- [ ] `grep -F 'updatedAt' scripts/validate-indexes.sql migrations/README.md migrations/20260213_072000_add_composite_indexes.ts` returns 0 lines
- [ ] All 4 snake_case index names present across all 3 files (confirmed: 21 matches total)
- [ ] Migration body (`up()`/`down()` functions) is byte-for-byte unchanged — only the JSDoc comment block was edited

## Screenshots

N/A — SQL/comment fix

## Plan reference

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)