### PR TITLE
infra: pre-flight bridge execution — skill alignment + Mergify invariants

### DIFF
--- a/.claude/skills/analysis-funnel/SKILL.md
+++ b/.claude/skills/analysis-funnel/SKILL.md
@@ -94,7 +94,7 @@ Before running the funnel, gather these from the conversation or explicitly ask:
 
 If any of these are ambiguous, ask the user before starting Phase 0. Do not assume.
 
-**Data gathering before Phase 0.** Use available MCP servers to fill in gaps *before* framing, not during. Query issue trackers (Linear `mcp__linear-server__*`, GitHub Issues, Jira) for context, use codebase tools (e.g. `mcp__plugin_serena_serena__*`) to understand current state, and fetch library docs via Context7 (`mcp__plugin_context7_context7__*`) for any technology in scope. Grounding every phase in real data is the difference between an analysis and a plausible-sounding guess.
+**Data gathering before Phase 0.** Use available MCP servers to fill in gaps *before* framing, not during. Query the project's issue tracker (e.g., GitHub Issues via `gh issue list / view`) for context, use codebase tools (e.g. `mcp__plugin_serena_serena__*`) to understand current state, and fetch library docs via Context7 (`mcp__plugin_context7_context7__*`) for any technology in scope. Grounding every phase in real data is the difference between an analysis and a plausible-sounding guess.
 
 ---
 

--- a/.claude/skills/decision-funnel/SKILL.md
+++ b/.claude/skills/decision-funnel/SKILL.md
@@ -37,7 +37,7 @@ If you find yourself about to dispatch agents without having written the precedi
 
 **CRITICAL: Use MCP Servers for Data.** Throughout every phase, actively use available MCP servers to query for real data rather than relying on assumptions or stale knowledge. This includes but is not limited to:
 - **Context7** (`mcp__context7__*` / `mcp__plugin_context7_context7__*`) — Query up-to-date library documentation, API references, and code examples for any technology in the problem space. Use this before making claims about how a library or framework works.
-- **Issue tracker** (e.g., `mcp__linear-server__*`) — Read issue descriptions, acceptance criteria, comments, and linked context. Never fabricate issue details.
+- **Issue tracker** (e.g., GitHub Issues via `gh issue list / view`) — Read issue descriptions, acceptance criteria, comments, and linked context. Never fabricate issue details.
 - **Codebase tools** (e.g., `mcp__plugin_serena_serena__*`) — Use symbolic code analysis tools to understand existing architecture, find symbols, trace references, and read implementations. Prefer these over reading entire files.
 - **Browser/Playwright** (e.g., `mcp__playwright__*`) — Validate UI assumptions by actually looking at the current state of the application during investigation phases, not just during execution.
 - **Any other available MCP servers** — Check what's available and use them when they provide relevant data for the problem at hand.
@@ -356,7 +356,7 @@ Ordered list of what gets built/changed and in what order. Include dependency ar
 
 #### D.3) Work Unit Specs
 
-Define the units of work that the orchestration workflow will turn into real tickets (in Linear, GitHub Issues, or whatever tracker the project uses). **This skill does NOT create tickets** — it produces specs. The orchestration workflow (e.g., `Skill(subagent-workflow)`) is responsible for creating actual tickets, assigning them, and tracking their state.
+Define the units of work that the orchestration workflow will turn into real GitHub Issues. **This skill does NOT create issues** — it produces specs. The orchestration workflow (e.g., `Skill(subagent-workflow)`) is responsible for creating actual issues, assigning them, and tracking their state.
 
 Each work unit spec:
 
@@ -661,7 +661,7 @@ Sessions crash, context gets lost, conversations expire. The funnel is designed 
 
 - Everything in `{ARTIFACT_ROOT}/` — STATUS.md, phase outputs, context packets, execution artifacts
 - Git state — branches, commits, worktrees, PRs
-- Issue tracker state — Linear/ticket statuses, comments
+- GitHub Issue state — issue labels, assignees, linked PRs, comments
 
 ### Recovery Procedure
 

--- a/.claude/skills/subagent-workflow/SKILL.md
+++ b/.claude/skills/subagent-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subagent-workflow
-description: MANDATORY for all multi-step tasks - parallel task execution with sequential per-task workflow (implementer → spec review → quality review) with Linear as source of truth
+description: MANDATORY for all multi-step tasks - parallel task execution with sequential per-task workflow (implementer → spec review → quality review) with GitHub Issues as source of truth
 ---
 
 # Subagent-Driven Development Workflow
@@ -9,61 +9,78 @@ description: MANDATORY for all multi-step tasks - parallel task execution with s
 
 ## 8 Core Principles
 
-1. **One Linear issue = one worktree = one PR** — never split an issue across multiple PRs
-2. **Always query Linear before starting** — Linear is the source of truth
+1. **One GitHub Issue = one worktree = one PR** — never split an issue across multiple PRs
+2. **Always query GitHub Issues before starting** — they are the source of truth
 3. **Both spec + quality reviews required for each pull request** — no exceptions, no shortcuts
-4. **E2E tests must pass before PR** — GitHub Actions are disabled; local validation is mandatory
+4. **E2E tests must pass before PR** — CI may run them too, but local validation is mandatory; do not rely on the queue to catch what the local run could
 5. **All work via dispatched agents** — lead agent orchestrates, never edits code directly
 6. **Fixes stay in the same worktree/PR** — never create a new PR for review fixes
-7. **Update Linear at every state transition** — full audit trail required - clean, templated status updates with status bars and recently completed items
+7. **Update the GitHub Issue at every state transition** — full audit trail required: clean, templated comments with status bars and recently completed items
 8. **Clean debug artifacts before PR** — no debug-*.spec.ts, *.bak, or console.log leftovers
 
-## Linear State Definitions
+## GitHub Issue State Definitions
 
-| State | Meaning |
-|-------|---------|
-| **Backlog** | Not yet planned |
-| **Todo** | Ready to start (no blockers) |
-| **In Progress** | Actively being worked on |
-| **Blocked** | Work started but cannot proceed (set `blockedBy`) |
-| **In Review** | PR created, awaiting review |
-| **Done** | Merged and complete |
+GitHub Issues do not ship a built-in state machine beyond `open` / `closed`. Use a small set of `status:*` labels to express workflow state, plus assignee:
+
+| State | Expression on the issue |
+|-------|------------------------|
+| **Backlog** | `open`, no assignee, no `status:*` label |
+| **Todo** | `open`, label `status:todo`, no assignee |
+| **In Progress** | `open`, label `status:in-progress`, assignee = you |
+| **Blocked** | `open`, label `status:blocked` (use `Blocked by #N` line in the body to link) |
+| **In Review** | `open`, label `status:in-review`, linked PR open |
+| **Done** | `closed`, linked PR merged |
+
+If the repo doesn't have these labels yet, create them once with `gh label create status:todo`, etc., before running this skill.
 
 ## Workflow Overview
 
 ```
-PARALLEL across Linear issues, SEQUENTIAL within each issue:
+PARALLEL across GitHub Issues, SEQUENTIAL within each issue:
 
-BEA-330 ─┬─ Implementer → Spec Review → Quality Review → Merge
-BEA-331 ─┬─ Implementer → Spec Review → Quality Review → Merge
-BEA-332 ─┬─ Implementer → Spec Review → Quality Review → Merge
+#330 ─┬─ Implementer → Spec Review → Quality Review → Merge
+#331 ─┬─ Implementer → Spec Review → Quality Review → Merge
+#332 ─┬─ Implementer → Spec Review → Quality Review → Merge
 
 State flow: Backlog → Todo → In Progress → [Blocked] → In Review → Done
 ```
 
-## Linear Comments (3 per issue — no more)
+## Issue Comments (3 per issue — no more)
 
-1. **Started:** `"Starting work on {ISSUE_ID}"`
+1. **Started:** `"Starting work on #{N}"`
 2. **Review findings:** Combined spec + quality review results
-3. **Done:** `"Completed {ISSUE_ID}, merged PR #{PR_NUM}"`
+3. **Done:** `"Completed #{N}, merged PR #{PR_NUM}"`
 
 ---
 
-# Step 0: Get Work from Linear
+# Step 0: Get Work from GitHub Issues
 
 **MANDATORY first step.**
 
-1. List issues in "Todo" or "Backlog": `mcp__linear-server__list_issues`
-2. Filter for unblocked issues
-3. Read full issue details: `mcp__linear-server__get_issue { id: "issue-id" }`
-   - Description, acceptance criteria, comments, linked PRs, labels, dependencies
-4. **Claim the issue:** `mcp__linear-server__update_issue { id: "issue-id", state: "Todo", assignee: "me" }`
+1. List ready-to-start issues:
+   ```
+   gh issue list --state open --label "status:todo" --json number,title,labels,body,assignees
+   ```
+   Or to scan the backlog:
+   ```
+   gh issue list --state open --json number,title,labels,assignees
+   ```
+2. Filter for unblocked issues — drop anything with `status:blocked` or with a `Blocked by #N` reference whose blocker is still open.
+3. Read full issue details:
+   ```
+   gh issue view <issue-num> --json title,body,labels,assignees,comments,milestone
+   ```
+   Walk through: description, acceptance criteria, comments, linked PRs, labels, dependencies.
+4. **Claim the issue:**
+   ```
+   gh issue edit <issue-num> --add-assignee @me --add-label "status:in-progress" --remove-label "status:todo"
+   ```
 
-**If Linear is inaccessible:** STOP. Ask user to configure Linear MCP or provide a specific BEA-### issue ID. Never fabricate issue IDs.
+**If `gh` is not authenticated or the repo's issue tracker is unreachable:** STOP. Run `gh auth login` or ask the user to provide a specific issue number. Never fabricate issue numbers.
 
 ---
 
-# Step 1: Identify Parallel Linear Issues
+# Step 1: Identify Parallel GitHub Issues
 
 Look for independent issues that modify different files/areas and have no dependencies on each other.
 
@@ -78,11 +95,11 @@ Track each issue with `TodoWrite`.
 
 # Step 2: Create Git Worktrees
 
-One worktree per Linear issue using `Skill(using-git-worktrees)`:
+One worktree per GitHub Issue using `Skill(using-git-worktrees)`:
 
 ```bash
-git worktree add ../wt-BEA-330-login-form -b feat/BEA-330-login-form
-cd ../wt-BEA-330-login-form && ./scripts/setup-worktree-e2e.sh && cd -
+git worktree add ../wt-330-login-form -b feat/login-form
+cd ../wt-330-login-form && ./scripts/setup-worktree-e2e.sh && cd -
 ```
 
 **CRITICAL:** Run `./scripts/setup-worktree-e2e.sh` in EACH worktree to prevent port conflicts.
@@ -98,25 +115,23 @@ Steps 3, 4, and 5 each dispatch agents using `Task`. All agents for a given step
 ## Common Prompt Template
 
 ```
-You are the {ROLE} for Linear issue {ISSUE_ID}.
+You are the {ROLE} for GitHub Issue #{N}.
 
-**Working directory:** ../wt-{ISSUE_ID}-{slug}
-**Linear Issue:** {ISSUE_ID} "{title}"
+**Working directory:** ../wt-{N}-{slug}
+**Issue:** #{N} "{title}"
 {IF_REVIEW: **PR to review:** PR #{PR_NUM}}
 
 **Context scope:**
-1. Determine which app this issue affects from the Linear issue description/labels
-2. ONLY read that app's CLAUDE.md (e.g., apps/bingo/CLAUDE.md)
-3. Do NOT read other app CLAUDE.md files unless issue spans multiple apps
-4. Determine app from: issue title, description mentions, file paths, labels
-5. Always read root CLAUDE.md for project-wide patterns
+1. Always read the project root CLAUDE.md
+2. Read additional CLAUDE.md files only if the issue spans those areas
+3. Determine scope from: issue title, description, file paths mentioned, labels
 
-**Linear context:** Read issue {ISSUE_ID} description, comments, and linked PRs.
+**Issue context:** Read issue #{N} description, comments, and linked PRs.
 
 {ROLE_SPECIFIC_INSTRUCTIONS}
 
 **CRITICAL:**
-- One PR for the ENTIRE Linear issue — do NOT split
+- One PR for the ENTIRE issue — do NOT split
 - Fixes happen in the SAME worktree/PR, never a new one
 - E2E tests MUST pass before marking complete
 ```
@@ -125,13 +140,13 @@ You are the {ROLE} for Linear issue {ISSUE_ID}.
 
 # Step 3: Dispatch Implementer Agents
 
-Update Linear: `state: "In Progress"` for each issue. Post comment: `"Starting work on {ISSUE_ID}"`.
+Update each issue: add `status:in-progress` label, assign to you. Post comment: `"Starting work on #{N}"`.
 
 **Role-specific instructions for IMPLEMENTER:**
 
 ```
-1. Read Linear issue for FULL context (description, comments, linked PRs)
-2. Read the relevant app's CLAUDE.md for patterns (context scope above)
+1. Read the GitHub Issue for FULL context (description, comments, linked PRs)
+2. Read the project CLAUDE.md for patterns (context scope above)
 3. Implement the ENTIRE issue in this worktree
 4. Write tests (>80% coverage)
 5. Run pre-PR gate:
@@ -139,14 +154,14 @@ Update Linear: `state: "In Progress"` for each issue. Post comment: `"Starting w
    pnpm test:e2e && pnpm test:e2e:summary  # MUST show "0 failed"
    git status --porcelain | grep -E "debug-|\.bak$" && echo "FAIL" && exit 1
 6. Clean debug artifacts (debug-*.spec.ts, *.bak, console.log)
-7. Commit: feat(scope): description (BEA-###)
+7. Commit using conventional-commit prefix: feat(scope): description (#N)
 8. Self-review, push, create draft PR using .github/PULL_REQUEST_TEMPLATE.md
-9. Update Linear with pre-PR verification evidence (actual test output)
+9. Comment on the issue with pre-PR verification evidence (actual test output)
 10. Mark task as completed
-11. Documentation check: If your changes touch any of these high-signal files, update the corresponding doc section per the app's Update Triggers table:
+11. Documentation check: If your changes touch any of these high-signal files, update the corresponding doc section per the project's Update Triggers table:
     - Keyboard shortcut handlers → CLAUDE.md Keyboard Shortcuts
     - API route directories → CLAUDE.md API Routes
-    - New packages in packages/ → root CLAUDE.md package table
+    - New packages → root CLAUDE.md package table
     - Scene/state type definitions → CLAUDE.md Architecture Notes
     If no doc-impacting changes, note "No doc updates needed" in your commit.
 ```
@@ -162,14 +177,14 @@ One reviewer per issue/PR.
 **Role-specific instructions for SPEC COMPLIANCE REVIEWER:**
 
 ```
-1. Read Linear issue acceptance criteria
+1. Read the GitHub Issue's acceptance criteria
 2. Review PR diff and code
 3. Verify EACH acceptance criterion is met
 4. Check tests cover acceptance criteria
 5. Verify E2E tests pass
-6. Documentation verification: Confirm that the implementer updated docs if changes touched files listed in the app's Update Triggers table, or explicitly noted "No doc updates needed."
+6. Documentation verification: Confirm that the implementer updated docs if changes touched files listed in the project's Update Triggers table, or explicitly noted "No doc updates needed."
 
-If APPROVED: "SPEC COMPLIANT - {ISSUE_ID} acceptance criteria met"
+If APPROVED: "SPEC COMPLIANT - #{N} acceptance criteria met"
 If ISSUES: "SPEC GAPS FOUND" + specific gaps → implementer fixes in SAME worktree → re-review
 
 Do NOT review code quality — that is Step 5.
@@ -196,7 +211,7 @@ Only after spec review PASSES. One reviewer per issue/PR.
 8. No debug artifacts (debug-*.spec.ts, *.bak, console.log)
 9. No code duplication
 
-If APPROVED: "QUALITY APPROVED - {ISSUE_ID} code meets standards"
+If APPROVED: "QUALITY APPROVED - #{N} code meets standards"
 If ISSUES: "QUALITY ISSUES FOUND" + specific issues → implementer fixes in SAME worktree → re-review
 
 Focus on HIGH-IMPACT issues only. Don't nitpick.
@@ -210,11 +225,11 @@ Focus on HIGH-IMPACT issues only. Don't nitpick.
 
 Once BOTH reviews pass for each issue:
 
-1. Update Linear: `state: "In Review"`
+1. Update the issue: replace `status:in-progress` with `status:in-review`
 2. Verify PR template is complete (all checkboxes checked, Five-Level Explanation filled)
-3. Merge PRs in dependency order (foundation first, UI last; parallel if no dependencies)
-4. Update Linear: `state: "Done"`. Post comment: `"Completed {ISSUE_ID}, merged PR #{PR_NUM}"`
-5. Cleanup: `git worktree remove ../wt-{ISSUE_ID}-{slug}`
+3. Merge PRs in dependency order (foundation first, UI last; parallel if no dependencies). On Mergify-managed repos, comment `@mergifyio queue` rather than calling `gh pr merge` directly.
+4. Issue closes automatically if the PR body contains `Closes #N`. Otherwise, run `gh issue close <N>`. Post comment: `"Completed #{N}, merged PR #{PR_NUM}"`
+5. Cleanup: `git worktree remove ../wt-{N}-{slug}`
 
 **Merge blockers:** Unchecked E2E checkbox, missing Five-Level Explanation, unresolved review issues.
 
@@ -222,16 +237,16 @@ Once BOTH reviews pass for each issue:
 
 # Example: Multiple Independent Issues
 
-**Issues:** BEA-330 (login form), BEA-331 (trivia fix), BEA-332 (theme colors)
+**Issues:** #330 (login form), #331 (trivia fix), #332 (theme colors)
 
 ```
-Step 0: Query Linear for all 3, read full context, claim with assignee: "me"
+Step 0: gh issue list with status:todo, read full context, claim with @me + status:in-progress
 Step 1: 3 independent issues → task list
-Step 2: 3 worktrees (wt-BEA-330-login, wt-BEA-331-trivia, wt-BEA-332-theme)
+Step 2: 3 worktrees (wt-330-login, wt-331-trivia, wt-332-theme)
 Step 3: 3 implementers dispatched in parallel (one Task call each, single message)
 Step 4: 3 spec reviewers in parallel after implementers complete
 Step 5: 3 quality reviewers in parallel after spec reviews pass
-Step 6: Merge 3 PRs, update 3 issues to Done, cleanup 3 worktrees
+Step 6: Merge 3 PRs (auto-closes 3 issues via "Closes #N"), cleanup 3 worktrees
 ```
 
 Result: 3 issues → 3 worktrees → 3 PRs
@@ -240,14 +255,14 @@ Result: 3 issues → 3 worktrees → 3 PRs
 
 # Troubleshooting
 
-**Can't access Linear:** Check MCP config (`/mcp`), authenticate, or ask user for issue ID. Never fabricate IDs.
+**Can't access GitHub:** Run `gh auth login`, or ask the user for the issue number. Never fabricate issue numbers.
 
 **Agent failed:** Read output, check worktree status, fix blockers, re-dispatch with corrected context.
 
-**Reviews keep finding issues:** Verify acceptance criteria are clear in Linear. If ambiguous, ask user and update the issue.
+**Reviews keep finding issues:** Verify acceptance criteria are clear in the GitHub Issue. If ambiguous, ask the user and update the issue body.
 
 **Quality reviewer too strict:** Focus on high-impact issues only (security, performance, accessibility are non-negotiable; style is negotiable if consistent).
 
 **Merge conflicts:** Should not happen with independent issues. If they do, identify conflicting files, resolve manually, re-run reviews.
 
-**Blocked on dependency:** Set issue state to "Blocked", add comment explaining the blocker, set `blockedBy` to the blocking issue ID. Resume when unblocked.
+**Blocked on dependency:** Add `status:blocked` label to the issue, add a comment explaining the blocker, and add a `Blocked by #N` line to the issue body. Resume when unblocked.

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,18 @@
+# Three load-bearing invariants for strict-mode branch protection (per
+# the mergify-merge-workflow skill). Do NOT change without reading that skill:
+#   1. merge_queue.max_parallel_checks: 1 — only one PR runs checks at a time
+#      (prevents stale-base race when branch protection requires up-to-date branches)
+#   2. queue_rules[].batch_size: 1 — each PR runs checks alone, not bundled
+#   3. NO merge_conditions: block — all conditions live under queue_conditions:
+#      so the queue's pre-merge state is the single source of truth.
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: default
     merge_method: squash
     update_method: merge
+    batch_size: 1
     queue_conditions:
       - "#approved-reviews-by >= 1"
       - base = main


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  classDef gh fill:#18181b,stroke:#84cc16,color:#fafafa
  classDef cfg fill:#18181b,stroke:#38bdf8,color:#fafafa
  classDef out fill:#18181b,stroke:#22c55e,color:#fafafa

  S1[subagent-workflow SKILL.md<br/>Linear → GitHub Issues]:::gh
  S2[analysis-funnel SKILL.md<br/>Linear MCP refs → generic]:::gh
  S3[decision-funnel SKILL.md<br/>Linear MCP refs → generic]:::gh
  M[.mergify.yml<br/>+ invariant header + explicit<br/>max_parallel_checks/batch_size]:::cfg

  S1 & S2 & S3 & M --> R[Wave 0 dispatchable<br/>against actual repo state]:::out
```

## Summary

- **Why-first:** Wave 0+ implementer subagents need a workflow contract (subagent-workflow SKILL.md) that matches reality. The skill said Linear; this repo uses GitHub Issues. Wave 0 issues themselves are blocked on this.
- **What:** scrub Linear references from 3 SKILL.md files; add explicit `max_parallel_checks: 1` + `batch_size: 1` to `.mergify.yml` + a top-of-file comment documenting the three invariants from `mergify-merge-workflow` skill.
- **Scope discipline:** orchestrator-side state only — no repo content (Wave 0 #305 + #306 handle that). The `setup-worktree-e2e.sh` script is intentionally NOT created; W0.2 explicitly removes that reference per locked decision.

## Screenshots

N/A — not UI; configuration + skill text changes only.

## Test plan

- [x] `pnpm lint` passes (no code touched)
- [x] `pnpm typecheck` passes (no code touched)
- [x] `grep -c "linear\|BEA-\|mcp__linear" .claude/skills/*/SKILL.md` returns `0` for all 5 active skills
- [x] `.mergify.yml` parses (Mergify will validate on PR open)
- [x] `gh api repos/julianken/detached-node --jq .delete_branch_on_merge` returns `true`
- [x] `gh label list | grep "^status:in-review"` returns 1 line
- [ ] `@Mergifyio queue` accepts the queue command (validates the loop on this low-stakes PR before any wave dispatches)

## Plan reference

Part of Epic #302, pre-flight step (orchestrator-side state). See `/Users/jul/.claude/plans/synchronous-squishing-badger.md` § Pre-flight.
