### PR TITLE
chore(skills): remove dead script ref + restore analysis-funnel mirror subdirs

### DIFF
--- a/.claude/skills/analysis-funnel/references/context-management.md
+++ b/.claude/skills/analysis-funnel/references/context-management.md
@@ -1,0 +1,66 @@
+# Context management
+
+Without discipline here, agents run out of context window or produce degraded output from consuming too much upstream content. This is the single most common way a funnel run fails.
+
+## Context budget tiers
+
+| What the agent receives | Approximate token cost | Rule |
+|------------------------|----------------------|------|
+| Full phase output (e.g., all 5 reports) | 3,000–8,000 tokens per report | Never send to downstream agents |
+| Context packet (1–2 pages) | 500–1,000 tokens | Safe to send; this is the designed handoff artifact |
+| Single investigation area assignment | 200–500 tokens | Safe to send |
+| Full analysis report | 2,000–5,000 tokens | Only for final review; individual agents get their assignment only |
+| Codebase reads (file contents) | Varies wildly | Agent reads on-demand; do NOT pre-load files into prompt |
+
+## Context waterfall
+
+What each phase's agents see:
+
+```
+Phase 0 (orchestrator): analysis question input only
+                         ↓ produces phase-0-packet (question + areas + criteria)
+
+Phase 1 investigators:  phase-0-packet + their specific area assignment
+  (5 parallel)           ↓ orchestrator reads all 5 reports, produces phase-1-packet
+
+Phase 2 iterators:      phase-0-packet + phase-1-packet (compressed findings)
+  (5 parallel)           ↓ orchestrator reads all 5 reports, produces phase-2-packet
+
+Phase 3 synthesizers:   phase-0-packet + phase-2-packet (compressed Phase 2 output)
+  (3 parallel)           ↓ orchestrator reads all 3 syntheses, produces phase-3-packet
+
+Phase 4 final synth:    phase-0-packet + phase-3-packet + full Phase 3 artifacts
+  (1 agent)              ↓ produces analysis-report
+```
+
+**Key principle:** each agent sees packets from at most 2 prior phases, never the raw artifacts. Phase 4 is the one exception because it needs the detail to write the final report.
+
+## Context packet format
+
+Each context packet MUST fit this template. If it exceeds ~1,000 tokens, it's too long — cut prose, keep data.
+
+```markdown
+# Context Packet: Phase {N}
+
+## Key Findings
+- {bullet list of most important findings, max 7}
+
+## Confidence Levels
+- {high-confidence findings}
+- {medium-confidence findings}
+- {low-confidence / uncertain findings}
+
+## Contradictions & Open Questions
+- {max 3 items that the next phase must address}
+
+## Artifacts (read only if needed)
+- {file path}: {1-line description}
+```
+
+## Anti-bloat rules
+
+1. **Never paste file contents into agent prompts.** Tell the agent which file to read; let it read on-demand. If you pre-load, the agent pays for content it may not need, and you've lost the opportunity for the agent to skip it.
+2. **Never send "for reference" context.** If the agent doesn't need it for their specific task, don't include it. "Just in case" context is the fastest way to burn a context window.
+3. **Summarize, don't excerpt.** If an investigator wrote 500 words about a finding, the packet says "Area 3 found high complexity in auth middleware — 4 verification paths with no shared abstraction (confidence: high)." That's it.
+4. **One investigation task per agent prompt when possible.** If an agent handles 2+ tasks, they must be tightly related. Otherwise, dispatch separate agents.
+5. **Agent prompts should be under 2,000 tokens** (excluding the skill/system prompt). If your prompt to a dispatched agent exceeds this, you're sending too much context.

--- a/.claude/skills/analysis-funnel/references/crash-recovery.md
+++ b/.claude/skills/analysis-funnel/references/crash-recovery.md
@@ -1,0 +1,118 @@
+# Crash recovery
+
+Sessions crash, context gets lost, conversations expire. The funnel is designed to be **fully recoverable from local artifacts alone** — no conversation history required.
+
+## What survives a crash
+
+- Everything in `{ARTIFACT_ROOT}/` — `STATUS.md`, phase outputs, context packets
+- Git state — branches, commits, worktrees
+
+## What gets lost
+
+- Conversation context (messages, reasoning, intermediate thinking)
+- Any agent state not written to disk
+- The orchestrator's mental model of what's in progress
+
+## STATUS.md format
+
+`STATUS.md` is the single source of truth for recovery. A new session with zero context must be able to read this one file and know exactly where things stand.
+
+```markdown
+# Analysis Funnel Status: {topic}
+
+## Current State
+- **Phase:** {0|1|2|3|4}
+- **Sub-state:** {e.g., "Phase 1: investigators 1-3 complete, 4-5 pending"}
+- **Last updated:** {ISO timestamp}
+- **Artifact root:** {absolute path}
+
+## Analysis Question
+{2-3 sentences from Phase 0 — what we're analyzing}
+
+## Analysis Conclusion
+{Filled after Phase 4 — 2-3 sentences summarizing the key finding}
+
+## Domain Tags
+{List from Phase 0}
+
+## Phase Completion
+- [x] Phase 0: Frame — {artifact path}
+- [x] Phase 1: Investigate (5 areas) — {artifact path}
+- [ ] Phase 2: Iterate (5 iterators) — iterators 1-3 done, 4-5 pending
+- [ ] Phase 3: Synthesize (3 synthesizers)
+- [ ] Phase 4: Final report
+
+## Context Packets Available
+- phase-0-packet.md: {1-line summary}
+- phase-1-packet.md: {1-line summary}
+- ...
+
+## Recovery Instructions
+To resume from this state:
+1. Read this STATUS.md
+2. Read the context packet for the current phase
+3. Read any incomplete artifacts for the sub-state
+4. Continue from where the sub-state indicates
+```
+
+Use `scripts/update_status.py` to manage transitions atomically — don't hand-edit unless you're recovering a broken state.
+
+## Update rules
+
+- Update `STATUS.md` **before** starting each phase (mark in-progress) and **after** completing each phase (mark done, link artifacts). The `init_funnel.sh`, `update_status.py`, and `verify_phase.sh` scripts enforce this.
+- Never delete previous entries — only update status fields.
+- If `STATUS.md` does not exist when you're about to dispatch agents for any phase, stop. You skipped a checkpoint. Write `STATUS.md` before proceeding.
+
+## Recovery procedure
+
+When starting a new conversation after a crash, or when the user says "recover" or "where were we":
+
+### Step 1: Find the artifact root
+
+```bash
+scripts/list_funnels.sh docs     # default location
+# or wherever the user put it
+```
+
+If multiple funnels exist, show the user the list and ask which to resume.
+
+### Step 2: Read STATUS.md
+
+This tells you which phase was in progress, which sub-steps were complete, and where all artifacts live.
+
+### Step 3: Read the relevant context packets
+
+Based on the current phase:
+- Resuming Phase 2: read `phase-0-packet` + `phase-1-packet`
+- Resuming Phase 3: read `phase-0-packet` + `phase-2-packet`
+- Resuming Phase 4: read `phase-0-packet` + `phase-3-packet`
+
+**Do NOT read all artifacts.** The packets contain everything you need. Only read raw phase artifacts if a packet is missing or `STATUS.md` indicates an artifact was incomplete.
+
+### Step 4: Resume
+
+| State | Action |
+|-------|--------|
+| Mid-phase (e.g., Phase 1 investigators 1–3 done) | Read completed artifacts + packets, dispatch remaining agents, continue |
+| Between phases (e.g., Phase 2 done, Phase 3 not started) | Read the latest packet, proceed to next phase |
+| Phase 4 done | Report is complete; present to user |
+| `STATUS.md` missing | Scan artifact root for what exists, reconstruct state from file timestamps and contents, write `STATUS.md` before proceeding |
+
+### Step 5: Announce state to user
+
+Before doing anything, tell the user:
+
+```
+Recovered funnel state for "{topic}":
+- Phase: {current phase}
+- Progress: {what's done / what's pending}
+- Next action: {what you'll do next}
+
+Proceed?
+```
+
+## Preventing data loss
+
+1. Write `STATUS.md` before AND after every state transition. This is a ~100-token write. Do it every time.
+2. Agents must write their output to disk before reporting completion. Never rely on agent return values as the sole record.
+3. If `STATUS.md` does not exist when you're about to dispatch agents for any phase, stop. Write `STATUS.md` before proceeding.

--- a/.claude/skills/analysis-funnel/references/domain-detection.md
+++ b/.claude/skills/analysis-funnel/references/domain-detection.md
@@ -1,0 +1,74 @@
+# Domain Detection and Area Carving
+
+Analyze the question and tag all applicable domains. Each domain activates a specialist investigation lens (Phase 1) and guides agent type selection for all phases.
+
+## Domain table
+
+| Domain | Detected When | Investigation Focus |
+|--------|--------------|---------------------|
+| **UI/Visual** | Analysis involves layouts, styling, visual hierarchy, animations, theming | Aesthetics, consistency, visual hierarchy, responsiveness |
+| **React/Components** | Analysis involves component architecture, state, props, hooks, rendering | Component boundaries, re-render efficiency, hook correctness |
+| **State Management** | Analysis involves stores, sync, real-time updates, caching | Data flow, race conditions, consistency guarantees |
+| **API/Backend** | Analysis involves endpoints, data fetching, auth, server logic | Contracts, error handling, security, performance |
+| **Database** | Analysis involves schema, queries, migrations, data modeling | Normalization, query patterns, migration safety |
+| **GraphQL** | Analysis involves schema design, resolvers, federation, subscriptions | Schema design, N+1 risks, type safety, caching |
+| **Auth/Security** | Analysis involves authentication, authorization, tokens, encryption | Attack vectors, token handling, OWASP compliance |
+| **Accessibility** | Analysis involves screen readers, keyboard nav, ARIA, color contrast | WCAG compliance, assistive tech compatibility, focus management |
+| **Performance** | Analysis involves load times, bundle size, rendering speed, memory | Bottlenecks, measurement methodology, regression risk |
+| **Testing** | Analysis involves test strategy, coverage, E2E, mocking | Coverage gaps, flakiness risk, test maintainability |
+| **DevOps/Infra** | Analysis involves CI/CD, deployment, monitoring, scaling | Deployment safety, rollback capability, observability |
+| **Mobile/Native** | Analysis involves iOS, Android, React Native, responsive mobile UX | Platform conventions, gesture handling, offline behavior |
+| **Architecture** | Analysis involves system design, module boundaries, patterns, coupling | Cohesion, coupling, abstraction quality, evolution fitness |
+| **Developer Experience** | Analysis involves tooling, documentation, onboarding, workflow friction | Ergonomics, discoverability, consistency, cognitive load |
+
+**Tagging rules:**
+- Tag 2–5 domains. More than 5 → decompose the question into separate funnels.
+- Fewer than 2 → you may be thinking too narrowly; most real analyses span multiple domains.
+- The detected domains guide which specialist agent types the orchestrator selects for each phase.
+
+## Quality criteria (defaults)
+
+Adjust weights per analysis — these are starting points, not mandates:
+
+| Criterion | Weight | Description |
+|-----------|--------|-------------|
+| Evidence strength | 25% | Are findings backed by concrete data, code references, or verifiable facts? |
+| Completeness | 20% | Does the analysis cover the full scope of the question? |
+| Accuracy | 20% | Are claims factually correct and technically sound? |
+| Actionability | 15% | Can someone act on the findings (even if actions aren't prescribed)? |
+| Nuance | 10% | Does it acknowledge uncertainty, trade-offs, and multiple perspectives? |
+| Clarity | 10% | Is it well-organized and comprehensible to the stated audience? |
+
+Commit to weights *before* seeing findings. Retrofitting criteria to match the evidence you wanted is the most common way a sincere analysis becomes motivated reasoning.
+
+## Carving rules for 5 investigation areas
+
+Each area should be a different **facet** of the question, not a different answer. Rules:
+
+- Areas explore different ASPECTS, not different conclusions
+- Each area should align with one of the tagged domains
+- Areas should have minimal overlap — if two areas would investigate the same files, merge them
+- Each area must be independently investigable — no area depends on another's results (that's what Phase 2 is for)
+
+## Examples
+
+**Architecture audit:**
+1. Component structure & dependencies
+2. Data flow patterns
+3. Error handling & resilience
+4. Performance characteristics
+5. Security posture
+
+**Technology assessment:**
+1. Current usage patterns
+2. Ecosystem maturity
+3. Performance benchmarks
+4. Developer experience
+5. Migration / adoption costs
+
+**Codebase health check:**
+1. Test coverage & quality
+2. Code complexity & duplication
+3. Dependency freshness
+4. Documentation completeness
+5. Operational readiness

--- a/.claude/skills/analysis-funnel/references/phase-templates.md
+++ b/.claude/skills/analysis-funnel/references/phase-templates.md
@@ -1,0 +1,114 @@
+# Phase output templates
+
+Every agent writes to its designated file path **before** returning. Return values are advisory; the file on disk is authoritative. If the file is missing after the agent returns, treat the agent as failed and re-dispatch.
+
+## Phase 1 — Investigator output
+
+File path: `{ARTIFACT_ROOT}/phase-1/area-{N}-{slug}.md`
+
+Each investigator must:
+
+1. Gather evidence — use MCP tools, read code, query docs, inspect the actual system
+2. Cite every claim with file path, line number, documentation URL, or tool output
+3. Identify surprises — things that were unexpected or contradict prior assumptions
+4. Flag unknowns — what couldn't be determined and why
+
+```markdown
+# Investigation: {Area Name}
+
+## Summary
+{3–5 sentence overview of findings}
+
+## Key Findings
+### Finding 1: {title}
+- **Evidence:** {specific code references, data, tool output}
+- **Confidence:** {high|medium|low} — {why}
+- **Implication:** {what this means for the broader analysis}
+
+### Finding 2: {title}
+...
+
+## Surprises
+- {Things that contradicted expectations}
+
+## Unknowns & Gaps
+- {What couldn't be determined and why}
+- {Suggested follow-up investigations}
+
+## Raw Evidence
+- {File paths read, tool queries run, data collected — for traceability}
+```
+
+## Phase 2 — Iterator output
+
+File path: `{ARTIFACT_ROOT}/phase-2/iterator-{N}-{focus}.md`
+
+Each iterator must:
+
+1. Deepen the analysis on their assigned task (not develop solution options)
+2. Cite evidence for every claim
+3. Assess confidence with reasoning
+4. Connect findings back to the broader analysis question
+
+```markdown
+# Iteration: {Focus Area}
+
+## Assignment
+{What the orchestrator asked this iterator to do}
+
+## Findings
+### {Finding title}
+- **Evidence:** {specific references}
+- **Confidence:** {high|medium|low}
+- **Relation to Phase 1:** {confirms|contradicts|extends} finding from area {N}
+- **Significance:** {why this matters for the analysis}
+
+## Resolved Questions
+- {Questions from Phase 1 that this iteration answered}
+
+## Remaining Unknowns
+- {What still couldn't be determined}
+
+## Revised Understanding
+{How the analysis picture has changed based on this iteration}
+```
+
+For cross-cutting analysis tasks, use an architecture or codebase-exploration specialist as the `subagent_type` — they need breadth, not depth in a single domain.
+
+## Phase 3 — Synthesizer output
+
+File path: `{ARTIFACT_ROOT}/phase-3/synthesis-{N}.md`
+
+Each synthesizer must:
+
+1. Synthesize — don't just list findings, build a coherent narrative or framework
+2. Cite back — every synthesis claim traces to specific Phase 1/2 findings
+3. Rate confidence for the synthesis as a whole and for individual conclusions
+4. Identify blind spots — what might this synthesis lens be missing?
+
+```markdown
+# Synthesis: {Lens Name}
+
+## Synthesis Approach
+{How this synthesis lens was applied}
+
+## Core Narrative
+{The coherent story that emerges from the evidence through this lens — 1–2 paragraphs}
+
+## Key Conclusions
+### Conclusion 1: {title}
+- **Supporting evidence:** {references to Phase 1/2 findings}
+- **Confidence:** {high|medium|low}
+- **Caveats:** {conditions under which this conclusion might not hold}
+
+### Conclusion 2: {title}
+...
+
+## Blind Spots
+- {What this lens might be missing or underweighting}
+
+## Recommendations (if applicable)
+- {High-level suggestions, NOT implementation plans}
+```
+
+Use broad architectural/analytical specialists for all 3 synthesizers. They need broad thinking, not domain specialization.

--- a/.claude/skills/analysis-funnel/references/report-template.md
+++ b/.claude/skills/analysis-funnel/references/report-template.md
@@ -1,0 +1,111 @@
+# Final analysis report template
+
+File path: `{ARTIFACT_ROOT}/phase-4/analysis-report.md`
+
+The analysis report must be comprehensive enough to inform downstream decisions without requiring re-investigation.
+
+## Structure
+
+### A) Executive summary
+
+Non-technical summary anyone could understand. 5–7 sentences covering: what was analyzed, the most important findings, and the key implications.
+
+### B) Analysis question & scope
+
+Restatement of what was analyzed and what was explicitly in/out of scope.
+
+### C) Table of contents
+
+Every section of the report with 1–2 sentence summaries.
+
+### D) Methodology
+
+Brief description of what was investigated and how (which MCP tools, code areas, documents, etc.). This establishes credibility and traceability.
+
+### E) Key findings
+
+Organized by theme (not by investigation area). Each finding:
+
+```
+### Finding: {TITLE}
+**Confidence:** {high|medium|low}
+**Evidence:** {specific code references, data, tool output}
+**Impact:** {what this means — why it matters}
+**Related findings:** {cross-references to other findings}
+```
+
+Order by a combination of confidence and impact — high-confidence, high-impact findings first.
+
+### F) Analysis & implications
+
+The "so what" section. What do the findings mean when considered together? This is where the synthesis lenses combine:
+
+- **Thematic patterns** — what recurring themes emerge across findings?
+- **Risks & vulnerabilities** — what problems or dangers were identified?
+- **Strengths & opportunities** — what's working well or could be leveraged?
+- **Gaps & unknowns** — what couldn't be determined? What should be investigated further?
+
+### G) Confidence assessment
+
+Overall assessment of how much to trust this analysis:
+
+```
+### Overall Confidence: {high|medium|low}
+
+**Strongest claims** (high confidence):
+- {claim 1} — {why we're confident}
+- {claim 2} — {why we're confident}
+
+**Moderate claims** (medium confidence):
+- {claim 1} — {what would increase confidence}
+
+**Weakest claims** (low confidence):
+- {claim 1} — {why we're uncertain, what would help}
+
+**Known blind spots:**
+- {areas the analysis did not or could not cover}
+```
+
+### H) Recommendations
+
+High-level recommendations, NOT implementation plans. Each recommendation:
+
+```
+### Recommendation: {TITLE}
+**Priority:** {high|medium|low}
+**Rationale:** {which findings support this}
+**Trade-offs:** {what you'd be giving up or risking}
+**Open questions:** {what needs to be answered before acting on this}
+```
+
+Recommendations stay high-level — implementation details and execution plans belong in a separate deliverable.
+
+### I) Open questions
+
+Questions that this analysis surfaced but did not answer. For each:
+- The question itself
+- Why it matters
+- Suggested approach to answering it
+
+### J) Appendix: Evidence index
+
+A reference table mapping every major finding to its evidence sources:
+
+```
+| Finding | Evidence Source | Type | Location |
+|---------|---------------|------|----------|
+| {title} | {file/tool/doc} | {code|data|doc|observation} | {path/URL} |
+```
+
+## Phase 4 synthesis checklist
+
+The Phase 4 agent must:
+
+1. Weave together insights from all 3 synthesis lenses into a unified narrative
+2. Resolve contradictions between synthesis outputs with explicit reasoning
+3. Verify completeness — does the report address every aspect of the original analysis question from Phase 0?
+4. Check for blind spots — did any investigation area's findings get lost during synthesis?
+5. Assess overall confidence — how confident are we in the analysis as a whole?
+6. Produce the full analysis report per the structure above
+
+This is NOT just "pick the best of 3" — it's a final synthesis that weaves insights from all three lenses together.

--- a/.claude/skills/analysis-funnel/references/troubleshooting.md
+++ b/.claude/skills/analysis-funnel/references/troubleshooting.md
@@ -1,0 +1,50 @@
+# Troubleshooting
+
+Common failure modes and their fixes.
+
+## Agents in a wave produced redundant output
+
+The orchestrator's task assignments for that wave weren't differentiated enough. Re-read the previous wave's output and reconsider how to assign tasks — each agent should have a meaningfully different slice of the problem.
+
+## Agents didn't follow their assigned task
+
+The prompt was too vague or included too much context that distracted from the specific task. Re-dispatch with a more focused prompt and less background context. If the agent had multiple concerns, split the task.
+
+## Findings lack evidence
+
+The agent prompt didn't emphasize evidence-gathering strongly enough, or the agent wasn't given the right MCP tools/file paths to investigate. Re-dispatch with explicit instructions to use specific tools and cite specific sources. Consider naming the specific MCP servers to use in the prompt.
+
+## Context packets are too long
+
+Enforce the 1–2 page limit strictly. If you can't summarize a phase in 2 pages, the phase output needs restructuring, not a longer summary. The packet captures *signal*, not *all content* — the raw artifacts exist for anyone who needs detail.
+
+## User wants to skip phases
+
+The funnel's value comes from the full pipeline. Skipping Phase 2 (iteration) is the most common request and the most dangerous — without it, raw investigation findings go directly to synthesis without being developed, validated, or cross-referenced. Push back gently but firmly.
+
+## Agent ran out of context / output degraded
+
+The agent prompt was too large. Check:
+1. Are you sending raw phase artifacts instead of context packets?
+2. Are you sending multiple tasks to one agent?
+3. Are you pre-loading file contents into the prompt instead of letting the agent read on-demand?
+
+Fix: follow the Context Waterfall strictly — each agent sees packets from at most 2 prior phases. Agent prompts should be under 2,000 tokens.
+
+## Crashed mid-funnel, no conversation context
+
+Read `{ARTIFACT_ROOT}/STATUS.md`. It contains the full recovery state. Follow the recovery procedure in `references/crash-recovery.md` — read `STATUS.md`, then the relevant context packets, then resume from the indicated sub-state. Do NOT re-read all phase artifacts.
+
+## STATUS.md is missing or stale
+
+Scan the artifact root directory. Check which phase folders exist and which contain complete artifacts. Look at file timestamps to determine order. Reconstruct `STATUS.md` from what you find, write it, then proceed with recovery.
+
+This situation means the disk-checkpoint discipline was violated in the previous session. After recovering, make sure all missing checkpoint artifacts (analysis-brief, context packets) are reconstructed before dispatching any new agents.
+
+## Multiple funnel artifact roots exist
+
+Run `scripts/list_funnels.sh [search-root]`, show the user their topics and states, and ask which to resume.
+
+## Analysis produced actionable recommendations — now what?
+
+The analysis report is the final deliverable. It's up to the user to decide what to do with the recommendations.

--- a/.claude/skills/analysis-funnel/scripts/init_funnel.sh
+++ b/.claude/skills/analysis-funnel/scripts/init_funnel.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Initialize an analysis-funnel artifact tree.
+# Usage: init_funnel.sh <artifact-root> "<question summary>"
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <artifact-root> \"<question summary>\"" >&2
+  exit 2
+fi
+
+ROOT="$1"
+QUESTION="$2"
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+mkdir -p "$ROOT/phase-0" "$ROOT/phase-1" "$ROOT/phase-2" "$ROOT/phase-3" "$ROOT/phase-4" "$ROOT/context-packets"
+
+STATUS="$ROOT/STATUS.md"
+if [ -f "$STATUS" ]; then
+  echo "STATUS.md already exists at $STATUS — refusing to overwrite." >&2
+  echo "If you are recovering, hand-edit or delete it first." >&2
+  exit 3
+fi
+
+cat > "$STATUS" <<EOF
+# Analysis Funnel Status
+
+## Current State
+- **Phase:** 0
+- **Sub-state:** Phase 0 in-progress (framing)
+- **Last updated:** $TS
+- **Artifact root:** $(cd "$ROOT" && pwd)
+
+## Analysis Question
+$QUESTION
+
+## Analysis Conclusion
+_Filled after Phase 4._
+
+## Domain Tags
+_To be filled during Phase 0._
+
+## Phase Completion
+- [ ] Phase 0: Frame
+- [ ] Phase 1: Investigate (5 areas)
+- [ ] Phase 2: Iterate (5 iterators)
+- [ ] Phase 3: Synthesize (3 synthesizers)
+- [ ] Phase 4: Final report
+
+## Context Packets Available
+_None yet._
+
+## Recovery Instructions
+To resume from this state:
+1. Read this STATUS.md
+2. Read the context packet for the current phase
+3. Read any incomplete artifacts for the sub-state
+4. Continue from where the sub-state indicates
+EOF
+
+echo "Initialized funnel at $ROOT"
+echo "STATUS.md written. Next: write phase-0/analysis-brief.md and context-packets/phase-0-packet.md, then run verify_phase.sh $ROOT 0"

--- a/.claude/skills/analysis-funnel/scripts/list_funnels.sh
+++ b/.claude/skills/analysis-funnel/scripts/list_funnels.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Find all analysis-funnel runs under a search root and summarize their state.
+# Usage: list_funnels.sh [search-root]  (default: docs)
+set -euo pipefail
+
+ROOT="${1:-docs}"
+
+if [ ! -d "$ROOT" ]; then
+  echo "No such directory: $ROOT" >&2
+  exit 1
+fi
+
+found=0
+while IFS= read -r -d '' status_file; do
+  found=$((found + 1))
+  artifact_dir="$(dirname "$status_file")"
+  topic="$(basename "$artifact_dir")"
+
+  phase=$(grep -m1 '^\- \*\*Phase:\*\*' "$status_file" 2>/dev/null | sed 's/.*Phase:\*\* //' || echo "?")
+  substate=$(grep -m1 '^\- \*\*Sub-state:\*\*' "$status_file" 2>/dev/null | sed 's/.*Sub-state:\*\* //' || echo "?")
+  updated=$(grep -m1 '^\- \*\*Last updated:\*\*' "$status_file" 2>/dev/null | sed 's/.*Last updated:\*\* //' || echo "?")
+
+  echo "[$topic] phase=$phase  last-updated=$updated"
+  echo "    sub-state: $substate"
+  echo "    root: $artifact_dir"
+  echo
+done < <(find "$ROOT" -maxdepth 4 -name STATUS.md -print0 2>/dev/null)
+
+if [ "$found" -eq 0 ]; then
+  echo "No funnels found under $ROOT (searched for */STATUS.md up to depth 4)."
+  exit 0
+fi
+
+echo "$found funnel(s) found."

--- a/.claude/skills/analysis-funnel/scripts/update_status.py
+++ b/.claude/skills/analysis-funnel/scripts/update_status.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Atomically update STATUS.md for an analysis-funnel run.
+
+Usage:
+  update_status.py <artifact-root> [--complete N] [--start N] [--substate "text"] [--conclusion "text"]
+
+Flags can be combined. --complete N marks phase N done, --start N marks phase N in-progress.
+"""
+
+import argparse
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+def utc_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def update_phase_state(status: str, phase: int, *, complete: bool, start: bool) -> str:
+    pattern = rf"^- \[[ x]\] Phase {phase}:"
+    marker = "[x]" if complete else "[ ]"
+    suffix_hint = ""
+    if start and not complete:
+        suffix_hint = " _(in progress)_"
+
+    def repl(m: re.Match) -> str:
+        line = m.group(0)
+        # replace checkbox
+        new = re.sub(r"^- \[[ x]\]", f"- {marker}", line)
+        # strip any existing "(in progress)" hint
+        new = re.sub(r" _\(in progress\)_$", "", new)
+        return new + suffix_hint
+
+    new_status = re.sub(pattern, repl, status, count=1, flags=re.MULTILINE)
+    if new_status == status:
+        print(f"warning: no Phase {phase} checkbox line found in STATUS.md", file=sys.stderr)
+    return new_status
+
+
+def replace_section(status: str, header: str, new_body: str) -> str:
+    """Replace a markdown section (## Header) with new body text."""
+    pattern = rf"(## {re.escape(header)}\n)(.*?)(?=\n## |\Z)"
+    def repl(m: re.Match) -> str:
+        return m.group(1) + new_body + "\n"
+    new = re.sub(pattern, repl, status, count=1, flags=re.DOTALL)
+    return new
+
+
+def update_timestamp_and_substate(status: str, substate: Optional[str]) -> str:
+    status = re.sub(r"(\*\*Last updated:\*\* )\S+", f"\\g<1>{utc_iso()}", status, count=1)
+    if substate is not None:
+        status = re.sub(r"(\*\*Sub-state:\*\* ).*", f"\\g<1>{substate}", status, count=1)
+    return status
+
+
+def update_current_phase(status: str, phase: int) -> str:
+    return re.sub(r"(\*\*Phase:\*\* )\d+", f"\\g<1>{phase}", status, count=1)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", help="Artifact root containing STATUS.md")
+    parser.add_argument("--complete", type=int, help="Mark phase N complete")
+    parser.add_argument("--start", type=int, help="Mark phase N in-progress and set as current")
+    parser.add_argument("--substate", help="Free-text sub-state description")
+    parser.add_argument("--conclusion", help="Fill the Analysis Conclusion section")
+    args = parser.parse_args()
+
+    root = Path(args.root)
+    status_path = root / "STATUS.md"
+    if not status_path.exists():
+        print(f"error: {status_path} does not exist. Run init_funnel.sh first.", file=sys.stderr)
+        return 2
+
+    status = status_path.read_text()
+
+    if args.complete is not None:
+        status = update_phase_state(status, args.complete, complete=True, start=False)
+    if args.start is not None:
+        status = update_phase_state(status, args.start, complete=False, start=True)
+        status = update_current_phase(status, args.start)
+
+    status = update_timestamp_and_substate(status, args.substate)
+
+    if args.conclusion is not None:
+        status = replace_section(status, "Analysis Conclusion", args.conclusion)
+
+    # atomic write
+    tmp = status_path.with_suffix(".md.tmp")
+    tmp.write_text(status)
+    tmp.replace(status_path)
+    print(f"Updated {status_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/analysis-funnel/scripts/verify_phase.sh
+++ b/.claude/skills/analysis-funnel/scripts/verify_phase.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Verify that all expected files exist for a given phase transition.
+# Exits non-zero with a list of missing files if any are absent.
+# Usage: verify_phase.sh <artifact-root> <phase-number:0|1|2|3|4>
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <artifact-root> <phase:0|1|2|3|4>" >&2
+  exit 2
+fi
+
+ROOT="$1"
+PHASE="$2"
+
+missing=()
+check() {
+  if [ ! -f "$1" ]; then
+    missing+=("$1")
+  fi
+}
+
+glob_count() {
+  # count files matching a glob; does not fail on zero matches
+  local pattern="$1"
+  local count
+  count=$(find "$(dirname "$pattern")" -maxdepth 1 -type f -name "$(basename "$pattern")" 2>/dev/null | wc -l | tr -d ' ')
+  echo "$count"
+}
+
+case "$PHASE" in
+  0)
+    check "$ROOT/STATUS.md"
+    check "$ROOT/phase-0/analysis-brief.md"
+    check "$ROOT/context-packets/phase-0-packet.md"
+    ;;
+  1)
+    check "$ROOT/STATUS.md"
+    check "$ROOT/context-packets/phase-1-packet.md"
+    count=$(glob_count "$ROOT/phase-1/area-*.md")
+    if [ "$count" -lt 5 ]; then
+      missing+=("$ROOT/phase-1/area-*.md (found $count, expected 5)")
+    fi
+    ;;
+  2)
+    check "$ROOT/STATUS.md"
+    check "$ROOT/context-packets/phase-2-packet.md"
+    count=$(glob_count "$ROOT/phase-2/iterator-*.md")
+    if [ "$count" -lt 5 ]; then
+      missing+=("$ROOT/phase-2/iterator-*.md (found $count, expected 5)")
+    fi
+    ;;
+  3)
+    check "$ROOT/STATUS.md"
+    check "$ROOT/context-packets/phase-3-packet.md"
+    count=$(glob_count "$ROOT/phase-3/synthesis-*.md")
+    if [ "$count" -lt 3 ]; then
+      missing+=("$ROOT/phase-3/synthesis-*.md (found $count, expected 3)")
+    fi
+    ;;
+  4)
+    check "$ROOT/STATUS.md"
+    check "$ROOT/phase-4/analysis-report.md"
+    ;;
+  *)
+    echo "Invalid phase: $PHASE (expected 0-4)" >&2
+    exit 2
+    ;;
+esac
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "Phase $PHASE verification FAILED. Missing:" >&2
+  for f in "${missing[@]}"; do
+    echo "  - $f" >&2
+  done
+  exit 1
+fi
+
+echo "Phase $PHASE verification OK."

--- a/.claude/skills/subagent-workflow/SKILL.md
+++ b/.claude/skills/subagent-workflow/SKILL.md
@@ -99,10 +99,7 @@ One worktree per GitHub Issue using `Skill(using-git-worktrees)`:
 
 ```bash
 git worktree add ../wt-330-login-form -b feat/login-form
-cd ../wt-330-login-form && ./scripts/setup-worktree-e2e.sh && cd -
 ```
-
-**CRITICAL:** Run `./scripts/setup-worktree-e2e.sh` in EACH worktree to prevent port conflicts.
 
 Verify: `git worktree list`
 


### PR DESCRIPTION
## Diagrams

N/A — skill text + file mirror only

## Summary

- **Dead reference removed:** `subagent-workflow/SKILL.md` Step 2 referenced `./scripts/setup-worktree-e2e.sh` which has never existed in the repo; the stale call was replaced with a plain `git worktree add` invocation so the skill reflects what actually works here.
- **Mirror restored:** `references/` and `scripts/` subdirectories mirrored from `~/.claude/skills/analysis-funnel/` into `.claude/skills/analysis-funnel/` per the Skill Ownership § in CLAUDE.md (analysis-funnel is global-canonical; repo copy is a mirror).
- Both fixes unblock wave-1 Tier A sections that cite `.claude/skills/analysis-funnel/` paths.

## Screenshots

N/A — not UI

## Test plan

- [x] `grep -nE 'setup-worktree-e2e|worktree-agent-' .claude/skills/subagent-workflow/SKILL.md` → zero hits (exit 1 = no match)
- [x] `grep -rn "setup-worktree-e2e" .claude/ docs/` → zero hits across entire tree
- [x] `ls .claude/skills/analysis-funnel/` → shows `SKILL.md`, `references/`, `scripts/`
- [x] `diff -rq ~/.claude/skills/analysis-funnel/references/ .claude/skills/analysis-funnel/references/` → no missing files
- [x] `pnpm test:unit` → 30 test files, 322 tests passed
- [x] `pnpm lint` → 0 errors (18 pre-existing warnings, no new)
- [x] `pnpm typecheck` → clean (0 errors)
- [ ] `pnpm test:e2e` — skipped; change is skill text + file mirror only, no runtime code touched

## Plan reference

Part of Epic #302, action W0.2. See `docs/agentic-bridge/reframe/action-plan-v1.json`.

Closes #306