### PR TITLE
feat(adp): four Tier C cross-link sections across 3 host satellites (W2.9)

### DIFF
--- a/src/data/agentic-design-patterns/patterns/context-engineering.ts
+++ b/src/data/agentic-design-patterns/patterns/context-engineering.ts
@@ -138,7 +138,7 @@ export {}
   ],
   addedAt: '2026-05-03',
   dateModified: '2026-05-05',
-  lastChangeNote: 'Add realizingInClaudeCode Tier A + minimal-CLAUDE.md inline Tier C (W1.2 #309).',
+  lastChangeNote: 'W2.9 additive: 5-section PR body as reviewer context packet cross-link.',
   realizingInClaudeCode: {
     tier: 'A',
     ccPrimitives: [
@@ -176,6 +176,13 @@ Measuring the always-on budget is the prerequisite step. Count tokens in \`CLAUD
 <summary>Cross-link: minimal-CLAUDE.md pattern</summary>
 
 The minimal-CLAUDE.md configuration applies the same token-economics meta-rule at the file level. The editorial split is: unconditional facts about the project (framework, conventions, non-goals) stay in \`CLAUDE.md\`; triggered behaviors (pre-commit checks, screenshot procedures, PR review rubrics) live in \`.claude/skills/\` and load only when invoked. The result is a \`CLAUDE.md\` that is dense with signal per token rather than exhaustive. The user-level meta-rule — "If a rule has a trigger, it belongs in a skill, not here" — is the one-sentence specification for this configuration. Context Engineering names the budget rationale; minimal-CLAUDE.md names the file-level split that implements it.
+
+</details>
+
+<details>
+<summary>Cross-link: 5-section PR body as reviewer context packet</summary>
+
+The five-section PR body (Diagrams / Summary / Screenshots / Test plan / Plan reference) is an engineered context packet for the reviewer's first read. Each section maps to a distinct attention slot: Diagrams anchors visual changes before the diff is opened; Summary compresses scope to a single scroll; Test plan itemizes the pre-review checklist the bot is expected to verify claim-by-claim before scoring the implementation. Placing Test plan before Plan reference is a layout choice, not convention — the sections that require active checking arrive before the sections that are reference-only, matching the U-shape recall curve the pattern documents. [PR #339 (W1.1 Orchestrator-Workers)](https://github.com/julianken/detached-node/pull/339) shows the full five-section structure as read by the julianken-bot reviewer on its first cycle.
 
 </details>`,
   },

--- a/src/data/agentic-design-patterns/patterns/evaluation-llm-as-judge.ts
+++ b/src/data/agentic-design-patterns/patterns/evaluation-llm-as-judge.ts
@@ -148,7 +148,7 @@ export {}
   ],
   addedAt: '2026-05-03',
   dateModified: '2026-05-05',
-  lastChangeNote: 'W2.6 additive: add seeAlso.articleSlug and identity-separated-review sibling cross-link.',
+  lastChangeNote: 'W2.9 additive: Mergify merge-queue structural-lock cross-link + 5-section PR body cross-link.',
 
   realizingInClaudeCode: {
     tier: 'A',
@@ -193,6 +193,20 @@ The 3-finding cap (R3) and the "no filler praise" rule (R4) derive from PR-Agent
 **Credential topology**
 
 The bot PAT lives in macOS Keychain under service \`julianken-bot@github.com\`, account \`token\`. Four accounts cover all bot access: \`password\` (web UI fallback), \`token\` (every \`gh\` call), \`totp-secret\` (TOTP generation via \`scripts/bot-totp.sh\`), and \`recovery-codes\`. The \`GH_TOKEN=$(...) gh\` scoping pattern keeps Julian's main \`gh auth\` state untouched — \`gh auth status\` always shows \`julianken\`, never the bot. The token is never exported, never written to \`.env\` or \`.netrc\`, and never visible in \`ps aux\`.
+
+<details>
+<summary>Cross-link: Mergify merge queue as structural lock</summary>
+
+The merge queue is the infrastructure that closes the cross-tier review loop. The bot's APPROVE is the gate signal: the [\`.mergify.yml\`](https://github.com/julianken/detached-node/blob/main/.mergify.yml) \`queue_conditions\` block requires \`#approved-reviews-by >= 1\` before Mergify rebases the branch, re-runs all CI checks, and squash-merges. In practice this means the reviewer's verdict — not a human clicking a button after the fact — is what opens the merge boundary. The convention of commenting \`@mergifyio queue\` only after the bot APPROVE translates the evaluation pattern's "structured verdict gates the next stage" contract into a deployment primitive. (For OSS projects without paid Mergify, GitHub-native merge queue provides the same structural lock.)
+
+</details>
+
+<details>
+<summary>Cross-link: 5-section PR body as reviewer context packet</summary>
+
+The canonical five-section PR body (Diagrams / Summary / Screenshots / Test plan / Plan reference) is the artifact the julianken-bot reviewer reads before opening the diff. Each section serves the rubric: Diagrams surfaces render changes so R1 (trace-every-claim) has visual evidence; Test plan provides a deterministic checklist the reviewer can verify claim-by-claim; Plan reference anchors the PR to its action-plan entry so scope is auditable. [PR #342 (W2.2 Checkpointing)](https://github.com/julianken/detached-node/pull/342) demonstrates the full shape: five sections, all populated, first-cycle APPROVE with zero BLOCKER findings.
+
+</details>
 `.trim(),
 
     readerMove: {

--- a/src/data/agentic-design-patterns/patterns/human-in-the-loop.ts
+++ b/src/data/agentic-design-patterns/patterns/human-in-the-loop.ts
@@ -154,6 +154,23 @@ export {}
     },
   ],
   addedAt: '2026-05-04',
-  dateModified: '2026-05-04',
-  lastChangeNote: 'Author Human in the Loop satellite: pause-snapshot-resume contract, three sub-variants, automation-bias gotcha.',
+  dateModified: '2026-05-05',
+  lastChangeNote: 'W2.9 additive: Tier C realizingInClaudeCode — Mergify merge-queue as deployment-layer HITL gate.',
+
+  realizingInClaudeCode: {
+    tier: 'C',
+
+    bodyMarkdown: `
+The merge queue is the deployment-layer realization of Human in the Loop at the merge boundary. In this repo, Mergify enforces the gate structurally: the [\`.mergify.yml\`](https://github.com/julianken/detached-node/blob/main/.mergify.yml) declares a \`queue_conditions\` block requiring \`#approved-reviews-by >= 1\` and all CI checks passing before a squash-merge proceeds. The human signal — an explicit collaborator approval — is the precondition the queue checks before the run continues. No approval, no merge; the pending PR sits in the queue until the signal arrives, exactly the pause-and-resume contract the pattern names. The convention in this repo is to wait for the julianken-bot APPROVE before commenting \`@mergifyio queue\`, making the reviewer's verdict the trigger that opens the merge boundary. (Mergify is paid SaaS; GitHub-native merge queue is the OSS substitute.)
+`.trim(),
+
+    readerMove: {
+      text: 'Add `#approved-reviews-by >= 1` to `.mergify.yml` queue_conditions; comment `@mergifyio queue` after the bot approves.',
+      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.mergify.yml',
+    },
+
+    seeAlso: {
+      siblingPatternSlugs: ['evaluation-llm-as-judge', 'guardrails', 'checkpointing'],
+    },
+  },
 }


### PR DESCRIPTION
## Diagrams

No new Mermaid diagrams — this PR adds prose-only bodyMarkdown cross-link sections to existing pattern satellites.

## Summary

Adds four leave-in-bridge Tier C cross-link sections across three host satellite files. Single commit, ~420w new bodyMarkdown total.

**human-in-the-loop.ts** — new Tier C `realizingInClaudeCode` block:
- Names the Mergify merge queue as the deployment-layer realization of Human in the Loop at the merge boundary
- Cites [`.mergify.yml`](https://github.com/julianken/detached-node/blob/main/.mergify.yml) structure + URL anchor
- Includes Risk 13 parenthetical: "Mergify is paid SaaS; GitHub-native merge queue is the OSS substitute"
- Tier C shape: `readerMove` + `seeAlso` + `bodyMarkdown` (all required Tier C fields)

**evaluation-llm-as-judge.ts** — two additive `<details>` blocks inside existing Tier A `bodyMarkdown`:
1. Mergify merge queue as structural lock that closes the cross-tier review loop (bot APPROVE is the gate signal); cites `.mergify.yml`; OSS-substitute note cross-referenced
2. 5-section PR body (Diagrams / Summary / Screenshots / Test plan / Plan reference) as the artifact the reviewer reads first; cites [PR #342 (W2.2 Checkpointing)](https://github.com/julianken/detached-node/pull/342) — first-cycle APPROVE, verified

**context-engineering.ts** — one additive `<details>` block inside existing Tier A `bodyMarkdown`:
- Frames the 5-section PR body as an engineered context packet for the reviewer; layout-rationale angle (Test plan before Plan reference matches U-shape recall curve)
- Cites [PR #339 (W1.1 Orchestrator-Workers)](https://github.com/julianken/detached-node/pull/339) — first-cycle APPROVE, verified (different from Section 3 to diversify citations)

## Screenshots

No visual changes — data-only edits to TypeScript pattern satellite files. The `RealizingDisclosure` component renders from this data; visual output is covered by existing E2E tests.

## Test plan

- [x] `pnpm test:unit` — 402/402 pass (31 test files; `realizing.test.ts` validates all Tier A invariants on existing fields remain intact; new Tier C `realizingInClaudeCode` on `human-in-the-loop` passes Tier C required-field checks)
- [x] `pnpm lint` — 0 errors, 18 pre-existing warnings (unchanged)
- [x] `pnpm typecheck` — clean (0 errors)
- [x] `pnpm lint:adp` — typecheck-sketches OK, validate-references OK, check-affiliate-links OK, lint-changelog OK
- [ ] `pnpm test:e2e` — requires Postgres (CI only; local Postgres role not provisioned); CI will run all 4 shards
- [x] `.mergify.yml` URL: `curl -s -o /dev/null -w "%{http_code}" https://github.com/julianken/detached-node/blob/main/.mergify.yml` → **200**
- [x] PR #342 URL: `https://github.com/julianken/detached-node/pull/342` → **200**; julianken-bot review count = 1 (first-cycle APPROVE)
- [x] PR #339 URL: `https://github.com/julianken/detached-node/pull/339` → **200**; julianken-bot review count = 1 (first-cycle APPROVE)
- [x] Substantive editorial grep (`miss\b|gap\b|caught|flagged|the bot found|fail.open|failure mode|anti.example`) → **0 hits**
- [x] Risk 13 parenthetical present on Section 1 (human-in-the-loop): ✓
- [x] Tier A invariants on existing `evaluation-llm-as-judge` and `context-engineering` `realizingInClaudeCode` blocks unchanged: ✓
- [x] context-engineering Tier C block count: 2 (minimal-CLAUDE.md + 5-section PR body) — within cap of 2 per coherence check #6

## Plan reference

Action `W2.9` from `docs/agentic-bridge/reframe/action-plan-v1.json`. Last in Wave 2; blocks W3.3.

Closes #321