### PR TITLE
feat(adp): Code Agent realizingInClaudeCode — Tier B + inline Tier C (W2.3)

### DIFF
--- a/src/data/agentic-design-patterns/patterns/code-agent.ts
+++ b/src/data/agentic-design-patterns/patterns/code-agent.ts
@@ -167,6 +167,36 @@ export {}
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-04',
-  lastChangeNote: 'Author Code Agent satellite: read-edit-test loop, Agent-Computer Interface as the differentiator from generic Tool Use, edit-format gotcha.',
+  dateModified: '2026-05-05',
+  lastChangeNote: 'W2.3: add realizingInClaudeCode Tier B + worktree-per-issue inline Tier C.',
+  realizingInClaudeCode: {
+    tier: 'B',
+    ccPrimitives: [
+      'Edit / Bash / Read tool loop (the Agent-Computer Interface Claude Code ships)',
+      'pnpm test:unit → pnpm lint → pnpm typecheck → pnpm test:e2e gate (the test-runner half of the loop)',
+      'subagent-workflow principle 5: "lead agent orchestrates, never edits code directly"',
+    ],
+    bodyMarkdown: `
+Claude Code is not a tool that supports the Code Agent pattern — it is the pattern. The CLI wires the read-edit-test loop directly: the model calls \`Read\`, \`Edit\`, and \`Bash\` tools against a real checkout, runs \`pnpm test:unit\` to get feedback, and iterates. No scaffolding is required to enter the loop; opening a terminal session is the Agent-Computer Interface.
+
+Three layers make the loop disciplined rather than merely runnable. First, a **tool layer**: \`Read\`, \`Edit\`, and \`Bash\` are the ACI primitives; the test-gate command sequence (\`pnpm test:unit → pnpm lint → pnpm typecheck → pnpm test:e2e\`) is the success criterion the loop converges on. Second, a **CLAUDE.md rule**: the subagent-workflow skill encodes the convention as principle 5 — "lead agent orchestrates, never edits code directly." The lead agent plans, dispatches, and reviews; implementer subagents hold the edit tools. This is a workflow convention in this repo's [\`.claude/skills/subagent-workflow/SKILL.md\`](https://github.com/julianken/detached-node/blob/main/.claude/skills/subagent-workflow/SKILL.md), not an enforced technical constraint. Third, a **worktree-per-issue discipline**: each GitHub Issue gets its own git worktree so implementer agents work in isolation and the lead agent's main checkout stays clean.
+
+The worked example is [issue #305](https://github.com/julianken/detached-node/issues/305) + [PR #335](https://github.com/julianken/detached-node/pull/335): a W0.1 hooks-restore task dispatched to a subagent that ran the read-edit-test loop in a dedicated worktree, produced a clean diff, and surfaced it for review — the pattern's lifecycle compressed into a single issue.
+
+<details>
+<summary>Cross-link: worktree-per-issue (Tier C)</summary>
+
+Each GitHub Issue in this repo's subagent workflow gets its own git worktree, created with \`git worktree add .claude/worktrees/wt-NNN-<slug> feat/<slug>\`. The naming places worktrees inside the repo at \`.claude/worktrees/\` so the harness sandbox can reach them without leaving the checkout root. The worktree inherits the repo's \`CLAUDE.md\` automatically; no extra config copy step is needed. The pattern prevents implementer agents from stepping on each other's working trees and keeps the lead agent's main checkout unmodified between dispatches. Remove with \`git worktree remove .claude/worktrees/wt-NNN-<slug>\` after the PR merges.
+
+</details>
+`.trim(),
+    readerMove: {
+      text: 'Add a one-line lead-never-edits rule to your CLAUDE.md and try git worktree add on your next issue.',
+      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/subagent-workflow/SKILL.md',
+    },
+    seeAlso: {
+      skillPath: '.claude/skills/subagent-workflow/SKILL.md',
+      siblingPatternSlugs: ['tool-use-react', 'orchestrator-workers'],
+    },
+  },
 }


### PR DESCRIPTION
## Summary

- Adds `realizingInClaudeCode` to `src/data/agentic-design-patterns/patterns/code-agent.ts` — Tier B compact block framing Claude Code as the Code Agent pattern itself
- Three-layer naming: ACI tool loop (`Read`/`Edit`/`Bash` + `pnpm test:unit` gate), CLAUDE.md lead-never-edits convention (citing `.claude/skills/subagent-workflow/SKILL.md` principle 5 verbatim), worktree-per-issue discipline
- Inline Tier C `<details>` section (~80w) names `git worktree add .claude/worktrees/wt-NNN-<slug>` convention with per-worktree `CLAUDE.md` inheritance
- Single full-URL anchor to issue [#305](https://github.com/julianken/detached-node/issues/305) + [PR #335](https://github.com/julianken/detached-node/pull/335) as worked-example evidence
- `seeAlso.siblingPatternSlugs = ['tool-use-react', 'orchestrator-workers']`

## Gate output

| Check | Result |
|-------|--------|
| `pnpm test:unit` | 369/369 PASS |
| `pnpm lint` | 0 errors (18 pre-existing warnings) |
| `pnpm typecheck` | Clean |
| `pnpm test:e2e` | 59/60 pass; 1 failure pre-existing (posts-listing DB seed missing seeded post — unrelated to this change) |

## Acceptance criteria

- [x] `tier: 'B'` set
- [x] `ccPrimitives` non-empty (3 entries)
- [x] `bodyMarkdown` non-empty (~200w Tier B)
- [x] Inline Tier C `<details>` section (~80w) names `git worktree add .claude/worktrees/wt-NNN-<slug>`
- [x] Tier B body names 'lead agent orchestrates, never edits code directly' from subagent-workflow SKILL.md principle 5
- [x] `readerMove.text` = "Add a one-line lead-never-edits rule to your CLAUDE.md and try git worktree add on your next issue." (19 words, ≤25)
- [x] `readerMove.anchorUrl` = `https://github.com/julianken/detached-node/blob/main/.claude/skills/subagent-workflow/SKILL.md` (HTTP 200)
- [x] Worked-example URLs HTTP 200: issue #305 (200), PR #335 (200)
- [x] `seeAlso.siblingPatternSlugs = ['tool-use-react', 'orchestrator-workers']` (both resolve in catalog)
- [x] No `[draft]`, no `1.33`

## Tier C layering note

Tier C is layered as a `<details>` block embedded inside Tier B's `bodyMarkdown` string — identical to how W1.2 layered the minimal-CLAUDE.md inline Tier C inside context-engineering's Tier A `bodyMarkdown`. The `RealizingInClaudeCode` type's `bodyMarkdown` field (optional on Tier B, required on Tier C) is shared across tiers; a single `bodyMarkdown` string carries both the Tier B prose and the inline Tier C cross-link section.

## Test plan

- [x] `pnpm test:unit` passes (Vitest realizing validator enforces Tier B: `readerMove` + `seeAlso` non-empty; both pass)
- [x] `pnpm lint` 0 errors
- [x] `pnpm typecheck` clean
- [x] `seeAlso.siblingPatternSlugs` both resolve (`tool-use-react`, `orchestrator-workers` present in catalog)
- [x] `readerMove.anchorUrl` parses via `new URL()` and returns HTTP 200
- [x] No `[draft]` marker anywhere in the file
- [x] No `1.33` multiplier anywhere in the file

Closes #315