### PR TITLE
refactor(agentic-patterns): remove REFS · N corner labels (#295)

### DIFF
--- a/src/components/agentic-patterns/PatternCard.tsx
+++ b/src/components/agentic-patterns/PatternCard.tsx
@@ -8,14 +8,13 @@
 // - Heading className matches PostCard verbatim — including font-mono, the
 //   text-wrap and tracking tokens. Without font-mono the title falls back to
 //   the body serif and breaks visual parity with PostCard.
-// - Layer/refs corner uses the frame-label utility (NOT inline span styling).
 //
 // Heading level is configurable: <h3> when the card sits under a flat layer
 // section (parent <h2>), <h4> when under a topology sub-tier (parent <h3>).
 //
-// v1: chip styling duplicated across components (frame-label, framework chips,
-// related chips, reference type badges). Acceptable as v1 — future refactor
-// extracts a <Chip> primitive.
+// v1: chip styling duplicated across components (framework chips, related
+// chips, reference type badges). Acceptable as v1 — future refactor extracts
+// a <Chip> primitive.
 
 import { Link } from "next-view-transitions";
 import type { Pattern } from "@/data/agentic-design-patterns/types";
@@ -30,20 +29,12 @@ interface PatternCardProps {
 export function PatternCard({ pattern, headingLevel }: PatternCardProps) {
   const Heading = headingLevel === 3 ? "h3" : "h4";
   const href = `/agentic-design-patterns/${pattern.slug}`;
-  const refsCount = pattern.references.length;
-  // Corner label: "REFS · N" tells the reader at a glance how grounded the
-  // pattern is. Empty references render the pattern name itself as fallback
-  // (avoids rendering "REFS · 0" which reads as a defect).
-  const cornerLabel = refsCount > 0 ? `REFS · ${refsCount}` : pattern.name.toUpperCase();
 
   return (
     <Link
       href={href}
       className="group card-trace card-scanline relative block rounded-sm border border-border bg-surface p-6 transition-colors hover:border-border-hover hover:bg-hover-bg hover:shadow-sm focus-ring"
     >
-      <span className="frame-label" aria-hidden="true">
-        {cornerLabel}
-      </span>
       <Heading className="font-mono text-lg font-semibold tracking-tight text-text-primary [text-wrap:balance]">
         {pattern.name}
       </Heading>


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TB
    subgraph before["PatternCard — before"]
        L1["&lt;Link&gt;"]
        L1 --> S["&lt;span class=frame-label&gt;<br/>REFS · N <i>(or pattern.name fallback)</i>"]
        L1 --> H1["&lt;Heading&gt; pattern.name"]
        L1 --> P1["&lt;p&gt; oneLineSummary"]
        L1 --> A1["&lt;p&gt; Open pattern →"]
    end

    subgraph after["PatternCard — after"]
        L2["&lt;Link&gt;"]
        L2 --> H2["&lt;Heading&gt; pattern.name"]
        L2 --> P2["&lt;p&gt; oneLineSummary"]
        L2 --> A2["&lt;p&gt; Open pattern →"]
    end

    style S stroke:#c33,fill:#fee,stroke-dasharray: 4 2
```

The `<span>` carrying the leaked metric is removed. The card's other children, the `.frame-label` CSS utility, and the `Pattern.references` data model are untouched.

## Summary

- Removes the `REFS · N` corner label from `PatternCard`. The label exposed an authoring-internal metric (count of `pattern.references`) that didn't help readers scanning the grid and risked implying that pattern value scales with citation count (per #295).
- Preserves the `.frame-label` CSS class (still consumed by `PostCard.tsx:32`) and `Pattern.references` (still used by the pattern detail page). The change is purely a visual deletion on the hub grid; no behavior or data shape changes.

## Screenshots

**Pending upload via paste flow** — the controlled browser session this implementer ran in was blocked from GitHub login by anti-automation, so the user-attachments paste flow couldn't run (see the `pr-screenshots-via-user-attachments` skill, which assumes a pre-existing logged-in session). Local PNGs are staged at `.playwright-mcp/refs-after-desktop.png` (1280×900) and `.playwright-mcp/refs-after-mobile-cards.png` (390×844, scrolled to the Single-agent card grid).

Machine-grade verification of the visual change is below.

```
# This branch (after the deletion):
$ curl -s http://localhost:3000/agentic-design-patterns | grep -oE 'REFS\s*·\s*[0-9]+' | sort -u
(empty — no REFS · N strings on the rendered page)

$ curl -s http://localhost:3000/agentic-design-patterns | grep -oE 'class="[^"]*frame-label[^"]*"' | sort -u
(empty — no frame-label spans on this page)

# Sanity: pattern headings still render
$ curl -s http://localhost:3000/agentic-design-patterns | grep -oE '<h4[^>]*>[^<]+</h4>' | head -3
<h4 ...>Prompt Chaining</h4>
<h4 ...>Routing</h4>
<h4 ...>Parallelization</h4>
```

The corner where the label sat shows no orphan gap in either viewport — the heading starts cleanly at the card's `p-6` padding edge.

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — 0 errors, 18 pre-existing warnings (unrelated test/e2e files)
- [x] `pnpm test:unit` — 322/322 passing across 30 files (no regression from `origin/main`)
- [x] Browser drive (`pnpm dev` + Playwright) at desktop (1280×900) and mobile (390×844) — cards render correctly, no orphan gap where the label sat, `card-trace`/`card-scanline` chrome intact on hover
- [x] HTML-grep cross-check: `REFS · N` strings absent on `/agentic-design-patterns`; `frame-label` spans absent on that page; pattern headings still rendered
- [ ] Production `pnpm build` — deferred to CI's "Next.js Build" check (typecheck covered the TS surface locally)

## Plan reference

Closes #295. Out of plan — the issue itself is the unit of work; no `docs/plans/` task. The "Things to check" notes from #295 (frame chrome, frame-label utility lifetime, fallback path) are all resolved: chrome unaffected, CSS class kept alive by `PostCard`, fallback path collapsed away with the label as expected.