### PR TITLE
chore: add realizes: frontmatter to 5 active SKILL.md (W3.4)

### DIFF
--- a/.claude/skills/analysis-funnel/SKILL.md
+++ b/.claude/skills/analysis-funnel/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: analysis-funnel
 description: Structured 5→5→3→1 investigation pipeline that sends parallel agents to explore facets of a question, iterates on findings, and produces a comprehensive analysis report. Use this whenever the user asks to "analyze", "investigate", "audit", "assess", or "do a deep-dive on" a broad, open-ended topic where the goal is understanding (codebase health checks, technology assessments, architecture audits, research questions) rather than implementing a fix. Do NOT use for implementation planning (prefer decision-funnel or creative-funnel) or for tasks with a known answer.
+realizes:
+  - orchestrator-workers
+  - parallelization
+  - checkpointing
+  - prompt-chaining
 ---
 
 # Analysis Funnel: 5→5→3→1 Investigation Method

--- a/.claude/skills/creative-funnel/SKILL.md
+++ b/.claude/skills/creative-funnel/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: creative-funnel
 description: Parallel creative production pipeline (N items) with spec review and quality review cycles per item, disk checkpoints, and crash recovery. Produces N creative artifacts + structured documentation.
+realizes:
+  - orchestrator-workers
+  - parallelization
+  - checkpointing
+  - evaluator-optimizer
 ---
 
 # Creative Funnel: N-Item Parallel Production Pipeline

--- a/.claude/skills/decision-funnel/SKILL.md
+++ b/.claude/skills/decision-funnel/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: decision-funnel
 description: Structured investigate-iterate-synthesize pipeline (5->5->3->1) that sends parallel agents to explore different facets of a problem, iterates on findings, progressively synthesizes, and produces a detailed execution plan
+realizes:
+  - orchestrator-workers
+  - parallelization
+  - checkpointing
+  - planning
+  - prompt-chaining
 ---
 
 # Decision Funnel: 5→5→3→1 Investigation Method

--- a/.claude/skills/design-review/SKILL.md
+++ b/.claude/skills/design-review/SKILL.md
@@ -5,6 +5,7 @@ user-invocable: true
 disable-model-invocation: true
 context: fork
 agent: design-reviewer
+realizes: []
 ---
 
 # Design Review

--- a/.claude/skills/subagent-workflow/SKILL.md
+++ b/.claude/skills/subagent-workflow/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: subagent-workflow
 description: MANDATORY for all multi-step tasks - parallel task execution with sequential per-task workflow (implementer → spec review → quality review) with GitHub Issues as source of truth
+realizes:
+  - orchestrator-workers
+  - parallelization
+  - human-in-the-loop
+  - identity-separated-review
 ---
 
 # Subagent-Driven Development Workflow


### PR DESCRIPTION
## Summary

- Adds `realizes:` YAML frontmatter field to all 5 repo-canonical SKILL.md files at `.claude/skills/`
- Field is advisory only; no lint enforcement added (deferred per phase-0 default Q5)
- All cited slugs resolve as files in `src/data/agentic-design-patterns/patterns/`

## Pattern mappings

| SKILL.md | realizes: slugs |
|----------|-----------------|
| `analysis-funnel` | `orchestrator-workers`, `parallelization`, `checkpointing`, `prompt-chaining` |
| `decision-funnel` | `orchestrator-workers`, `parallelization`, `checkpointing`, `planning`, `prompt-chaining` |
| `creative-funnel` | `orchestrator-workers`, `parallelization`, `checkpointing`, `evaluator-optimizer` |
| `design-review` | `[]` — browser-navigate checklist skill; no strong pattern match |
| `subagent-workflow` | `orchestrator-workers`, `parallelization`, `human-in-the-loop`, `identity-separated-review` |

## Parser tolerance

TOOL-3 (#352, `tests/manual/skill-frontmatter-unknown-key.md`) confirmed that the Claude Code frontmatter parser tolerates unknown `realizes:` keys without erroring. No code changes required.

## Gate output

- `pnpm test:unit`: 31 files, 406 tests — all passed
- `pnpm lint`: 0 errors, 18 warnings (pre-existing)
- `pnpm typecheck`: clean

E2E skipped per task spec (frontmatter-only change, no runtime impact).

## AC verification

```
for f in .claude/skills/*/SKILL.md; do grep -q "^realizes:" "$f" || echo "MISSING: $f"; done
```
Returns no MISSING lines.

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)