### PR TITLE
feat(adp): nine skill-only patterns Tier C pointers (W3.3)

### DIFF
--- a/src/data/agentic-design-patterns/patterns/a2a.ts
+++ b/src/data/agentic-design-patterns/patterns/a2a.ts
@@ -153,6 +153,24 @@ export {}
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-04',
-  lastChangeNote: 'Author A2A satellite: Agent Card discovery, Task lifecycle, distinction from MCP and in-process Handoffs.',
+  dateModified: '2026-05-05',
+  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — subagent-workflow Task() dispatch as lightweight A2A realization.',
+
+  realizingInClaudeCode: {
+    tier: 'C',
+
+    bodyMarkdown: `
+The [subagent-workflow skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/subagent-workflow/SKILL.md) realizes a lightweight in-process A2A protocol using Claude Code's Task() primitive. Each implementer, spec reviewer, and quality reviewer is dispatched with a structured prompt that functions as an implicit Agent Card: it names the agent's role, working directory, issue number, PR reference, and expected deliverable. The orchestrator sends tasks and receives completions without shared state — each agent is isolated to its worktree. The protocol does not use the Google A2A spec's JSON-over-HTTP Task lifecycle, but mirrors its conceptual shape: structured task dispatch, isolated execution, result surfaced back to the orchestrating agent. [PR #335](https://github.com/julianken/detached-node/pull/335) and [PR #344](https://github.com/julianken/detached-node/pull/344) are instances of this dispatch protocol completing in production.
+`.trim(),
+
+    readerMove: {
+      text: 'Write each Task() prompt as a structured agent card: role, working directory, issue reference, and expected deliverable format.',
+      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/subagent-workflow/SKILL.md',
+    },
+
+    seeAlso: {
+      skillPath: '.claude/skills/subagent-workflow/SKILL.md',
+      siblingPatternSlugs: ['orchestrator-workers', 'handoffs-swarm', 'mcp'],
+    },
+  },
 }

--- a/src/data/agentic-design-patterns/patterns/agentic-rag.ts
+++ b/src/data/agentic-design-patterns/patterns/agentic-rag.ts
@@ -139,6 +139,24 @@ export {}
     },
   ],
   addedAt: '2026-05-04',
-  dateModified: '2026-05-04',
-  lastChangeNote: 'Initial authoring of Agentic RAG pattern (iterative retrieval loop; contrasts with single-shot RAG).',
+  dateModified: '2026-05-05',
+  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — analysis-funnel MCP-grounded investigation as agentic RAG realization.',
+
+  realizingInClaudeCode: {
+    tier: 'C',
+
+    bodyMarkdown: `
+The [analysis-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/analysis-funnel/SKILL.md) mandates agentic retrieval for every investigation phase: "Use MCP servers to fill in gaps before framing, not during." Each Phase 1 investigator actively queries Context7 for up-to-date library documentation, GitHub Issues for issue context, and codebase tools for current architecture before generating findings. This is the agentic variant of RAG — retrieval is driven by the agent mid-task via tool calls, not pre-loaded into a static prompt. The phase-0 context packet lists artifact paths and domain scope; investigators retrieve against those anchors on demand. The instruction "grounding every phase in real data is the difference between an analysis and a plausible-sounding guess" captures the pattern's mandate directly. [PR #336](https://github.com/julianken/detached-node/pull/336) shows a funnel run grounded in live codebase queries.
+`.trim(),
+
+    readerMove: {
+      text: 'Instruct each investigator to query MCP tools for real data before generating findings; never pre-load static context.',
+      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/analysis-funnel/SKILL.md',
+    },
+
+    seeAlso: {
+      skillPath: '.claude/skills/analysis-funnel/SKILL.md',
+      siblingPatternSlugs: ['rag', 'tool-use-react', 'context-engineering'],
+    },
+  },
 }

--- a/src/data/agentic-design-patterns/patterns/agentic-rag.ts
+++ b/src/data/agentic-design-patterns/patterns/agentic-rag.ts
@@ -140,22 +140,22 @@ export {}
   ],
   addedAt: '2026-05-04',
   dateModified: '2026-05-05',
-  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — analysis-funnel MCP-grounded investigation as agentic RAG realization.',
+  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — decision-funnel MCP-grounded investigation as agentic RAG realization.',
 
   realizingInClaudeCode: {
     tier: 'C',
 
     bodyMarkdown: `
-The [analysis-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/analysis-funnel/SKILL.md) mandates agentic retrieval for every investigation phase: "Use MCP servers to fill in gaps before framing, not during." Each Phase 1 investigator actively queries Context7 for up-to-date library documentation, GitHub Issues for issue context, and codebase tools for current architecture before generating findings. This is the agentic variant of RAG — retrieval is driven by the agent mid-task via tool calls, not pre-loaded into a static prompt. The phase-0 context packet lists artifact paths and domain scope; investigators retrieve against those anchors on demand. The instruction "grounding every phase in real data is the difference between an analysis and a plausible-sounding guess" captures the pattern's mandate directly. [PR #336](https://github.com/julianken/detached-node/pull/336) shows a funnel run grounded in live codebase queries.
+The [decision-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md) mandates agentic retrieval throughout every phase: "Throughout every phase, actively use available MCP servers to query for real data rather than relying on assumptions or stale knowledge." Each Phase 1 investigator actively queries Context7 for up-to-date library documentation, GitHub Issues for issue context, and codebase tools for current architecture before generating findings. This is the agentic variant of RAG — retrieval is driven by the agent mid-task via tool calls, not pre-loaded into a static prompt. The phase-0 context packet lists artifact paths and domain scope; investigators retrieve against those anchors on demand. [PR #336](https://github.com/julianken/detached-node/pull/336) shows a funnel run grounded in live codebase queries.
 `.trim(),
 
     readerMove: {
-      text: 'Instruct each investigator to query MCP tools for real data before generating findings; never pre-load static context.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/analysis-funnel/SKILL.md',
+      text: 'Instruct each investigator to query MCP tools for real data throughout every phase; never pre-load static context.',
+      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md',
     },
 
     seeAlso: {
-      skillPath: '.claude/skills/analysis-funnel/SKILL.md',
+      skillPath: '.claude/skills/decision-funnel/SKILL.md',
       siblingPatternSlugs: ['rag', 'tool-use-react', 'context-engineering'],
     },
   },

--- a/src/data/agentic-design-patterns/patterns/evaluator-optimizer.ts
+++ b/src/data/agentic-design-patterns/patterns/evaluator-optimizer.ts
@@ -151,6 +151,24 @@ export {}
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-04',
-  lastChangeNote: 'Author Evaluator-Optimizer satellite: within-attempt generator-critic loop, contrast with Reflexion, base-capability-ceiling gotcha.',
+  dateModified: '2026-05-05',
+  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — creative-funnel spec+quality review cycle as evaluator-optimizer realization.',
+
+  realizingInClaudeCode: {
+    tier: 'C',
+
+    bodyMarkdown: `
+The [creative-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/creative-funnel/SKILL.md) is evaluator-optimizer with two named critic roles and a capped iteration budget. Phase 1 creates N artifacts (generator). Phase 2 dispatches N spec reviewers who each return APPROVED or REVISION NEEDED with actionable instructions (evaluator pass 1). Failed items are revised and re-reviewed; maximum two cycles. Phase 3 dispatches N quality reviewers who rate craft and return APPROVED or POLISH NEEDED (evaluator pass 2). Failed items are polished and re-reviewed; maximum two cycles. After two failures the item is flagged for human attention rather than looped — the skill names the cap explicitly as an anti-drift measure. The two-gate structure separates correctness evaluation (spec) from quality evaluation (craft), matching the pattern's requirement that the evaluator produce actionable feedback the generator can act on. [PR #341](https://github.com/julianken/detached-node/pull/341) used this review structure.
+`.trim(),
+
+    readerMove: {
+      text: 'Separate spec review (correctness) from quality review (craft); cap each at two cycles; flag rather than loop after two failures.',
+      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/creative-funnel/SKILL.md',
+    },
+
+    seeAlso: {
+      skillPath: '.claude/skills/creative-funnel/SKILL.md',
+      siblingPatternSlugs: ['reflexion', 'evaluation-llm-as-judge', 'guardrails'],
+    },
+  },
 }

--- a/src/data/agentic-design-patterns/patterns/handoffs-swarm.ts
+++ b/src/data/agentic-design-patterns/patterns/handoffs-swarm.ts
@@ -148,6 +148,24 @@ export async function runSwarm(messages: { role: 'user' | 'assistant'; content: 
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-04',
-  lastChangeNote: 'Author Handoffs / Swarm satellite: sequential conversation ownership, transfer-as-tool-call, supervisor variant.',
+  dateModified: '2026-05-05',
+  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — subagent-workflow handoff chain as Handoffs/Swarm realization.',
+
+  realizingInClaudeCode: {
+    tier: 'C',
+
+    bodyMarkdown: `
+The [subagent-workflow skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/subagent-workflow/SKILL.md) wires a three-agent handoff chain for every GitHub Issue. Step 3 dispatches an implementer who owns the worktree and produces the PR. Step 4 hands off to a spec-compliance reviewer who reads the acceptance criteria and checks the diff. Step 5 hands off to a quality reviewer who checks conventions, security, and test coverage. Each handoff is explicit — the next agent receives the PR number and the preceding review's verdict as structured context. The chain is sequential within each issue and parallel across issues (all implementers run in one dispatch message). Principle 6 enforces handoff integrity: "Fixes stay in the same worktree/PR — never create a new PR for review fixes." [PR #344](https://github.com/julianken/detached-node/pull/344) and [PR #350](https://github.com/julianken/detached-node/pull/350) are instances of this chain completing in production.
+`.trim(),
+
+    readerMove: {
+      text: 'Model the implementer → spec-reviewer → quality-reviewer chain as three sequential dispatches per issue; never split fixes to a new PR.',
+      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/subagent-workflow/SKILL.md',
+    },
+
+    seeAlso: {
+      skillPath: '.claude/skills/subagent-workflow/SKILL.md',
+      siblingPatternSlugs: ['routing', 'orchestrator-workers', 'human-in-the-loop'],
+    },
+  },
 }

--- a/src/data/agentic-design-patterns/patterns/human-in-the-loop.ts
+++ b/src/data/agentic-design-patterns/patterns/human-in-the-loop.ts
@@ -155,13 +155,15 @@ export {}
   ],
   addedAt: '2026-05-04',
   dateModified: '2026-05-05',
-  lastChangeNote: 'W2.9 additive: Tier C realizingInClaudeCode — Mergify merge-queue as deployment-layer HITL gate.',
+  lastChangeNote: 'W3.3 additive over W2.9: second HITL realization — subagent-workflow within-task review gates.',
 
   realizingInClaudeCode: {
     tier: 'C',
 
     bodyMarkdown: `
 The merge queue is the deployment-layer realization of Human in the Loop at the merge boundary. In this repo, Mergify enforces the gate structurally: the [\`.mergify.yml\`](https://github.com/julianken/detached-node/blob/main/.mergify.yml) declares a \`queue_conditions\` block requiring \`#approved-reviews-by >= 1\` and all CI checks passing before a squash-merge proceeds. The human signal — an explicit collaborator approval — is the precondition the queue checks before the run continues. No approval, no merge; the pending PR sits in the queue until the signal arrives, exactly the pause-and-resume contract the pattern names. The convention in this repo is to wait for the julianken-bot APPROVE before commenting \`@mergifyio queue\`, making the reviewer's verdict the trigger that opens the merge boundary. (Mergify is paid SaaS; GitHub-native merge queue is the OSS substitute.)
+
+**Within-task review gates (W3.3 addition).** The [subagent-workflow skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/subagent-workflow/SKILL.md) adds two earlier HITL gates inside the per-issue loop. After the implementer completes the PR, a spec-compliance reviewer explicitly reads acceptance criteria and reports SPEC COMPLIANT or SPEC GAPS FOUND — the operator reads this verdict before quality review proceeds. After quality review passes, the operator comments \`@mergifyio queue\` to trigger the merge boundary gate. The pattern runs twice per issue: once as an agent-to-agent handoff signal, and once as the human-signal merge gate. Both are pause-and-resume; neither is optional. [PR #349](https://github.com/julianken/detached-node/pull/349) documents a completed cycle of both gates in a single merge.
 `.trim(),
 
     readerMove: {
@@ -170,6 +172,7 @@ The merge queue is the deployment-layer realization of Human in the Loop at the 
     },
 
     seeAlso: {
+      skillPath: '.claude/skills/subagent-workflow/SKILL.md',
       siblingPatternSlugs: ['evaluation-llm-as-judge', 'guardrails', 'checkpointing'],
     },
   },

--- a/src/data/agentic-design-patterns/patterns/multi-agent-debate.ts
+++ b/src/data/agentic-design-patterns/patterns/multi-agent-debate.ts
@@ -148,11 +148,11 @@ export {}
     tier: 'C',
 
     bodyMarkdown: `
-Phase 3 of the [decision-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md) is structured multi-agent debate with deterministic aggregation. Three synthesizers receive the same phase-2 packet and independently analyze findings through different lenses — thematic, risk/opportunity, and implication/coverage. They run in parallel (dispatched in a single message) so their outputs are independent, then the orchestrator reads all three and produces the phase-3-packet comparing areas of agreement and divergence. Phase 4 resolves disagreements into a final plan. The [design-review skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/design-review/SKILL.md) offers a lighter version: one reviewer runs a full checklist, producing a prioritized list of independent findings. [PR #347](https://github.com/julianken/detached-node/pull/347) and [PR #348](https://github.com/julianken/detached-node/pull/348) both used the Phase 3 synthesis structure.
+Phase 3 of the [decision-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md) is structured multi-agent debate with deterministic aggregation. Three synthesizers receive the same phase-2 packet; the orchestrator assigns each a specific task for that run — tasks are decided dynamically based on what Phase 2 produced, not fixed in advance. They run in parallel (dispatched in a single message) so their outputs are independent, then the orchestrator reads all three and produces the phase-3-packet comparing areas of agreement and divergence. Phase 4 resolves disagreements into a final plan. [PR #347](https://github.com/julianken/detached-node/pull/347) and [PR #348](https://github.com/julianken/detached-node/pull/348) both used the Phase 3 synthesis structure.
 `.trim(),
 
     readerMove: {
-      text: 'Assign three synthesizers different lenses (thematic, risk, implication); dispatch all three in one message; aggregate in a separate orchestrator step.',
+      text: 'Assign each synthesizer a distinct task against the shared phase-2-packet; dispatch all three in one message; aggregate in a separate orchestrator step.',
       anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md',
     },
 

--- a/src/data/agentic-design-patterns/patterns/multi-agent-debate.ts
+++ b/src/data/agentic-design-patterns/patterns/multi-agent-debate.ts
@@ -141,6 +141,24 @@ export {}
     },
   ],
   addedAt: '2026-05-04',
-  dateModified: '2026-05-04',
-  lastChangeNote: 'Author Multi-Agent Debate satellite: parallel-agent answers, peer-critique rounds, deterministic aggregation; degeneration-of-thought gotcha.',
+  dateModified: '2026-05-05',
+  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — decision-funnel Phase 3 synthesizers as multi-agent debate realization.',
+
+  realizingInClaudeCode: {
+    tier: 'C',
+
+    bodyMarkdown: `
+Phase 3 of the [decision-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md) is structured multi-agent debate with deterministic aggregation. Three synthesizers receive the same phase-2 packet and independently analyze findings through different lenses — thematic, risk/opportunity, and implication/coverage. They run in parallel (dispatched in a single message) so their outputs are independent, then the orchestrator reads all three and produces the phase-3-packet comparing areas of agreement and divergence. Phase 4 resolves disagreements into a final plan. The [design-review skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/design-review/SKILL.md) offers a lighter version: one reviewer runs a full checklist, producing a prioritized list of independent findings. [PR #347](https://github.com/julianken/detached-node/pull/347) and [PR #348](https://github.com/julianken/detached-node/pull/348) both used the Phase 3 synthesis structure.
+`.trim(),
+
+    readerMove: {
+      text: 'Assign three synthesizers different lenses (thematic, risk, implication); dispatch all three in one message; aggregate in a separate orchestrator step.',
+      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md',
+    },
+
+    seeAlso: {
+      skillPath: '.claude/skills/decision-funnel/SKILL.md',
+      siblingPatternSlugs: ['orchestrator-workers', 'evaluation-llm-as-judge', 'identity-separated-review'],
+    },
+  },
 }

--- a/src/data/agentic-design-patterns/patterns/prompt-chaining.ts
+++ b/src/data/agentic-design-patterns/patterns/prompt-chaining.ts
@@ -136,6 +136,24 @@ export {}
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-03',
-  lastChangeNote: 'Initial authoring of Prompt Chaining pattern (wave 1).',
+  dateModified: '2026-05-05',
+  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — decision-funnel skill as prompt-chaining realization.',
+
+  realizingInClaudeCode: {
+    tier: 'C',
+
+    bodyMarkdown: `
+The [decision-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md) in this repo is prompt chaining at scale. Each phase produces a context packet that is the prompt for the next: Phase 0 frames the problem, Phase 1's five investigators receive the phase-0-packet as their context, Phase 2's iterators receive the compressed phase-1-packet, Phase 3 synthesizers receive the phase-2-packet, and Phase 4 takes the phase-3-packet plus full Phase 3 artifacts to produce the execution plan. The key discipline is that the raw artifacts never flow forward — only the compressed packet flows to the next phase, preventing context bloat as the chain deepens. [PR #342](https://github.com/julianken/detached-node/pull/342) and [PR #343](https://github.com/julianken/detached-node/pull/343) are instances of the execution leg of this chain.
+`.trim(),
+
+    readerMove: {
+      text: 'Wire each phase\'s output as a compressed context packet that becomes the next phase\'s input prompt; never forward raw artifacts.',
+      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md',
+    },
+
+    seeAlso: {
+      skillPath: '.claude/skills/decision-funnel/SKILL.md',
+      siblingPatternSlugs: ['orchestrator-workers', 'parallelization', 'context-engineering'],
+    },
+  },
 }

--- a/src/data/agentic-design-patterns/patterns/rag.ts
+++ b/src/data/agentic-design-patterns/patterns/rag.ts
@@ -135,6 +135,24 @@ export {}
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-03',
-  lastChangeNote: 'Authored RAG pattern (vanilla retrieve-and-generate; agentic variant remains separate).',
+  dateModified: '2026-05-05',
+  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — analysis-funnel context packets as structured RAG realization.',
+
+  realizingInClaudeCode: {
+    tier: 'C',
+
+    bodyMarkdown: `
+The [analysis-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/analysis-funnel/SKILL.md) practices structured RAG at every phase transition. Each wave produces detailed artifacts on disk; what flows to the next wave is not those artifacts but a compressed **context packet** — a purpose-built retrieval unit distilled from the raw output. The packet carries problem summary, key findings, carry-forward concerns, and artifact paths. Downstream agents receive the packet as pre-loaded context (retrieve) alongside their specific task (generate), following the classic RAG contract. The anti-bloat rules in the skill's Context Management section enforce the retrieval discipline: sending raw artifacts instead of packets is the named failure mode. [PR #339](https://github.com/julianken/detached-node/pull/339) is an instance of this pipeline operating in production.
+`.trim(),
+
+    readerMove: {
+      text: 'Write a compressed context packet after each phase; send the packet, not the raw artifacts, to the next phase\'s agents.',
+      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/analysis-funnel/SKILL.md',
+    },
+
+    seeAlso: {
+      skillPath: '.claude/skills/analysis-funnel/SKILL.md',
+      siblingPatternSlugs: ['agentic-rag', 'context-engineering', 'checkpointing'],
+    },
+  },
 }

--- a/src/data/agentic-design-patterns/patterns/routing.ts
+++ b/src/data/agentic-design-patterns/patterns/routing.ts
@@ -141,6 +141,24 @@ export {}
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-03',
-  lastChangeNote: 'Initial authoring of the Routing pattern (wave-1, issue #173).',
+  dateModified: '2026-05-05',
+  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — decision-funnel domain detection as routing realization.',
+
+  realizingInClaudeCode: {
+    tier: 'C',
+
+    bodyMarkdown: `
+The [decision-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md) encodes a routing table as its Domain Detection section: twelve domains (UI/Visual, React/Components, Auth/Security, and more) each map to a preferred \`subagent_type\` value. Phase 0 classifies the problem against that table and the classification determines which specialist agent receives each investigation area in Phase 1. No separate router agent is required — the orchestrator reads the table and routes directly. The domain-to-agent-type mapping in the skill's D.4 Agent Type Selection section is the routing logic; the phase-0 domain tags are the runtime signal that triggers it. [PR #337](https://github.com/julianken/detached-node/pull/337) introduced the dispatch mechanic this routing table feeds.
+`.trim(),
+
+    readerMove: {
+      text: 'Build a domain-to-agent-type table in your SKILL.md; route Phase 1 investigators by domain tag, not by model default.',
+      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md',
+    },
+
+    seeAlso: {
+      skillPath: '.claude/skills/decision-funnel/SKILL.md',
+      siblingPatternSlugs: ['orchestrator-workers', 'handoffs-swarm', 'planning'],
+    },
+  },
 }


### PR DESCRIPTION
## Summary

- Adds `realizingInClaudeCode` Tier C blocks to 9 pattern files, closing the catalog at 20/23 patterns populated (the remaining 3 are Tier D honest-absence or pending Tier U)
- Each block names an in-repo `SKILL.md` that realizes the pattern + ≥1 verified GitHub PR URL as repo evidence + `readerMove` ≤25 words
- `human-in-the-loop` is additive over the W2.9 block: extends `bodyMarkdown` with a second section on within-task review gates without replacing the existing Mergify section

## Pattern → SKILL.md mapping

| Pattern | SKILL.md | Realization framing |
|---------|----------|---------------------|
| prompt-chaining | `.claude/skills/decision-funnel/SKILL.md` | Context-packet chain: phase output → compressed packet → next phase prompt |
| routing | `.claude/skills/decision-funnel/SKILL.md` | Domain-detection routing table maps 12 domains to specialist `subagent_type` |
| rag | `.claude/skills/analysis-funnel/SKILL.md` | Context packets as structured RAG: retrieve (packet), generate (agent task) |
| agentic-rag | `.claude/skills/analysis-funnel/SKILL.md` | MCP-grounded investigation: agents query Context7/gh mid-task, not pre-loaded |
| multi-agent-debate | `.claude/skills/decision-funnel/SKILL.md` | Phase 3 three-synthesizer parallel dispatch with orchestrator aggregation |
| handoffs-swarm | `.claude/skills/subagent-workflow/SKILL.md` | Implementer → spec-reviewer → quality-reviewer sequential handoff chain |
| human-in-the-loop | `.claude/skills/subagent-workflow/SKILL.md` | Within-task review gates + Mergify merge-boundary gate (additive over W2.9) |
| a2a | `.claude/skills/subagent-workflow/SKILL.md` | Task() prompt as implicit Agent Card: role, worktree, issue, deliverable |
| evaluator-optimizer | `.claude/skills/creative-funnel/SKILL.md` | Spec review (correctness) + quality review (craft), 2-cycle cap per gate |

All SKILL.md paths are in-repo (`.claude/skills/`). No global-only skill paths cited.

## Test plan

- [x] `pnpm test:unit` — 438 tests pass (115 in `realizing.test.ts` including all 9 new Tier C patterns)
- [x] `pnpm lint` — 0 errors, 18 pre-existing warnings
- [x] `pnpm typecheck` — clean
- [x] `pnpm test:e2e` — 59 pass, 1 pre-existing failure (`posts-listing` date regex unrelated to this PR; confirmed present on branch HEAD before changes)
- [x] `pnpm lint:adp` — all 4 scripts pass (typecheck-sketches, validate-references, check-affiliate-links, lint-changelog)
- [x] Substantive grep `grep -iE "miss\b|gap\b|fail.open|anti.example|caught|the bot"` → 0 hits
- [x] All 5 anchorUrls return HTTP 200 (decision-funnel/SKILL.md, analysis-funnel/SKILL.md, subagent-workflow/SKILL.md, creative-funnel/SKILL.md, .mergify.yml)
- [x] All 12 repo-evidence PR URLs return HTTP 200

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)