### PR TITLE
docs(brief): mark Phase 1 complete + state Phase 3 criteria

### DIFF
--- a/PROJECT_BRIEF.md
+++ b/PROJECT_BRIEF.md
@@ -4,15 +4,34 @@
 Create a tech blog exploring modern agentic AI workflows, autonomous systems, and the philosophy of machine intelligence. The site should have a distinctive editorial voice, a clear and repeatable content structure, be easy to publish to, easy to navigate, and ready for future customization.
 
 ## Audience
-Define during content planning. For Phase 1, assume a general reader and focus on clarity.
+AI engineers, agent-system practitioners, and technical readers exploring agentic AI workflows. Content assumes familiarity with software systems and an interest in how autonomous agents are designed, deployed, and reasoned about.
 
 ## Voice and Tone
-- To be defined with actual content.
+Writing on Detached Node is precise, analytical, and practitioner-facing. It prioritizes honest engagement with tradeoffs over promotional framing. For full editorial guidance, see the ADP style guide (SHA-pinned, survives `docs/` purge in #240):
+[`agentic-design-patterns-style-guide.md`](https://github.com/julianken/detached-node/blob/9ee44859dd28f345e804bca6a1b8916ff281cea9/docs/superpowers/specs/agentic-design-patterns-style-guide.md)
 
-## Success Criteria (Phase 1)
-- Live, deployed shell site with navigation and placeholder content.
-- Content model and site structure defined at a high level.
+## Phase Roadmap
 
-## Non-Goals (Phase 1)
-- Full authoring system.
-- Advanced search or personalization.
+### Phase 1 ✅ DONE
+Deployed shell site with navigation and placeholder content. Content model and site structure defined at a high level. Initial Vercel deployment, ESLint/TypeScript/Vitest CI, and Tailwind design system established.
+
+### Phase 2 ✅ DONE
+Full authoring and post pipeline shipped: Payload CMS with six collections (Posts, Listings, Pages, Tags, Media, Users), Lexical rich-text editor, Mermaid diagram support, ISR cache, preview pipeline, and ADP satellite posts (#152–#159) merged. Deployment migrated from Vercel to Google Cloud Run with Workload Identity Federation and Artifact Registry.
+
+### Phase 3 (current)
+Full aesthetic and interaction layer. Success criteria:
+- ADP series launch verified with live posts visible on the production site.
+- Interaction layer (post reactions, reading progress, or equivalent engagement surface) implemented and passing E2E.
+- Cloud Run preview environment audits clean (no stale ISR, no migration hangs).
+- Bundle size and Core Web Vitals baselines established and documented.
+- Design system finalized: dark/light parity, typography scale, and component library stable.
+
+### Phase 4
+MVP complete.
+
+## Non-Goals (current scope)
+- Social/community features (comments, user accounts, newsletters).
+- Advanced search or personalization beyond current tag filtering.
+- Native mobile app or PWA offline support.
+- Monetization or advertising infrastructure.
+- Support for non-English content.

--- a/PROJECT_BRIEF.md
+++ b/PROJECT_BRIEF.md
@@ -16,7 +16,7 @@ Writing on Detached Node is precise, analytical, and practitioner-facing. It pri
 Deployed shell site with navigation and placeholder content. Content model and site structure defined at a high level. Initial Vercel deployment, ESLint/TypeScript/Vitest CI, and Tailwind design system established.
 
 ### Phase 2 ✅ DONE
-Full authoring and post pipeline shipped: Payload CMS with six collections (Posts, Listings, Pages, Tags, Media, Users), Lexical rich-text editor, Mermaid diagram support, ISR cache, preview pipeline, and ADP satellite posts (#152–#159) merged. Deployment migrated from Vercel to Google Cloud Run with Workload Identity Federation and Artifact Registry.
+Full authoring and post pipeline shipped: Payload CMS with six collections (Posts, Listings, Pages, Tags, Media, Users), Lexical rich-text editor, Mermaid diagram support, ISR cache, preview pipeline, and ADP infrastructure shipped via PRs #162–#218 (Phase 1) plus #220 polish; 23 pattern satellites live at /agentic-design-patterns/. Deployment migrated from Vercel to Google Cloud Run with Workload Identity Federation and Artifact Registry.
 
 ### Phase 3 (current)
 Full aesthetic and interaction layer. Success criteria:


### PR DESCRIPTION
## Summary

- Marks Phase 1 and Phase 2 ✅ DONE with one-line summaries of what shipped in each phase
- States Phase 3 success criteria (5 bullets: ADP launch, interaction layer E2E, Cloud Run preview audits, bundle/CWV baselines, design system stability)
- Updates Audience to name AI engineers and agent-system practitioners explicitly
- Updates Voice section with SHA-pinned link to ADP editorial style guide at `9ee44859` (survives the `docs/` purge planned in #240)
- Removes "full authoring system" from Non-Goals (it shipped in Phase 2); refreshes non-goals list to reflect current scope

## Test plan

- [ ] `grep -E '✅ DONE|Phase 1.*\bDONE\b' PROJECT_BRIEF.md` returns ≥1 match
- [ ] `grep -E 'AI engineers|agent-system practitioners' PROJECT_BRIEF.md` returns ≥1 match
- [ ] `grep -A 3 'Phase 3' PROJECT_BRIEF.md | grep '^-' | head -1` returns a bullet
- [ ] `grep -F '9ee44859dd28f345e804bca6a1b8916ff281cea9' PROJECT_BRIEF.md` returns ≥1 match
- [ ] `grep -F 'full authoring system' PROJECT_BRIEF.md` returns 0 results

## Screenshots

N/A — text-only spec

## Notes

- Only `PROJECT_BRIEF.md` is touched; CLAUDE.md phase updates are handled by #228 (already merged)
- SHA pin strategy per issue: `docs/` is being purged in a later wave (#240), so we link by commit SHA rather than tree path

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)