### PR TITLE
infra(hooks): restore PreToolUse enforcement + remove worktree-agent dead code

### DIFF
--- a/.claude/hooks/block-console-log.sh
+++ b/.claude/hooks/block-console-log.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# block-console-log.sh
+# PreToolUse hook: blocks git commit when staged files outside the allowlist contain console.log
+# Allowlist: tests/, e2e/, scripts/, *.test.*, *.spec.*
+# Exit 2 on violation; exit 0 otherwise.
+
+set -euo pipefail
+
+staged_files=$(git diff --cached --name-only 2>/dev/null || true)
+
+if [ -z "$staged_files" ]; then
+  exit 0
+fi
+
+violations=()
+
+while IFS= read -r file; do
+  # Skip allowlisted paths
+  if [[ "$file" =~ ^tests/ ]]; then continue; fi
+  if [[ "$file" =~ ^e2e/ ]]; then continue; fi
+  if [[ "$file" =~ ^scripts/ ]]; then continue; fi
+  if [[ "$file" =~ \.test\. ]]; then continue; fi
+  if [[ "$file" =~ \.spec\. ]]; then continue; fi
+
+  # Check if the staged version of the file contains console.log
+  if git diff --cached -U0 -- "$file" | grep -qE '^\+.*console\.log'; then
+    violations+=("$file")
+  fi
+done <<< "$staged_files"
+
+if [ ${#violations[@]} -gt 0 ]; then
+  echo "ERROR: block-console-log: staged files contain console.log outside the allowlist:" >&2
+  for v in "${violations[@]}"; do
+    echo "  - $v" >&2
+  done
+  echo "Remove console.log statements before committing. Allowlist: tests/, e2e/, scripts/, *.test.*, *.spec.*" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/block-debug-artifacts.sh
+++ b/.claude/hooks/block-debug-artifacts.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# block-debug-artifacts.sh
+# PreToolUse hook: blocks git commit when staged files match debug-*.spec.ts or *.bak
+# Exit 2 on violation; exit 0 otherwise.
+
+set -euo pipefail
+
+staged_files=$(git diff --cached --name-only 2>/dev/null || true)
+
+if [ -z "$staged_files" ]; then
+  exit 0
+fi
+
+violations=()
+
+while IFS= read -r file; do
+  # Match debug-*.spec.ts
+  if [[ "$file" =~ (^|/)debug-[^/]*\.spec\.ts$ ]]; then
+    violations+=("$file (matches debug-*.spec.ts)")
+    continue
+  fi
+  # Match *.bak
+  if [[ "$file" =~ \.bak$ ]]; then
+    violations+=("$file (matches *.bak)")
+  fi
+done <<< "$staged_files"
+
+if [ ${#violations[@]} -gt 0 ]; then
+  echo "ERROR: block-debug-artifacts: staged files contain debug artifacts:" >&2
+  for v in "${violations[@]}"; do
+    echo "  - $v" >&2
+  done
+  echo "Remove these files from staging before committing." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,10 +14,6 @@
           {
             "type": "command",
             "command": "if echo \"$TOOL_INPUT\" | grep -q 'git commit'; then .claude/hooks/block-console-log.sh; fi"
-          },
-          {
-            "type": "command",
-            "command": "if echo \"$TOOL_INPUT\" | grep -q 'git push'; then .claude/hooks/block-worktree-push.sh; fi"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ scripts/.tmp-seed-images/
 /tests/.auth/
 
 # Tool configs
-.claude/hooks/
 .claude/settings.local.json
 .playwright-mcp/
 .serena/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,17 +90,6 @@ Key points:
 - The current hardcoded data is placeholder only
 - Content structure should align with `CONTENT_MODEL.md`
 
-## Worktree Branch Management
-
-Subagent workflows create temporary `worktree-agent-*` branches. These are local-only development artifacts that must never be pushed to the remote.
-
-**Safeguards:**
-- A PreToolUse hook blocks `git push` commands referencing worktree-agent branches
-- Cleanup script: `bash .claude/hooks/clean-worktree-branches.sh`
-- These branches should be deleted after each session
-
-**Convention:** If worktree branches accumulate, run the cleanup script before starting new work.
-
 ## Skill Ownership
 
 - **`analysis-funnel`** — global-canonical (`~/.claude/skills/analysis-funnel/SKILL.md`). Repo copy is a mirror; re-copy from global if drift recurs.
@@ -125,7 +114,6 @@ Config: `.mergify.yml` at repo root. Dashboard: https://dashboard.mergify.com
 | Add content types | Update `CONTENT_MODEL.md` first, then implement |
 | Add a Mermaid diagram to a post | Insert "Mermaid diagram" block in the body field; see `docs/design-system.md#mermaid-diagrams` |
 | Queue a PR to merge | Comment `@mergifyio queue` on the approved PR |
-| Clean worktree branches | `bash .claude/hooks/clean-worktree-branches.sh` |
 
 ## Phase Roadmap
 


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
    state "Pre-PR (fail-open)" as PRE
    state "Post-PR (enforced)" as POST

    PRE --> POST : This PR

    state PRE {
        S1: settings.json references 3 hooks
        S2: .claude/hooks/ gitignored
        S3: block-worktree-push.sh (nonexistent)
        S4: hooks never run on fresh clone
        S1 --> S2
        S2 --> S3
        S3 --> S4
    }

    state POST {
        T1: 2 hooks in settings.json
        T2: .claude/hooks/ tracked in git
        T3: block-debug-artifacts.sh (new, exec)
        T4: block-console-log.sh (new, exec)
        T5: Enforcement active on every clone
        T1 --> T2
        T2 --> T3
        T3 --> T4
        T4 --> T5
    }
```

## Summary

- **Hooks were fail-open**: `.claude/hooks/` was in `.gitignore` (line 62), so the two real enforcement scripts never existed on any fresh checkout; the third hook referenced a nonexistent `block-worktree-push.sh`. This PR tracks the scripts in git and drops the dead reference.
- **Two new scripts enforce artifact hygiene**: `block-debug-artifacts.sh` blocks staging `debug-*.spec.ts` or `*.bak` files; `block-console-log.sh` blocks staging files with `console.log` outside the allowlist (`tests/`, `e2e/`, `scripts/`, `*.test.*`, `*.spec.*`).
- **Dead documentation removed**: The `## Worktree Branch Management` section and the `Clean worktree branches` Common Tasks row referenced a `clean-worktree-branches.sh` that does not exist; both removed.

## Screenshots

N/A — not UI

## Test plan

- [x] `pnpm test:unit` — 322 tests passed, 0 failed
- [x] `pnpm lint` — 0 errors (18 pre-existing warnings, unchanged)
- [x] `pnpm typecheck` — clean, 0 errors
- [x] `pnpm test:e2e` — skipped (config + scripts only, no UI changes)
- [x] AC: `git ls-files .claude/hooks/` shows both `.sh` files tracked
- [x] AC: `ls -l .claude/hooks/*.sh` shows `rwxr-xr-x` on both
- [x] AC: `grep -c 'block-worktree-push' .claude/settings.json` → `0`
- [x] AC: `grep -c '## Worktree Branch Management' CLAUDE.md` → `0`
- [x] AC: `grep -nE '^\\.claude/hooks/$' .gitignore` → nothing
- [x] AC (cycle-2): `grep -c "clean-worktree-branches\|worktree-agent-" CLAUDE.md` → `0`
- [x] Smoke test — `block-debug-artifacts.sh`: staged `debug-foo.spec.ts` → exit 2 (hook fires)
- [x] Smoke test — negative: staged `foo.ts` (no console.log) → exit 0
- [x] Smoke test (cycle-2) — `block-console-log.sh`: staged `src/_smoketest.ts` with `console.log(1)` → exit 2, stderr contains "console.log"
- [x] Smoke test — allowlist: staged `tests/_smoketest.ts` with `console.log(1)` → exit 0 (allowlisted)

## Plan reference

Part of Epic #302, action W0.1. See `docs/agentic-bridge/reframe/action-plan-v1.json`.

Closes #305.