### PR TITLE
feat(adp): Reflexion + Streaming honest-absence Tier D pointers (W3.2)

### DIFF
--- a/src/data/agentic-design-patterns/patterns/reflexion.ts
+++ b/src/data/agentic-design-patterns/patterns/reflexion.ts
@@ -11,7 +11,7 @@ export const pattern: Pattern = {
   bodySummary: [
     'Reflexion teaches a language agent to learn from its own trajectories without touching model weights. After each attempt, the agent inspects the trajectory and any environment feedback, then writes a short verbal critique — a paragraph that names what went wrong and what to try next. That critique is appended to an episodic memory buffer keyed by task or task class. On the next attempt, the agent retrieves the most recent and most relevant critiques and conditions its plan on them, treating prior failures as instructions rather than as silent gradient signal.',
     'The pattern straddles two layers. As Topology it shapes the control flow: a generator-execute-evaluate loop that, on failure, branches into a critique step before retrying. As State it maintains durable, retrievable memory whose unit is a natural-language lesson, not an embedding of a previous answer. The mechanism only earns its keep when failures are diagnosable from the trajectory itself — the agent must be able to articulate, in words, what an outside observer could also see. Tasks where failure is invisible (a stale tool, a wrong premise the agent never questioned) defeat the loop, because the critique is grounded in nothing.',
-    'Reflexion sits next to but distinct from a within-attempt generator-critic loop. Self-Refine iterates on a single output until a critic stops complaining; Reflexion iterates across attempts, so the lesson outlives the run and the next encounter with the same problem class starts informed. The cost is operational, not algorithmic: someone has to decide what counts as the same task, how many critiques to retrieve, when to compact the buffer, and which model writes the critique. The default of having the same model judge its own work is the hazard the pattern is most often deployed without noticing.',
+    'Reflexion sits next to but distinct from a within-attempt generator-critic loop. Self-Refine iterates on a single output until a critic stops complaining; Reflexion iterates across attempts, so the lesson outlives the run and the next encounter with the same problem class starts informed. The cost is operational, not algorithmic: someone has to decide what counts as the same task, how many critiques to retrieve, when to compact the buffer, and which model writes the critique. The default of having the same model judge its own work is the hazard the pattern is most often deployed without noticing. Reflexion does not have its own Claude Code realization in this catalog yet; the closest in-repo realization of the critic-feedback loop is `evaluation-llm-as-judge` — both patterns turn on an identity-separated judge over generated output, differing mainly in time-scale (per-PR rather than per-iteration) and in whether the lesson persists across runs.',
   ],
   mermaidSource: `graph LR
   A[Task] --> B[Generate]
@@ -143,6 +143,6 @@ export {}
     },
   ],
   addedAt: '2026-05-02',
-  dateModified: '2026-05-03',
-  lastChangeNote: 'Initial authoring as the Phase-1 exemplar.',
+  dateModified: '2026-05-05',
+  lastChangeNote: 'W3.2 — Tier D honest-absence pointer: adjacent realization → evaluation-llm-as-judge.',
 }

--- a/src/data/agentic-design-patterns/patterns/streaming.ts
+++ b/src/data/agentic-design-patterns/patterns/streaming.ts
@@ -9,7 +9,7 @@ export const pattern: Pattern = {
   bodySummary: [
     'Streaming changes when the model\'s output reaches the consumer: bytes leave the inference server the moment they are generated, rather than accumulating until the full response is ready. The transport is almost always Server-Sent Events — a long-lived HTTP response whose body is a sequence of newline-delimited data frames the client parses as it reads. Each frame carries a small typed delta: a chunk of generated text, a partial JSON fragment of a tool call, an updated finish reason, or a terminal event that closes the stream. The consumer reconstructs the final state by accumulating deltas in order; nothing is broadcast and nothing is replayed.',
     'Three sub-variants share the same wire shape but differ in what is being incrementally revealed. Token streaming emits text deltas one fragment at a time and is what every chat UI renders character-by-character. Structured streaming emits a partial JSON object whose shape is fixed by a schema — the Vercel AI SDK\'s streamObject exposes the partial as a typed value at every step, so a form fills in field-by-field instead of appearing all at once. Tool-call streaming emits the arguments of a function call as they are generated; a long argument list becomes visible before the model has finished writing it, and a UI can begin rendering the call before dispatch.',
-    'The pattern is a UX contract change as much as a transport detail. A thirty-second response that streams feels usable because the user sees evidence of work within the first hundred milliseconds; the same thirty seconds behind a single blocking request reads as a hung connection. Streaming is distinct from polling, where the client repeatedly asks whether the result is ready, and from progress events, which are out-of-band metadata about an otherwise-blocking operation. With streaming, the partial output is the operation.',
+    'The pattern is a UX contract change as much as a transport detail. A thirty-second response that streams feels usable because the user sees evidence of work within the first hundred milliseconds; the same thirty seconds behind a single blocking request reads as a hung connection. Streaming is distinct from polling, where the client repeatedly asks whether the result is ready, and from progress events, which are out-of-band metadata about an otherwise-blocking operation. With streaming, the partial output is the operation. Streaming does not have its own Claude Code realization in this catalog yet; the closest in-repo realization of incremental tool-call output is `tool-use-react` — that pattern\'s PreToolUse hook intercepts the call at the argument-complete boundary, which is the harness-level equivalent of acting on a stream at the moment the argument delta closes rather than after the full response returns.',
   ],
   mermaidSource: `graph LR
   A[Client request] --> B[Inference server]
@@ -137,6 +137,6 @@ export {}
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-04',
-  lastChangeNote: 'Author Streaming satellite: SSE event-flow, token vs structured vs tool-call variants, mid-stream-error gotcha.',
+  dateModified: '2026-05-05',
+  lastChangeNote: 'W3.2 — Tier D honest-absence pointer: adjacent realization → tool-use-react.',
 }


### PR DESCRIPTION
## Summary

- Add Adjacent realization pointer to `reflexion.ts` bodySummary: closest in-repo realization of the critic-feedback loop is `evaluation-llm-as-judge` (identity-separated judge over generated output; same structural property at per-PR time-scale)
- Add Adjacent realization pointer to `streaming.ts` bodySummary: closest in-repo realization of incremental tool-call output is `tool-use-react` (PreToolUse hook acts at the argument-complete boundary, structurally equivalent to acting on a stream when the argument delta closes)
- `realizingInClaudeCode` field stays undefined on both patterns (Tier D = honest absence)

## Gate results

- `pnpm test:unit`: 406 tests passed (31 files)
- `pnpm lint` + `pnpm lint:adp`: 0 errors (18 pre-existing warnings, all unrelated)
- `pnpm typecheck`: clean
- Substantive grep (`miss\b|gap\b|fail.open|anti.example|caught`): **0 hits**
- `grep -E 'realizingInClaudeCode\s*[:=]' reflexion.ts streaming.ts`: **0 hits**

## Adjacent sibling rationale

**Reflexion → `evaluation-llm-as-judge`**: Both patterns turn on an identity-separated judge producing structured feedback over generated content. The `evaluation-llm-as-judge` satellite's body already explicitly cites the Reflexion gotcha as "the class-level concern that the Reflexion gotcha names as one instance," confirming structural alignment. The difference is time-scale (per-PR vs per-iteration) and whether the lesson persists across runs.

**Streaming → `tool-use-react`**: Streaming's third sub-variant is tool-call streaming — emitting argument deltas before the model finishes writing them. `tool-use-react`'s Tier C realization (PreToolUse hook) intercepts exactly at the argument-complete boundary, which is the harness-level analogue of acting on a stream at delta-close. `tool-use-react` is already in Streaming's `relatedSlugs`, grounding the pointer structurally.

## Test plan

- [x] Unit tests pass
- [x] Lint clean (no new errors)
- [x] TypeScript clean
- [x] `realizingInClaudeCode` absent from both files
- [x] Substantive grep returns 0 hits
- [x] No anti-example framing in added prose

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)