### PR TITLE
feat(adp): 12-factor-agent Tier U umbrella (W3.1, final Epic #302)

### DIFF
--- a/scripts/check_meta_rule_consistency.sh
+++ b/scripts/check_meta_rule_consistency.sh
@@ -12,10 +12,10 @@ PATTERNS_DIR="$REPO_ROOT/src/data/agentic-design-patterns/patterns"
 META_RULE='it belongs in a skill, not here'
 
 # Files that must contain the meta-rule when they exist.
-# 12-factor-agent.ts will be added here once W3.1 (#322) lands.
 TARGETS=(
   "$PATTERNS_DIR/context-engineering.ts"
   "$PATTERNS_DIR/memory-management.ts"
+  "$PATTERNS_DIR/12-factor-agent.ts"
 )
 
 FAILED=0

--- a/src/data/agentic-design-patterns/patterns/12-factor-agent.ts
+++ b/src/data/agentic-design-patterns/patterns/12-factor-agent.ts
@@ -205,7 +205,7 @@ export {}
       },
       {
         patternSlug: 'evaluation-llm-as-judge',
-        oneLine: 'Factor 9 — compact errors back into the window: scores model output against a rubric so regressions surface before they ship.',
+        oneLine: 'Factor 6 — small focused agents: stronger judge model, rubric-scoped and distinct from the candidate it grades.',
       },
       {
         patternSlug: 'evaluator-optimizer',

--- a/src/data/agentic-design-patterns/patterns/12-factor-agent.ts
+++ b/src/data/agentic-design-patterns/patterns/12-factor-agent.ts
@@ -205,7 +205,7 @@ export {}
       },
       {
         patternSlug: 'evaluation-llm-as-judge',
-        oneLine: 'Factor 7 adjacent — human-gated merge: bot APPROVE gate closes the loop with a structured signal.',
+        oneLine: 'Factor 9 — compact errors back into the window: scores model output against a rubric so regressions surface before they ship.',
       },
       {
         patternSlug: 'evaluator-optimizer',
@@ -233,7 +233,7 @@ export {}
       },
       {
         patternSlug: 'mcp',
-        oneLine: 'Factor 4 + Factor 11 — tools as outputs, trigger anywhere: open protocol for cross-vendor tool discovery.',
+        oneLine: 'Factor 4 — tools as structured outputs: open protocol for cross-vendor tool discovery and call.',
       },
       {
         patternSlug: 'a2a',
@@ -264,7 +264,7 @@ export {}
         oneLine: 'Factor 11 — trigger from anywhere: delivers partial output as generated for any consumer transport.',
       },
     ],
-    closingRule: 'If a rule has a trigger (when X, each time X, before/after X), it belongs in a skill, not here.',
+    closingRule: `If a rule has a trigger ("when adding screenshots", "before committing", "during PR review"), it belongs in a skill, not here.`,
     seeAlso: {
       siblingPatternSlugs: ['context-engineering', 'memory-management', 'checkpointing', 'tool-use-react'],
     },

--- a/src/data/agentic-design-patterns/patterns/12-factor-agent.ts
+++ b/src/data/agentic-design-patterns/patterns/12-factor-agent.ts
@@ -161,6 +161,112 @@ export {}
     },
   ],
   addedAt: '2026-05-04',
-  dateModified: '2026-05-04',
-  lastChangeNote: 'Author 12-Factor Agent satellite: production methodology layered above mechanism patterns; HumanLayer/Horthy framing; stateless-reducer sketch; reducer-purity gotcha.',
+  dateModified: '2026-05-05',
+  lastChangeNote: 'W3.1: add realizingInClaudeCode Tier U umbrella — openingFraming, 24 umbrellaPointers, closingRule (token-economics meta-rule canonical home).',
+  realizingInClaudeCode: {
+    tier: 'U',
+    openingFraming: `The twelve factors of 12-factor-agent are not abstract ideals — they are the operational constraints that every production agent must satisfy to be legible, durable, and portable. Dexter Horthy's HumanLayer guide names them: own your prompts, own your context window, treat tools as structured outputs, unify execution and business state, expose launch and pause and resume as APIs, contact humans through tool calls, own your control flow, compact errors back into the window, keep agents small and focused, trigger from anywhere, and make the agent a stateless reducer over an event log. Each factor has a realization: a mechanism, a pattern, or a runtime primitive a team reaches for when that factor's constraint bites in production. The sibling patterns in this catalog are those realizations. Context Engineering makes Factor 3 concrete. Checkpointing makes Factors 5 and 12 operational. Human-in-the-Loop is one rigorous implementation of Factor 7. Parallelization and Orchestrator-Workers realize the small-focused-agents principle across different coordination shapes. The index below names each pattern's factor in the catalog. Read this entry as a methodology map: the factors are the requirements, and each sibling is a production implementation a team assembles, selects among, and owns.`,
+    umbrellaPointers: [
+      {
+        patternSlug: 'context-engineering',
+        oneLine: 'Factor 3 — own your context window: ranks, packs, and lays out tokens before each call.',
+      },
+      {
+        patternSlug: 'memory-management',
+        oneLine: 'Factor 3 + token-economics: tiers working, episodic, and semantic state across session resets.',
+      },
+      {
+        patternSlug: 'checkpointing',
+        oneLine: 'Factor 5 + Factor 12 — unify state and pure reducer: persists run state so restarts lose nothing.',
+      },
+      {
+        patternSlug: 'tool-use-react',
+        oneLine: 'Factor 4 — tools as structured outputs: thought→tool-call→result loop with owned control flow.',
+      },
+      {
+        patternSlug: 'human-in-the-loop',
+        oneLine: 'Factor 7 — contact humans with tool calls: agent pauses and waits for a human signal.',
+      },
+      {
+        patternSlug: 'orchestrator-workers',
+        oneLine: 'Factor 6 — small focused agents: central planner spawns narrow workers rather than one monolith.',
+      },
+      {
+        patternSlug: 'parallelization',
+        oneLine: 'Factor 6 + Factor 8 — own the loop: fans fixed calls out simultaneously and collapses results deterministically.',
+      },
+      {
+        patternSlug: 'planning',
+        oneLine: 'Factor 8 — own your control flow: agent drafts, executes, and rewrites the plan in owned loop code.',
+      },
+      {
+        patternSlug: 'reflexion',
+        oneLine: 'Factor 9 — compact errors into context: writes self-critiques into memory to improve next attempts.',
+      },
+      {
+        patternSlug: 'evaluation-llm-as-judge',
+        oneLine: 'Factor 7 adjacent — human-gated merge: bot APPROVE gate closes the loop with a structured signal.',
+      },
+      {
+        patternSlug: 'evaluator-optimizer',
+        oneLine: 'Factor 9 — compact errors back into the window: generate, score with rubric, refine until critic stops.',
+      },
+      {
+        patternSlug: 'prompt-chaining',
+        oneLine: 'Factor 2 + Factor 8 — own prompts and the loop: fixed sequence of LLM calls, each consuming prior output.',
+      },
+      {
+        patternSlug: 'routing',
+        oneLine: 'Factor 6 + Factor 11 — small focused agents, trigger from anywhere: classifies input and dispatches to matching handler.',
+      },
+      {
+        patternSlug: 'rag',
+        oneLine: 'Factor 3 adjacent — own the context window: retrieves passages from an external store and conditions the model.',
+      },
+      {
+        patternSlug: 'agentic-rag',
+        oneLine: 'Factor 3 + Factor 8 — own context and loop: agent reads partial passages and decides whether to re-query.',
+      },
+      {
+        patternSlug: 'guardrails',
+        oneLine: 'Factor 8 + safety layer — own the control flow: layered checks block unsafe input and output before either ships.',
+      },
+      {
+        patternSlug: 'mcp',
+        oneLine: 'Factor 4 + Factor 11 — tools as outputs, trigger anywhere: open protocol for cross-vendor tool discovery.',
+      },
+      {
+        patternSlug: 'a2a',
+        oneLine: 'Factor 11 — trigger from anywhere: cross-runtime agents discover each other by URL and exchange tasks over HTTP+JSON.',
+      },
+      {
+        patternSlug: 'handoffs-swarm',
+        oneLine: 'Factor 6 + Factor 7 — small focused agents: transfer-as-tool-call hands conversation to specialist without shared memory.',
+      },
+      {
+        patternSlug: 'funnel-method',
+        oneLine: 'Factor 5 + Factor 12 — unified state and stateless reducer: disk-anchored phase boundaries over an owned event log.',
+      },
+      {
+        patternSlug: 'identity-separated-review',
+        oneLine: 'Factor 7 — contact humans with tool calls: separate machine-user identity runs rubric review before merge.',
+      },
+      {
+        patternSlug: 'multi-agent-debate',
+        oneLine: 'Factor 6 — small focused agents: several agents argue and critique each other to converge on one answer.',
+      },
+      {
+        patternSlug: 'code-agent',
+        oneLine: 'Factor 8 + Factor 4 — own the loop and tools: codebase-toolkit agent with an owned test runner.',
+      },
+      {
+        patternSlug: 'streaming',
+        oneLine: 'Factor 11 — trigger from anywhere: delivers partial output as generated for any consumer transport.',
+      },
+    ],
+    closingRule: 'If a rule has a trigger (when X, each time X, before/after X), it belongs in a skill, not here.',
+    seeAlso: {
+      siblingPatternSlugs: ['context-engineering', 'memory-management', 'checkpointing', 'tool-use-react'],
+    },
+  },
 }

--- a/src/data/agentic-design-patterns/patterns/context-engineering.ts
+++ b/src/data/agentic-design-patterns/patterns/context-engineering.ts
@@ -138,7 +138,7 @@ export {}
   ],
   addedAt: '2026-05-03',
   dateModified: '2026-05-05',
-  lastChangeNote: 'W2.9 additive: 5-section PR body as reviewer context packet cross-link.',
+  lastChangeNote: 'W3.1 additive: add 12-factor-agent to seeAlso.siblingPatternSlugs, resolving W1.2 forward-reference.',
   realizingInClaudeCode: {
     tier: 'A',
     ccPrimitives: [
@@ -160,7 +160,7 @@ export {}
     },
     seeAlso: {
       skillPath: '.claude/skills/analysis-funnel/SKILL.md',
-      siblingPatternSlugs: ['memory-management', 'checkpointing'],
+      siblingPatternSlugs: ['memory-management', 'checkpointing', '12-factor-agent'],
     },
     bodyMarkdown: `Context engineering in a Claude Code setup begins with the three files that load on every session — \`CLAUDE.md\`, \`settings.json\`, and the skills directory. These are the always-on context: they arrive before any tool call, before any task instruction, before any retrieved content. The user-level \`~/.claude/CLAUDE.md\` token-economics meta-rule captures the load-bearing editorial discipline for this file class: "If a rule has a trigger ("when adding screenshots", "before committing", "during PR review"), it belongs in a skill, not here." ([source](https://github.com/julianken/detached-node/blob/main/CLAUDE.md)). Rules without triggers stay in \`CLAUDE.md\`; rules with triggers migrate to skills. The discipline is token-economic: every unconditional rule that migrates to a skill is a line evicted from the always-on budget.
 

--- a/src/data/agentic-design-patterns/patterns/memory-management.ts
+++ b/src/data/agentic-design-patterns/patterns/memory-management.ts
@@ -151,7 +151,7 @@ export {}
   ],
   addedAt: '2026-05-03',
   dateModified: '2026-05-05',
-  lastChangeNote: 'W1.4: add realizingInClaudeCode Tier B (Monday audit move + seeAlso cross-links).',
+  lastChangeNote: 'W3.1 additive: seeAlso already includes 12-factor-agent; W1.4 forward-reference resolved by umbrella landing.',
   realizingInClaudeCode: {
     tier: 'B',
     bodyMarkdown: `


### PR DESCRIPTION
## Diagrams

No visual component changes. This PR adds a data-only `realizingInClaudeCode` Tier U block to the 12-factor-agent pattern.

## Summary

- **`12-factor-agent.ts`**: Adds `realizingInClaudeCode` Tier U block — `openingFraming` (~193w framing the 12 factors as a methodology umbrella), 24 `umbrellaPointers` (each sibling pattern mapped to its realized factor with a ≤20w `oneLine`), and `closingRule` (the token-economics meta-rule verbatim, canonical home for the substring `it belongs in a skill, not here`).
- **`context-engineering.ts`**: Additive edit — adds `12-factor-agent` to `seeAlso.siblingPatternSlugs`, resolving the W1.2 forward-reference. Updates `lastChangeNote`.
- **`memory-management.ts`**: Additive edit — updates `lastChangeNote` to confirm W1.4 forward-reference is resolved by the umbrella landing (seeAlso already included `12-factor-agent`).
- **`scripts/check_meta_rule_consistency.sh`**: Adds `12-factor-agent.ts` to the TARGETS array per the TODO comment left in W3.1's TOOL-2 prerequisite (#354).

## Screenshots

N/A — data-only changes.

## Test plan

- [x] `pnpm test:unit` — 420 tests pass (31 test files). Tier U invariant tests for `12-factor-agent`: `tier is one of A|B|C|U`, `seeAlso is present`, `siblingPatternSlugs all resolve`, `openingFraming non-empty`, `closingRule non-empty`, `umbrellaPointers ≥10`, `all umbrellaPointers[].patternSlug resolve` — all 7 pass.
- [x] `pnpm lint` — 0 errors, 18 pre-existing warnings
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint:adp` — typecheck-sketches OK, validate-references OK, check-affiliate-links OK, lint-changelog OK
- [x] `bash scripts/check_meta_rule_consistency.sh` — exit 0 (OK for all 3 targets including new `12-factor-agent.ts`)
- [x] Substantive grep `git diff | grep -iE "miss\b|gap\b|fail.open|anti.example|caught|the bot found"` — 0 hits
- [x] Word count: 622w (openingFraming 193w + 24 oneLines avg ~17w each + closingRule 20w) — within 600-800w AC range
- [x] umbrellaPointers: 24 rows (≥22 AC target, ≥10 unit test threshold)
- [ ] E2E: 2 pre-existing failures (`posts-listing` date format + `theme-aware-hero` crossfade) unrelated to data changes; 58 pass

## Plan reference

Action `W3.1` in `docs/agentic-bridge/reframe/action-plan-v1.json`. Final PR of Epic #302 (the ADP `realizingInClaudeCode` epic). The `closingRule` field in `12-factor-agent.ts` is now the canonical home for the token-economics meta-rule; all citing patterns reference it via `seeAlso.siblingPatternSlugs`.

Closes #322