### PR TITLE
infra: add scripts/verify_bridge_urls.sh (TOOL-1, #327)

### DIFF
--- a/scripts/verify_bridge_urls.sh
+++ b/scripts/verify_bridge_urls.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Verify every full GitHub URL anchor in bridge content resolves; calendar-driven cadence (TOOL-1, not CI-integrated per RISK-2).
+
+set -euo pipefail
+
+BRIDGE_DIRS=(
+  "src/data/agentic-design-patterns/patterns"
+  "scripts/seed-cross-identity-code-review.ts"
+  "scripts/seed-test-db.ts"
+  "scripts/seed-theme-hero.ts"
+)
+
+REPO_SLUG="julianken/detached-node"
+REPO_URL_PREFIX="https://github.com/${REPO_SLUG}"
+
+failures=()
+urls=()
+pass_count=0
+
+# Collect all unique full GitHub repo URLs from bridge content
+while IFS= read -r line; do urls+=("$line"); done < <(
+  grep -roh "https://github\.com/${REPO_SLUG}[^[:space:],'\")\`]*" \
+    "${BRIDGE_DIRS[@]}" 2>/dev/null \
+  | sort -u
+)
+
+if [[ ${#urls[@]} -eq 0 ]]; then
+  echo "No bridge URLs found — nothing to verify." >&2
+  exit 0
+fi
+
+for url in "${urls[@]}"; do
+  # PRs: use gh pr view for authoritative state check
+  if [[ "$url" =~ /pull/([0-9]+)$ ]]; then
+    pr_num="${BASH_REMATCH[1]}"
+    state=$(gh pr view "$pr_num" --repo "$REPO_SLUG" --json state --jq '.state' 2>/dev/null || echo "ERROR")
+    if [[ -z "$state" || "$state" == "ERROR" ]]; then
+      failures+=("$url: gh-pr-error (no JSON / command failed)")
+    else
+      echo "OK [pr:${state}] $url"
+      (( pass_count++ )) || true
+    fi
+
+  # Issues: use gh issue view
+  elif [[ "$url" =~ /issues/([0-9]+)$ ]]; then
+    issue_num="${BASH_REMATCH[1]}"
+    state=$(gh issue view "$issue_num" --repo "$REPO_SLUG" --json state --jq '.state' 2>/dev/null || echo "ERROR")
+    if [[ -z "$state" || "$state" == "ERROR" ]]; then
+      failures+=("$url: gh-issue-error (no JSON / command failed)")
+    else
+      echo "OK [issue:${state}] $url"
+      (( pass_count++ )) || true
+    fi
+
+  # All other URLs (blob/main/...) — HEAD check via curl
+  else
+    http_code=$(curl -sI -L -o /dev/null -w '%{http_code}' "$url" 2>/dev/null || echo "000")
+    if [[ "$http_code" == "200" ]]; then
+      echo "OK [${http_code}] $url"
+      (( pass_count++ )) || true
+    else
+      failures+=("$url: HTTP ${http_code}")
+    fi
+  fi
+done
+
+echo ""
+echo "--- verify_bridge_urls summary ---"
+echo "Checked : $((pass_count + ${#failures[@]}))"
+echo "Passed  : $pass_count"
+echo "Failed  : ${#failures[@]}"
+
+if [[ ${#failures[@]} -gt 0 ]]; then
+  echo ""
+  echo "FAILURES:"
+  for f in "${failures[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+
+exit 0

--- a/scripts/verify_bridge_urls.sh
+++ b/scripts/verify_bridge_urls.sh
@@ -13,6 +13,14 @@ BRIDGE_DIRS=(
 REPO_SLUG="julianken/detached-node"
 REPO_URL_PREFIX="https://github.com/${REPO_SLUG}"
 
+# Validate every BRIDGE_DIRS entry exists before proceeding
+for dir in "${BRIDGE_DIRS[@]}"; do
+  if [[ ! -e "$dir" ]]; then
+    echo "ERROR: BRIDGE_DIRS path missing: $dir — paths may be stale; aborting" >&2
+    exit 1
+  fi
+done
+
 failures=()
 urls=()
 pass_count=0
@@ -25,8 +33,8 @@ while IFS= read -r line; do urls+=("$line"); done < <(
 )
 
 if [[ ${#urls[@]} -eq 0 ]]; then
-  echo "No bridge URLs found — nothing to verify." >&2
-  exit 0
+  echo "ERROR: BRIDGE_DIRS produced no URLs — paths may be stale; aborting" >&2
+  exit 1
 fi
 
 for url in "${urls[@]}"; do


### PR DESCRIPTION
## Diagrams

\`\`\`mermaid
flowchart TD
    A[scripts/verify_bridge_urls.sh] --> B{URL type?}
    B -- pull/NNN --> C[gh pr view NNN --json state]
    B -- issues/NNN --> D[gh issue view NNN --json state]
    B -- blob/main/... --> E[curl -sI -L -o /dev/null -w http_code]
    C --> F{state present?}
    D --> F
    E --> G{HTTP 200?}
    F -- yes --> OK[OK — log state]
    F -- no --> FAIL[failures list]
    G -- yes --> OK
    G -- no --> FAIL
    OK --> SUM[Summary: checked / passed / failed]
    FAIL --> SUM
    SUM -- failed == 0 --> EXIT0[exit 0]
    SUM -- failed > 0 --> EXIT1[exit 1 + diff-style output]
\`\`\`

## Summary

- Adds `scripts/verify_bridge_urls.sh` (TOOL-1): greps every full `https://github.com/julianken/detached-node/…` anchor from bridge content (satellite pattern `.ts` files + article seed scripts), checks PRs/issues via `gh` CLI for authoritative state, and HEAD-checks all other anchors via `curl -sI`.
- Calendar-driven cadence per RISK-2 — **not integrated into CI** (network fetches explicitly out-of-scope per `action-plan-v1.json` RISK-2 + cycle-2 addendum on issue #327).
- Idempotent: re-running always produces the same check results with no side effects.

## Screenshots

N/A — not UI

## Test plan

- [x] `pnpm test:unit` — 406 tests passed (31 files)
- [x] `pnpm lint` — 0 errors (18 pre-existing warnings, unchanged)
- [x] `pnpm typecheck` — clean
- [x] `bash scripts/verify_bridge_urls.sh` — exit 0, 12/12 URLs green (5 blob anchors + 6 PRs + 1 issue)
- [x] Script is executable (`chmod +x` applied, `create mode 100755` in commit)
- [x] No `.github/workflows/` files touched — confirmed no CI integration added

## Plan reference

Part of Epic #302 (Agentic Bridge), Wave 3 Band A. See `docs/agentic-bridge/reframe/action-plan-v1.json` tooling_deliverables `TOOL-1`.

Closes #327