### PR TITLE
infra: add meta-rule consistency check (TOOL-2) + CI workflow

### DIFF
--- a/.github/workflows/meta-rule-consistency.yml
+++ b/.github/workflows/meta-rule-consistency.yml
@@ -1,0 +1,23 @@
+name: Meta-Rule Consistency
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/data/agentic-design-patterns/patterns/12-factor-agent.ts'
+      - 'src/data/agentic-design-patterns/patterns/context-engineering.ts'
+      - 'src/data/agentic-design-patterns/patterns/memory-management.ts'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Meta-Rule Consistency
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check meta-rule consistency
+        run: bash scripts/check_meta_rule_consistency.sh

--- a/scripts/check_meta_rule_consistency.sh
+++ b/scripts/check_meta_rule_consistency.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Verify that the user-CLAUDE.md token-economics meta-rule is present byte-identically in every pattern file that cites it.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PATTERNS_DIR="$REPO_ROOT/src/data/agentic-design-patterns/patterns"
+
+# Verbatim fingerprint from ~/.claude/CLAUDE.md — the identifying substring shared by all citing files.
+# Full source sentence: If a rule has a trigger ("when adding screenshots", "before committing",
+# "during PR review"), it belongs in a skill, not here.
+META_RULE='it belongs in a skill, not here'
+
+# Files that must contain the meta-rule when they exist.
+# 12-factor-agent.ts will be added here once W3.1 (#322) lands.
+TARGETS=(
+  "$PATTERNS_DIR/context-engineering.ts"
+  "$PATTERNS_DIR/memory-management.ts"
+)
+
+FAILED=0
+for FILE in "${TARGETS[@]}"; do
+  if [[ ! -f "$FILE" ]]; then
+    echo "SKIP: $FILE (not present)"
+    continue
+  fi
+  if grep -qF "$META_RULE" "$FILE"; then
+    echo "OK:   $FILE"
+  else
+    echo "FAIL: $FILE — meta-rule fingerprint not found"
+    echo "      Expected: $META_RULE"
+    FAILED=1
+  fi
+done
+
+if [[ $FAILED -ne 0 ]]; then
+  echo ""
+  echo "Meta-rule consistency check failed. Ensure each citing file contains:"
+  echo "  $META_RULE"
+  exit 1
+fi
+
+echo ""
+echo "Meta-rule consistency check passed."


### PR DESCRIPTION
## Summary

- Adds `scripts/check_meta_rule_consistency.sh`: greps for the token-economics meta-rule fingerprint (`it belongs in a skill, not here`) across `context-engineering.ts` and `memory-management.ts`, asserting byte-identical presence; exits 0 on match, 1 with a diagnostic on mismatch
- Adds `.github/workflows/meta-rule-consistency.yml`: triggers on PRs touching `12-factor-agent.ts`, `context-engineering.ts`, or `memory-management.ts`; runs the script as the `Meta-Rule Consistency` check
- `12-factor-agent.ts` is handled gracefully: skipped if absent, enforced once W3.1 (#322) adds the verbatim quote and the script is updated
- `.mergify.yml` is NOT modified (adding the new required check is scoped to W3.1 per the issue)
- Mitigates Risk 7 (meta-rule drift) and Risk 11 (silent citation rot) from `docs/agentic-bridge/reframe/analysis-v1.md`

## Test plan

- [x] `bash scripts/check_meta_rule_consistency.sh` → exit 0 against current repo state
- [x] `pnpm test:unit` → 406 tests passed (31 files)
- [x] `pnpm lint` → 0 errors
- [x] `pnpm typecheck` → clean
- [ ] CI: verify `Meta-Rule Consistency` check appears and passes on this PR's diff (no pattern files touched → workflow skips; expected green)

## Files created

- `scripts/check_meta_rule_consistency.sh` — bash consistency checker, executable
- `.github/workflows/meta-rule-consistency.yml` — CI workflow (paths-filtered PR trigger)

## Verbatim meta-rule enforced

```
it belongs in a skill, not here
```

Source: `~/.claude/CLAUDE.md` line 3 — `If a rule has a trigger ("when adding screenshots", "before committing", "during PR review"), it belongs in a skill, not here.`

## Notes

- The workflow check name is `Meta-Rule Consistency` (job name in the YAML). Adding it to `.mergify.yml` required checks is deferred to W3.1 (#322) per issue AC.
- Once W3.1 adds the verbatim quote to `12-factor-agent.ts`, add that file to the `TARGETS` array in the script and update the comment.

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)