### PR TITLE
fix(ci): remove paths-ignore from E2E workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, ready_for_review]
-    paths-ignore:
-      - '.github/dependabot.yml'
   workflow_dispatch:
     inputs:
       test_pattern:


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  A[PR with config-only diff] --> B{paths-ignore matches?}
  B -- yes --> C[Workflow SKIPPED]
  C --> D[No E2E Shard 1/4..4/4 check-runs]
  D --> E[Branch protection BLOCKED forever]
  B -- no after fix --> F[E2E runs]
  F --> G[Shards SUCCESS]
  G --> H[Branch protection satisfied]
```

## Summary

- E2E workflow's `paths-ignore: ['.github/dependabot.yml']` skips the workflow entirely for dependabot.yml-only PRs.
- Branch protection still requires the 4 E2E Shard contexts.
- Result: deadlock — config-only PRs cannot satisfy required checks.
- Fix removes paths-ignore entirely. ~5min CI cost on the rare config-only PR; permanent unblock.

## Screenshots

N/A — workflow YAML only.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] PR head SHA's pull_request workflow run will produce all 4 E2E Shard contexts (this PR's own diff contains a workflow change, paths-ignore wouldn't have matched anyway — verifies the workflow definition still works)
- [ ] Post-merge: re-queue #268, verify it passes branch protection naturally

## Plan reference

Out of plan — unblocks #268 (issue #235); same admin-merge bootstrap as #260 and #263.