### PR TITLE
feat(adp): Pattern type extension + RealizingDisclosure component + Vitest validator (W1.0 #307)

### DIFF
--- a/src/app/(frontend)/agentic-design-patterns/[slug]/page.tsx
+++ b/src/app/(frontend)/agentic-design-patterns/[slug]/page.tsx
@@ -22,6 +22,7 @@ import { PatternStickyRail } from "@/components/agentic-patterns/PatternStickyRa
 import { PatternBody } from "@/components/agentic-patterns/PatternBody";
 import { ReferencesSection } from "@/components/agentic-patterns/ReferencesSection";
 import { DisclosureSection } from "@/components/agentic-patterns/DisclosureSection";
+import { RealizingDisclosure } from "@/components/agentic-patterns/RealizingDisclosure";
 import { PrevNextNav } from "@/components/agentic-patterns/PrevNextNav";
 import {
   generateHubChildBreadcrumb,
@@ -127,6 +128,9 @@ export default async function PatternSatellitePage({
                   ))}
                 </div>
               </DisclosureSection>
+            )}
+            {pattern.realizingInClaudeCode && (
+              <RealizingDisclosure pattern={pattern} />
             )}
           </article>
         </div>

--- a/src/components/agentic-patterns/RealizingDisclosure.tsx
+++ b/src/components/agentic-patterns/RealizingDisclosure.tsx
@@ -1,0 +1,272 @@
+// ---------------------------------------------------------------------------
+// RealizingDisclosure — W1.0
+// ---------------------------------------------------------------------------
+// Third collapsible disclosure on each ADP satellite page. Renders only when
+// pattern.realizingInClaudeCode is defined; callers guard with && so absent
+// patterns render nothing.
+//
+// Dispatches on tier:
+//   Tier A — 5 sub-sections: CC primitives, scaffolding, worked example,
+//             reader move, see also
+//   Tier B  — compact: reader move + see also (+ optional body prose)
+//   Tier C  — cross-link paragraph: body prose + reader move + see also
+//   Tier U  — umbrella index: opening framing + pointer list + closing rule
+//             + see also
+//
+// All styles follow the design system (zinc dark theme, Tailwind utilities).
+// ---------------------------------------------------------------------------
+
+import { DisclosureSection } from './DisclosureSection'
+import type { Pattern, RealizingInClaudeCode, CcSeeAlso } from '@/data/agentic-design-patterns/types'
+
+interface RealizingDisclosureProps {
+  pattern: Pattern
+}
+
+// ---------------------------------------------------------------------------
+// Sub-section heading (shared chrome)
+// ---------------------------------------------------------------------------
+
+function SubHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h4 className="mb-1.5 font-mono text-[0.7rem] font-semibold uppercase tracking-[0.08em] text-text-tertiary">
+      {children}
+    </h4>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Pill list for CC primitives / scaffolding
+// ---------------------------------------------------------------------------
+
+function PillList({ items }: { items: string[] }) {
+  return (
+    <ul className="flex flex-wrap gap-1.5">
+      {items.map((item) => (
+        <li
+          key={item}
+          className="rounded-sm border border-border-subtle bg-zinc-100 px-2 py-0.5 font-mono text-xs text-text-secondary dark:bg-zinc-800"
+        >
+          {item}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// See-also block (shared across tiers)
+// ---------------------------------------------------------------------------
+
+function SeeAlsoBlock({ seeAlso }: { seeAlso: CcSeeAlso }) {
+  const hasSiblings = seeAlso.siblingPatternSlugs && seeAlso.siblingPatternSlugs.length > 0
+  const hasSkillPath = Boolean(seeAlso.skillPath)
+  const hasArticleSlug = Boolean(seeAlso.articleSlug)
+
+  if (!hasSiblings && !hasSkillPath && !hasArticleSlug) return null
+
+  return (
+    <div className="mt-3 border-t border-border-subtle pt-3">
+      <SubHeading>See also</SubHeading>
+      <ul className="flex flex-col gap-1">
+        {hasSkillPath && (
+          <li className="font-mono text-xs text-text-secondary">
+            Skill: <span className="text-text-primary">{seeAlso.skillPath}</span>
+          </li>
+        )}
+        {hasArticleSlug && (
+          <li className="font-mono text-xs text-text-secondary">
+            Article:{' '}
+            <span className="text-text-primary">/{seeAlso.articleSlug}</span>
+          </li>
+        )}
+        {hasSiblings && (
+          <li className="font-mono text-xs text-text-secondary">
+            Related patterns:{' '}
+            <span className="text-text-primary">
+              {seeAlso.siblingPatternSlugs!.join(' · ')}
+            </span>
+          </li>
+        )}
+      </ul>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Reader move block (shared Tier A / B / C)
+// ---------------------------------------------------------------------------
+
+function ReaderMoveBlock({ text, anchorUrl }: { text: string; anchorUrl: string }) {
+  return (
+    <div className="rounded-sm border border-border-subtle bg-zinc-50 px-3 py-2.5 dark:bg-zinc-800/60">
+      <SubHeading>Monday-morning move</SubHeading>
+      <p className="text-sm leading-6 text-text-secondary">
+        {text}{' '}
+        <a
+          href={anchorUrl}
+          className="font-mono text-xs text-accent underline underline-offset-2 hover:no-underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          [anchor]
+        </a>
+      </p>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tier A body
+// ---------------------------------------------------------------------------
+
+function TierABody({ r }: { r: RealizingInClaudeCode }) {
+  return (
+    <div className="flex flex-col gap-4">
+      {r.ccPrimitives && r.ccPrimitives.length > 0 && (
+        <div>
+          <SubHeading>CC primitives</SubHeading>
+          <PillList items={r.ccPrimitives} />
+        </div>
+      )}
+
+      {r.scaffolding && r.scaffolding.length > 0 && (
+        <div>
+          <SubHeading>Scaffolding</SubHeading>
+          <PillList items={r.scaffolding} />
+        </div>
+      )}
+
+      {r.workedExample && (
+        <div>
+          <SubHeading>Worked example</SubHeading>
+          <a
+            href={r.workedExample.url}
+            className="text-sm text-accent underline underline-offset-2 hover:no-underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {r.workedExample.description}
+          </a>
+        </div>
+      )}
+
+      {r.readerMove && (
+        <ReaderMoveBlock text={r.readerMove.text} anchorUrl={r.readerMove.anchorUrl} />
+      )}
+
+      {r.seeAlso && <SeeAlsoBlock seeAlso={r.seeAlso} />}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tier B body (compact: reader move + see also + optional body prose)
+// ---------------------------------------------------------------------------
+
+function TierBBody({ r }: { r: RealizingInClaudeCode }) {
+  return (
+    <div className="flex flex-col gap-4">
+      {r.bodyMarkdown && (
+        <p className="text-sm leading-6 text-text-secondary [text-wrap:pretty]">
+          {r.bodyMarkdown}
+        </p>
+      )}
+
+      {r.readerMove && (
+        <ReaderMoveBlock text={r.readerMove.text} anchorUrl={r.readerMove.anchorUrl} />
+      )}
+
+      {r.seeAlso && <SeeAlsoBlock seeAlso={r.seeAlso} />}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tier C body (cross-link paragraph: body prose required + reader move + see also)
+// ---------------------------------------------------------------------------
+
+function TierCBody({ r }: { r: RealizingInClaudeCode }) {
+  return (
+    <div className="flex flex-col gap-4">
+      {r.bodyMarkdown && (
+        <p className="text-sm leading-6 text-text-secondary [text-wrap:pretty]">
+          {r.bodyMarkdown}
+        </p>
+      )}
+
+      {r.readerMove && (
+        <ReaderMoveBlock text={r.readerMove.text} anchorUrl={r.readerMove.anchorUrl} />
+      )}
+
+      {r.seeAlso && <SeeAlsoBlock seeAlso={r.seeAlso} />}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tier U body (umbrella index)
+// ---------------------------------------------------------------------------
+
+function TierUBody({ r }: { r: RealizingInClaudeCode }) {
+  return (
+    <div className="flex flex-col gap-4">
+      {r.openingFraming && (
+        <p className="text-sm leading-6 text-text-secondary [text-wrap:pretty]">
+          {r.openingFraming}
+        </p>
+      )}
+
+      {r.umbrellaPointers && r.umbrellaPointers.length > 0 && (
+        <div>
+          <SubHeading>Pattern index</SubHeading>
+          <ul className="flex flex-col gap-1.5">
+            {r.umbrellaPointers.map((pointer) => (
+              <li
+                key={pointer.patternSlug}
+                className="flex items-baseline gap-2 text-sm text-text-secondary"
+              >
+                <span className="shrink-0 font-mono text-xs text-text-tertiary">
+                  {pointer.patternSlug}
+                </span>
+                <span className="text-text-secondary">{pointer.oneLine}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {r.closingRule && (
+        <div className="rounded-sm border border-border-subtle bg-zinc-50 px-3 py-2.5 dark:bg-zinc-800/60">
+          <SubHeading>Meta-rule</SubHeading>
+          <p className="font-mono text-xs leading-5 text-text-secondary italic">
+            {r.closingRule}
+          </p>
+        </div>
+      )}
+
+      {r.seeAlso && <SeeAlsoBlock seeAlso={r.seeAlso} />}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export function RealizingDisclosure({ pattern }: RealizingDisclosureProps) {
+  const r = pattern.realizingInClaudeCode
+  if (!r) return null
+
+  return (
+    <DisclosureSection
+      id="realizing-disclosure"
+      label="Realizing in Claude Code"
+    >
+      {r.tier === 'A' && <TierABody r={r} />}
+      {r.tier === 'B' && <TierBBody r={r} />}
+      {r.tier === 'C' && <TierCBody r={r} />}
+      {r.tier === 'U' && <TierUBody r={r} />}
+    </DisclosureSection>
+  )
+}

--- a/src/data/agentic-design-patterns/types.ts
+++ b/src/data/agentic-design-patterns/types.ts
@@ -52,6 +52,74 @@ export type SdkAvailability =
   | 'python-only'
   | 'no-sdk'
 
+// ---------------------------------------------------------------------------
+// Realizing in Claude Code — discriminated field added in W1.0
+// ---------------------------------------------------------------------------
+// Optional field on Pattern; all 23 existing patterns default undefined.
+// Render path guards with pattern.realizingInClaudeCode && so absent values
+// produce no output.
+// ---------------------------------------------------------------------------
+
+/** A concrete CC primitive name, e.g. "Task() parallel dispatch" */
+export type CcPrimitive = string
+
+/** A concrete scaffolding artifact name, e.g. "analysis-funnel/SKILL.md" */
+export type CcScaffolding = string
+
+/** A worked example anchor with a verified GitHub URL */
+export type CcWorkedExample = {
+  url: string
+  description: string
+}
+
+/** The Monday-morning move: text ≤25 words + SKILL.md or GitHub anchor */
+export type CcReaderMove = {
+  text: string
+  anchorUrl: string
+}
+
+/** Cross-links: optional skill path, article slug, sibling pattern slugs */
+export type CcSeeAlso = {
+  skillPath?: string
+  articleSlug?: string
+  siblingPatternSlugs?: string[]
+}
+
+/** Single row in a Tier-U umbrella pointer list */
+export type CcUmbrellaPointer = {
+  patternSlug: string
+  oneLine: string
+}
+
+/**
+ * Discriminated union over four tiers:
+ * - Tier A: full satellite (ccPrimitives + scaffolding + workedExample + readerMove + seeAlso)
+ * - Tier B: compact (readerMove + seeAlso; bodyMarkdown optional)
+ * - Tier C: cross-link paragraph (readerMove + seeAlso + bodyMarkdown)
+ * - Tier U: umbrella index (openingFraming + umbrellaPointers ≥10 + closingRule + seeAlso)
+ */
+export type RealizingInClaudeCode = {
+  tier: 'A' | 'B' | 'C' | 'U'
+  /** Required Tier A: CC primitive names that realize this pattern */
+  ccPrimitives?: CcPrimitive[]
+  /** Required Tier A: scaffolding artifacts (SKILL.md paths, config files) */
+  scaffolding?: CcScaffolding[]
+  /** Required Tier A: one verified worked-example PR or tree URL */
+  workedExample?: CcWorkedExample
+  /** Required Tier A, B, C: the Monday-morning reader move */
+  readerMove?: CcReaderMove
+  /** Required all tiers: cross-link block */
+  seeAlso?: CcSeeAlso
+  /** Tier C (and Tier A supplementary): compact paragraph prose */
+  bodyMarkdown?: string
+  /** Tier U only: ≥10 umbrella pointer rows */
+  umbrellaPointers?: CcUmbrellaPointer[]
+  /** Tier U only: opening framing paragraph (~100w) */
+  openingFraming?: string
+  /** Tier U only: closing rule sentence (verbatim meta-rule) */
+  closingRule?: string
+}
+
 export type Pattern = {
   slug: string                // kebab-case, equals filename
   name: string                // canonical name we use
@@ -77,6 +145,8 @@ export type Pattern = {
   dateModified: string        // ISO date — last meaningful content edit
   lastChangeNote?: string     // 1-line description of last edit
   archived?: boolean          // true when retired
+  /** W1.0: optional bridge field; absent for all 23 patterns until W1.1+ fills them */
+  realizingInClaudeCode?: RealizingInClaudeCode
 }
 
 export type ChangelogEntryType = 'added' | 'edited' | 'retired'

--- a/tests/unit/data/agentic-design-patterns/realizing.test.ts
+++ b/tests/unit/data/agentic-design-patterns/realizing.test.ts
@@ -1,0 +1,160 @@
+// ---------------------------------------------------------------------------
+// Realizing-in-Claude-Code validator — W1.0
+// ---------------------------------------------------------------------------
+// Iterates every pattern in the catalog. If realizingInClaudeCode is absent
+// (graceful-absent migration), the test passes with no assertions. When the
+// field is present, per-tier required-field invariants are enforced.
+//
+// Tier A: ccPrimitives + scaffolding + workedExample + readerMove + seeAlso
+// Tier B: readerMove + seeAlso (bodyMarkdown optional)
+// Tier C: readerMove + seeAlso (bodyMarkdown present)
+// Tier U: openingFraming + closingRule + umbrellaPointers (≥10) + seeAlso
+//
+// Additional cross-tier assertions:
+//   - tier field is one of A|B|C|U
+//   - readerMove.text word count ≤ 25
+//   - workedExample.url parses via new URL()
+//   - seeAlso.siblingPatternSlugs all resolve in getPatternSlugs()
+//   - umbrellaPointers[].patternSlug all resolve in getPatternSlugs()
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect } from 'vitest'
+import { PATTERNS, getPatternSlugs } from '@/data/agentic-design-patterns/index'
+
+const VALID_TIERS = new Set(['A', 'B', 'C', 'U'])
+const ALL_SLUGS = new Set(getPatternSlugs())
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function wordCount(text: string): number {
+  return text.trim().split(/\s+/).length
+}
+
+function assertValidUrl(url: string, label: string): void {
+  expect(() => new URL(url), `${label} must be a parseable URL: "${url}"`).not.toThrow()
+}
+
+// ---------------------------------------------------------------------------
+// per-pattern loop
+// ---------------------------------------------------------------------------
+
+describe('realizingInClaudeCode — per-tier invariants', () => {
+  for (const pattern of PATTERNS) {
+    const { slug, realizingInClaudeCode: r } = pattern
+
+    if (!r) {
+      // Graceful-absent: field not yet populated. No assertions.
+      it(`${slug} — absent field passes (graceful-absent migration)`, () => {
+        expect(r).toBeUndefined()
+      })
+      continue
+    }
+
+    describe(`${slug} (Tier ${r.tier})`, () => {
+      // ── All tiers ──────────────────────────────────────────────────────────
+
+      it('tier is one of A|B|C|U', () => {
+        expect(VALID_TIERS.has(r.tier)).toBe(true)
+      })
+
+      it('seeAlso is present', () => {
+        expect(r.seeAlso).toBeDefined()
+      })
+
+      if (r.seeAlso?.siblingPatternSlugs) {
+        it('seeAlso.siblingPatternSlugs all resolve in the catalog', () => {
+          for (const siblingSlug of r.seeAlso!.siblingPatternSlugs!) {
+            expect(ALL_SLUGS.has(siblingSlug), `siblingPatternSlug "${siblingSlug}" not found in catalog`).toBe(true)
+          }
+        })
+      }
+
+      // ── Tier A ─────────────────────────────────────────────────────────────
+
+      if (r.tier === 'A') {
+        it('ccPrimitives is present and non-empty', () => {
+          expect(r.ccPrimitives).toBeDefined()
+          expect(r.ccPrimitives!.length).toBeGreaterThan(0)
+        })
+
+        it('scaffolding is present and non-empty', () => {
+          expect(r.scaffolding).toBeDefined()
+          expect(r.scaffolding!.length).toBeGreaterThan(0)
+        })
+
+        it('workedExample is present with a valid URL', () => {
+          expect(r.workedExample).toBeDefined()
+          assertValidUrl(r.workedExample!.url, `${slug}.workedExample.url`)
+          expect(r.workedExample!.description.trim().length).toBeGreaterThan(0)
+        })
+
+        it('readerMove is present with text ≤25 words and a valid anchorUrl', () => {
+          expect(r.readerMove).toBeDefined()
+          expect(wordCount(r.readerMove!.text)).toBeLessThanOrEqual(25)
+          assertValidUrl(r.readerMove!.anchorUrl, `${slug}.readerMove.anchorUrl`)
+        })
+      }
+
+      // ── Tier B ─────────────────────────────────────────────────────────────
+
+      if (r.tier === 'B') {
+        it('readerMove is present with text ≤25 words and a valid anchorUrl', () => {
+          expect(r.readerMove).toBeDefined()
+          expect(wordCount(r.readerMove!.text)).toBeLessThanOrEqual(25)
+          assertValidUrl(r.readerMove!.anchorUrl, `${slug}.readerMove.anchorUrl`)
+        })
+      }
+
+      // ── Tier C ─────────────────────────────────────────────────────────────
+
+      if (r.tier === 'C') {
+        it('readerMove is present with text ≤25 words and a valid anchorUrl', () => {
+          expect(r.readerMove).toBeDefined()
+          expect(wordCount(r.readerMove!.text)).toBeLessThanOrEqual(25)
+          assertValidUrl(r.readerMove!.anchorUrl, `${slug}.readerMove.anchorUrl`)
+        })
+
+        it('bodyMarkdown is present and non-empty for Tier C', () => {
+          expect(r.bodyMarkdown).toBeDefined()
+          expect(r.bodyMarkdown!.trim().length).toBeGreaterThan(0)
+        })
+      }
+
+      // ── Tier U ─────────────────────────────────────────────────────────────
+
+      if (r.tier === 'U') {
+        it('openingFraming is present and non-empty', () => {
+          expect(r.openingFraming).toBeDefined()
+          expect(r.openingFraming!.trim().length).toBeGreaterThan(0)
+        })
+
+        it('closingRule is present and non-empty', () => {
+          expect(r.closingRule).toBeDefined()
+          expect(r.closingRule!.trim().length).toBeGreaterThan(0)
+        })
+
+        it('umbrellaPointers is present with ≥10 entries', () => {
+          expect(r.umbrellaPointers).toBeDefined()
+          expect(r.umbrellaPointers!.length).toBeGreaterThanOrEqual(10)
+        })
+
+        if (r.umbrellaPointers) {
+          it('all umbrellaPointers[].patternSlug resolve in the catalog', () => {
+            for (const pointer of r.umbrellaPointers!) {
+              expect(
+                ALL_SLUGS.has(pointer.patternSlug),
+                `umbrellaPointer.patternSlug "${pointer.patternSlug}" not found in catalog`,
+              ).toBe(true)
+              expect(
+                pointer.oneLine.trim().length,
+                `umbrellaPointer.oneLine for "${pointer.patternSlug}" must be non-empty`,
+              ).toBeGreaterThan(0)
+            }
+          })
+        }
+      }
+    })
+  }
+})


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
  T[types.ts] -->|adds RealizingInClaudeCode + 6 helper types| P[Pattern.realizingInClaudeCode?]
  P -->|imported by| R[RealizingDisclosure.tsx]
  P -->|validated by| V[realizing.test.ts]
  R -->|wraps| D[DisclosureSection]
  R -->|renders nothing when absent| G{guard: && check}
  S[slug/page.tsx] -->|imports + appends| R
  S -->|third disclosure after Overview + Background| A[ADP satellite pages]
```

## Summary

- Decouples schema from content so the 23 existing satellites ship unchanged while W1.1+ PRs populate the field independently without coordination.
- Graceful-absent migration: `realizingInClaudeCode` is optional on `Pattern`; every satellite page renders identically to pre-PR state until a downstream PR fills the field.
- Vitest validator enforces per-tier invariants at catalog-iteration scope — catches invalid tier values, missing required fields, malformed URLs, oversized reader-move text, and dead slug references before any downstream satellite PR can land.

## Screenshots

Graceful-absent rendering confirmed locally on `/agentic-design-patterns/parallelization` (port 3700, dev server in worktree). No third disclosure renders because `parallelization.ts` does not populate `realizingInClaudeCode`. Screenshot saved at `docs/agentic-bridge/screenshots/w10-graceful-absent-parallelization.png`.

The third disclosure does NOT render on any of the 23 satellite pages because `realizingInClaudeCode` is absent on all patterns in this PR. Visual verification is that the page is byte-identical to pre-PR on every `/agentic-design-patterns/[slug]` route.

## Test plan

- [x] `pnpm test:unit` — 345 tests pass (322 pre-existing + 23 new graceful-absent assertions from `realizing.test.ts`)
- [x] `pnpm lint` — 0 errors, 18 pre-existing warnings (none from new files)
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm build` — 64/64 static pages generated, all 23 ADP satellite slugs compiled; Postgres errors are pre-existing graceful-degradation (no local DB)
- [ ] Visual: satellite page with absent `realizingInClaudeCode` renders no third disclosure — confirmed by build route table showing all 23 ADP slugs compiled without error
- [ ] E2E: not run locally (no DB); CI will run 4-shard playwright suite

## Plan reference

Part of Epic #302, action W1.0. See `docs/agentic-bridge/reframe/action-plan-v1.json`.

Closes #307
