### PR TITLE
feat(adp): Memory Management realizingInClaudeCode Tier B (W1.4)

### DIFF
--- a/src/data/agentic-design-patterns/patterns/memory-management.ts
+++ b/src/data/agentic-design-patterns/patterns/memory-management.ts
@@ -150,6 +150,23 @@ export {}
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-03',
-  lastChangeNote: 'Initial authoring of Memory Management pattern (wave 2; tiered working/episodic/semantic stores).',
+  dateModified: '2026-05-05',
+  lastChangeNote: 'W1.4: add realizingInClaudeCode Tier B (Monday audit move + seeAlso cross-links).',
+  realizingInClaudeCode: {
+    tier: 'B',
+    bodyMarkdown: `
+In Claude Code, Memory Management resolves into three concrete layers: the **context window** (working memory — your \`CLAUDE.md\` files, recent turns, active tool outputs), **skills** (procedural memory — trigger-bearing rules externalised into \`.claude/skills/*/SKILL.md\` files loaded on demand), and **disk artifacts** (episodic memory — \`STATUS.md\`, phase packets, and context-packet files written between agent phases so the next session picks up where the last one left off).
+
+The practical constraint is the always-on token budget. Claude Code loads three files on every session start: the user-level \`~/.claude/CLAUDE.md\`, the repo \`CLAUDE.md\`, and (when present) \`AGENTS.md\`. Their combined token cost is fixed overhead, charged on every invocation regardless of task. When that overhead climbs above roughly 3 000 tokens, the working tier is already crowded before the first tool call. The audit move is the entry point: measure the combined token total with tiktoken \`cl100k_base\` or the proxy \`wc -w × 1.8\`, then lift any rule that carries a trigger condition ("when X", "before X", "each time X") into a skill. A rule that only fires in one context earns its keep in a skill file, not in always-on overhead.
+
+This pattern deliberately overlaps with Context Engineering — Memory Management names the audit; Context Engineering provides the budget rationale. The 12-factor-agent umbrella's closing rule captures the meta-principle: if a rule has a trigger, it belongs in a skill, not here.
+`.trim(),
+    readerMove: {
+      text: 'Audit your three always-on files; sum their Claude-token total via tiktoken cl100k_base or wc -w × 1.8; if > 3K, lift trigger-bearing rules into skills.',
+      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/CLAUDE.md',
+    },
+    seeAlso: {
+      siblingPatternSlugs: ['context-engineering', '12-factor-agent'],
+    },
+  },
 }


### PR DESCRIPTION
## Summary

- Populates `realizingInClaudeCode` on `memory-management.ts` as **Tier B** (Wave 1, action W1.4)
- `readerMove.text` uses `wc -w × 1.8` / tiktoken `cl100k_base` threshold — never `× 1.33`; references 3K combined-token threshold across `~/.claude/CLAUDE.md` + repo `CLAUDE.md` + `AGENTS.md`
- `seeAlso.siblingPatternSlugs = ['context-engineering', '12-factor-agent']` — both slugs resolve in catalog
- Optional `bodyMarkdown` covers three-layer realization (context window / skills / disk artifacts) in ~200 words; no `[draft]` markers; W1.4 forward-reference to 12-factor-agent umbrella present without `[draft]` per wave-1 discipline

## Pre-PR gate

```
pnpm test:unit  → 348/348 pass
pnpm lint       → 0 errors, 18 pre-existing warnings
pnpm typecheck  → clean (0 errors)
grep -F '1.33'  → nothing
grep -F '[draft]' → nothing
```

## Files changed

- `src/data/agentic-design-patterns/patterns/memory-management.ts` — single-file edit, +19 −2

## Plan reference

Part of Epic #302, action W1.4.

## Closes

Closes #311