### PR TITLE
feat(adp): realizing-in-IDE reference card redesign

### DIFF
--- a/src/app/(frontend)/agentic-design-patterns/[slug]/page.tsx
+++ b/src/app/(frontend)/agentic-design-patterns/[slug]/page.tsx
@@ -99,7 +99,21 @@ export default async function PatternSatellitePage({
           <PatternStickyRail pattern={pattern} />
           <article className="flex flex-col gap-10">
             <PatternHeader pattern={pattern} />
-            <PatternBody pattern={pattern} />
+            <PatternBody
+              pattern={pattern}
+              afterDiagram={
+                <div className="flex flex-col gap-3">
+                  <RealizingDisclosure
+                    label="Claude Code"
+                    realizing={pattern.realizingInClaudeCode}
+                  />
+                  <RealizingDisclosure
+                    label="Cursor"
+                    realizing={pattern.realizingInCursor}
+                  />
+                </div>
+              }
+            />
             <ReferencesSection pattern={pattern} />
             {overviewLead && (
               <DisclosureSection
@@ -128,9 +142,6 @@ export default async function PatternSatellitePage({
                   ))}
                 </div>
               </DisclosureSection>
-            )}
-            {pattern.realizingInClaudeCode && (
-              <RealizingDisclosure pattern={pattern} />
             )}
           </article>
         </div>

--- a/src/components/agentic-patterns/PatternBody.tsx
+++ b/src/components/agentic-patterns/PatternBody.tsx
@@ -24,6 +24,8 @@ import { SourcedClaimTable } from "./SourcedClaimTable";
 
 interface PatternBodyProps {
   pattern: Pattern;
+  /** Optional slot rendered immediately after the diagram, before the decision matrix. */
+  afterDiagram?: React.ReactNode;
 }
 
 const FRAMEWORK_LABELS: Record<Framework, string> = {
@@ -62,7 +64,7 @@ function SlotHeading({ id, children }: { id: string; children: React.ReactNode }
   );
 }
 
-export function PatternBody({ pattern }: PatternBodyProps) {
+export function PatternBody({ pattern, afterDiagram }: PatternBodyProps) {
   const showPseudocodeBanner = PSEUDOCODE_BANNER_SET.has(pattern.sdkAvailability);
 
   return (
@@ -81,6 +83,9 @@ export function PatternBody({ pattern }: PatternBodyProps) {
           </figure>
         </section>
       )}
+
+      {/* 1b. Optional slot — e.g. RealizingDisclosure card sits here */}
+      {afterDiagram}
 
       {/* 2. Decision matrix — replaces When-to-use + When-NOT */}
       <DecisionMatrix pattern={pattern} />

--- a/src/components/agentic-patterns/RealizingDisclosure.tsx
+++ b/src/components/agentic-patterns/RealizingDisclosure.tsx
@@ -1,19 +1,19 @@
 // ---------------------------------------------------------------------------
-// RealizingDisclosure — W4.0 reference-card redesign
+// RealizingDisclosure — IDE reference card
 // ---------------------------------------------------------------------------
-// Renders pattern.realizingInClaudeCode as an always-visible reference card
-// at the top of the satellite article (positioned by the slug page).
+// Renders one pattern's realization in a single IDE (e.g. Claude Code or
+// Cursor) as a collapsible card under the diagram on the slug page. Same
+// component, different `label` + `realizing` props per IDE; the slug page
+// invokes it once per IDE.
 //
-// Lead format for every tier: scannable `keyMoves` bullets first, followed by
-// the existing structured fields (pills, worked-example link, reader-move
-// callout, see-also chips). Long-form prose (`bodyMarkdown`) collapses into
-// an inner "Why this works" sub-disclosure for the rare deep-dive reader.
-//
-// Tier-specific extras render after the shared lead:
-//   Tier A — ccPrimitives + scaffolding pill rows + workedExample link
-//   Tier B — keyMoves + readerMove + seeAlso (+ bodyMarkdown if present)
-//   Tier C — keyMoves + readerMove + seeAlso (+ bodyMarkdown if present)
-//   Tier U — umbrellaPointers + closingRule + openingFraming (collapsed)
+// Surface order (any field renders only when populated):
+//   1. openingFraming         — inline paragraphs (umbrella patterns)
+//   2. keyMoves               — bulleted reference content (the lead)
+//   3. ccPrimitives           — pill row of IDE feature names
+//   4. umbrellaPointers       — sibling-pattern index (umbrella only)
+//   5. closingRule            — boxed verbatim rule (umbrella only)
+//   6. seeAlso                — sibling pattern link chips + article chip
+//   7. workedExample          — small footer Example link
 // ---------------------------------------------------------------------------
 
 import { Link } from 'next-view-transitions'

--- a/src/components/agentic-patterns/RealizingDisclosure.tsx
+++ b/src/components/agentic-patterns/RealizingDisclosure.tsx
@@ -1,26 +1,72 @@
 // ---------------------------------------------------------------------------
-// RealizingDisclosure — W1.0
+// RealizingDisclosure — W4.0 reference-card redesign
 // ---------------------------------------------------------------------------
-// Third collapsible disclosure on each ADP satellite page. Renders only when
-// pattern.realizingInClaudeCode is defined; callers guard with && so absent
-// patterns render nothing.
+// Renders pattern.realizingInClaudeCode as an always-visible reference card
+// at the top of the satellite article (positioned by the slug page).
 //
-// Dispatches on tier:
-//   Tier A — 5 sub-sections: CC primitives, scaffolding, worked example,
-//             reader move, see also
-//   Tier B  — compact: reader move + see also (+ optional body prose)
-//   Tier C  — cross-link paragraph: body prose + reader move + see also
-//   Tier U  — umbrella index: opening framing + pointer list + closing rule
-//             + see also
+// Lead format for every tier: scannable `keyMoves` bullets first, followed by
+// the existing structured fields (pills, worked-example link, reader-move
+// callout, see-also chips). Long-form prose (`bodyMarkdown`) collapses into
+// an inner "Why this works" sub-disclosure for the rare deep-dive reader.
 //
-// All styles follow the design system (zinc dark theme, Tailwind utilities).
+// Tier-specific extras render after the shared lead:
+//   Tier A — ccPrimitives + scaffolding pill rows + workedExample link
+//   Tier B — keyMoves + readerMove + seeAlso (+ bodyMarkdown if present)
+//   Tier C — keyMoves + readerMove + seeAlso (+ bodyMarkdown if present)
+//   Tier U — umbrellaPointers + closingRule + openingFraming (collapsed)
 // ---------------------------------------------------------------------------
 
-import { DisclosureSection } from './DisclosureSection'
-import type { Pattern, RealizingInClaudeCode, CcSeeAlso } from '@/data/agentic-design-patterns/types'
+import { Link } from 'next-view-transitions'
+import type { RealizingInClaudeCode, CcSeeAlso } from '@/data/agentic-design-patterns/types'
 
 interface RealizingDisclosureProps {
-  pattern: Pattern
+  /** Section label, e.g. "Claude Code" or "Cursor". */
+  label: string
+  /** Content for this IDE; if undefined, the section renders an empty-state placeholder. */
+  realizing?: RealizingInClaudeCode
+  /** Open by default (typical for the IDE the reader most likely uses). */
+  defaultOpen?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Inline markdown renderer — handles `code` and [text](url) only.
+// Strings are short technical lines, so a regex pass beats pulling in a
+// full markdown library.
+// ---------------------------------------------------------------------------
+
+const INLINE_TOKEN = /(`[^`]+`|\[[^\]]+\]\([^)]+\))/g
+const LINK_PARTS = /^\[([^\]]+)\]\(([^)]+)\)$/
+
+function renderInline(text: string): React.ReactNode[] {
+  const parts = text.split(INLINE_TOKEN)
+  return parts.map((part, i) => {
+    if (!part) return null
+    if (part.startsWith('`') && part.endsWith('`')) {
+      return (
+        <code
+          key={i}
+          className="rounded-sm bg-zinc-100 px-1 py-0.5 font-mono text-[0.85em] text-text-primary dark:bg-zinc-800"
+        >
+          {part.slice(1, -1)}
+        </code>
+      )
+    }
+    const link = part.match(LINK_PARTS)
+    if (link) {
+      return (
+        <a
+          key={i}
+          href={link[2]}
+          className="text-accent underline underline-offset-2 hover:no-underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {link[1]}
+        </a>
+      )
+    }
+    return <span key={i}>{part}</span>
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -29,9 +75,31 @@ interface RealizingDisclosureProps {
 
 function SubHeading({ children }: { children: React.ReactNode }) {
   return (
-    <h4 className="mb-1.5 font-mono text-[0.7rem] font-semibold uppercase tracking-[0.08em] text-text-tertiary">
+    <h4 className="mb-2.5 text-xl font-semibold text-text-primary">
       {children}
     </h4>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Lead heading for the whole card
+// ---------------------------------------------------------------------------
+
+// CardHeading replaced by the <summary> of the outer <details>.
+
+// ---------------------------------------------------------------------------
+// keyMoves bulleted list — primary reference content
+// ---------------------------------------------------------------------------
+
+function KeyMovesList({ items }: { items: string[] }) {
+  return (
+    <ul className="flex flex-col gap-2.5 pl-5 text-base leading-7 text-text-primary [list-style:disc] marker:text-text-tertiary">
+      {items.map((move, idx) => (
+        <li key={idx} className="[text-wrap:pretty]">
+          {renderInline(move)}
+        </li>
+      ))}
+    </ul>
   )
 }
 
@@ -60,56 +128,61 @@ function PillList({ items }: { items: string[] }) {
 
 function SeeAlsoBlock({ seeAlso }: { seeAlso: CcSeeAlso }) {
   const hasSiblings = seeAlso.siblingPatternSlugs && seeAlso.siblingPatternSlugs.length > 0
-  const hasSkillPath = Boolean(seeAlso.skillPath)
   const hasArticleSlug = Boolean(seeAlso.articleSlug)
 
-  if (!hasSiblings && !hasSkillPath && !hasArticleSlug) return null
+  if (!hasSiblings && !hasArticleSlug) return null
 
   return (
-    <div className="mt-3 border-t border-border-subtle pt-3">
-      <SubHeading>See also</SubHeading>
-      <ul className="flex flex-col gap-1">
-        {hasSkillPath && (
-          <li className="font-mono text-xs text-text-secondary">
-            Skill: <span className="text-text-primary">{seeAlso.skillPath}</span>
-          </li>
-        )}
-        {hasArticleSlug && (
-          <li className="font-mono text-xs text-text-secondary">
-            Article:{' '}
-            <span className="text-text-primary">/{seeAlso.articleSlug}</span>
-          </li>
-        )}
-        {hasSiblings && (
-          <li className="font-mono text-xs text-text-secondary">
-            Related patterns:{' '}
-            <span className="text-text-primary">
-              {seeAlso.siblingPatternSlugs!.join(' · ')}
-            </span>
-          </li>
-        )}
-      </ul>
+    <div className="flex flex-col gap-4 border-t border-border-subtle pt-4">
+      {hasSiblings && (
+        <div>
+          <SubHeading>Related patterns</SubHeading>
+          <ul className="flex flex-wrap gap-2">
+            {seeAlso.siblingPatternSlugs!.map((slug) => (
+              <li key={slug}>
+                <Link
+                  href={`/agentic-design-patterns/${slug}`}
+                  className="inline-flex rounded-sm border border-border-subtle bg-zinc-100 px-2.5 py-1 text-sm font-medium text-text-primary transition-colors hover:border-accent hover:text-accent dark:bg-zinc-800"
+                >
+                  {slug}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {hasArticleSlug && (
+        <div>
+          <SubHeading>Article</SubHeading>
+          <Link
+            href={`/${seeAlso.articleSlug}`}
+            className="inline-flex rounded-sm border border-border-subtle bg-zinc-100 px-2.5 py-1 text-sm font-medium text-text-primary transition-colors hover:border-accent hover:text-accent dark:bg-zinc-800"
+          >
+            /{seeAlso.articleSlug}
+          </Link>
+        </div>
+      )}
     </div>
   )
 }
 
 // ---------------------------------------------------------------------------
-// Reader move block (shared Tier A / B / C)
+// Example footer chip — small, optional, not lead content
 // ---------------------------------------------------------------------------
 
-function ReaderMoveBlock({ text, anchorUrl }: { text: string; anchorUrl: string }) {
+function ExampleChip({ url }: { url: string }) {
   return (
-    <div className="rounded-sm border border-border-subtle bg-zinc-50 px-3 py-2.5 dark:bg-zinc-800/60">
-      <SubHeading>Monday-morning move</SubHeading>
-      <p className="text-sm leading-6 text-text-secondary">
-        {text}{' '}
+    <div className="border-t border-border-subtle pt-3">
+      <p className="text-sm text-text-tertiary">
+        Example:{' '}
         <a
-          href={anchorUrl}
-          className="font-mono text-xs text-accent underline underline-offset-2 hover:no-underline"
+          href={url}
+          className="font-mono text-accent underline underline-offset-2 hover:no-underline"
           target="_blank"
           rel="noopener noreferrer"
         >
-          [anchor]
+          {url.replace(/^https?:\/\//, '')}
         </a>
       </p>
     </div>
@@ -117,156 +190,81 @@ function ReaderMoveBlock({ text, anchorUrl }: { text: string; anchorUrl: string 
 }
 
 // ---------------------------------------------------------------------------
-// Tier A body
+// Inline paragraphs (umbrella opening framing only — not used for bodyMarkdown)
 // ---------------------------------------------------------------------------
 
-function TierABody({ r }: { r: RealizingInClaudeCode }) {
+function InlineParagraphs({ text }: { text: string }) {
+  const paragraphs = text.split(/\n\s*\n/).filter((p) => p.trim().length > 0)
   return (
-    <div className="flex flex-col gap-4">
-      {r.ccPrimitives && r.ccPrimitives.length > 0 && (
-        <div>
-          <SubHeading>CC primitives</SubHeading>
-          <PillList items={r.ccPrimitives} />
-        </div>
-      )}
-
-      {r.scaffolding && r.scaffolding.length > 0 && (
-        <div>
-          <SubHeading>Scaffolding</SubHeading>
-          <PillList items={r.scaffolding} />
-        </div>
-      )}
-
-      {r.workedExample && (
-        <div>
-          <SubHeading>Worked example</SubHeading>
-          <a
-            href={r.workedExample.url}
-            className="text-sm text-accent underline underline-offset-2 hover:no-underline"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {r.workedExample.description}
-          </a>
-        </div>
-      )}
-
-      {r.readerMove && (
-        <ReaderMoveBlock text={r.readerMove.text} anchorUrl={r.readerMove.anchorUrl} />
-      )}
-
-      {r.seeAlso && <SeeAlsoBlock seeAlso={r.seeAlso} />}
+    <div className="flex flex-col gap-3 text-base leading-7 text-text-secondary [text-wrap:pretty]">
+      {paragraphs.map((para, i) => (
+        <p key={i}>{renderInline(para)}</p>
+      ))}
     </div>
   )
 }
 
 // ---------------------------------------------------------------------------
-// Tier B body (compact: reader move + see also + optional body prose)
+// Main export — single render path; surfaces whatever fields are populated
 // ---------------------------------------------------------------------------
 
-function TierBBody({ r }: { r: RealizingInClaudeCode }) {
+export function RealizingDisclosure({ label, realizing: r, defaultOpen }: RealizingDisclosureProps) {
   return (
-    <div className="flex flex-col gap-4">
-      {r.bodyMarkdown && (
-        <p className="text-sm leading-6 text-text-secondary [text-wrap:pretty]">
-          {r.bodyMarkdown}
-        </p>
-      )}
-
-      {r.readerMove && (
-        <ReaderMoveBlock text={r.readerMove.text} anchorUrl={r.readerMove.anchorUrl} />
-      )}
-
-      {r.seeAlso && <SeeAlsoBlock seeAlso={r.seeAlso} />}
-    </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Tier C body (cross-link paragraph: body prose required + reader move + see also)
-// ---------------------------------------------------------------------------
-
-function TierCBody({ r }: { r: RealizingInClaudeCode }) {
-  return (
-    <div className="flex flex-col gap-4">
-      {r.bodyMarkdown && (
-        <p className="text-sm leading-6 text-text-secondary [text-wrap:pretty]">
-          {r.bodyMarkdown}
-        </p>
-      )}
-
-      {r.readerMove && (
-        <ReaderMoveBlock text={r.readerMove.text} anchorUrl={r.readerMove.anchorUrl} />
-      )}
-
-      {r.seeAlso && <SeeAlsoBlock seeAlso={r.seeAlso} />}
-    </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Tier U body (umbrella index)
-// ---------------------------------------------------------------------------
-
-function TierUBody({ r }: { r: RealizingInClaudeCode }) {
-  return (
-    <div className="flex flex-col gap-4">
-      {r.openingFraming && (
-        <p className="text-sm leading-6 text-text-secondary [text-wrap:pretty]">
-          {r.openingFraming}
-        </p>
-      )}
-
-      {r.umbrellaPointers && r.umbrellaPointers.length > 0 && (
-        <div>
-          <SubHeading>Pattern index</SubHeading>
-          <ul className="flex flex-col gap-1.5">
-            {r.umbrellaPointers.map((pointer) => (
-              <li
-                key={pointer.patternSlug}
-                className="flex items-baseline gap-2 text-sm text-text-secondary"
-              >
-                <span className="shrink-0 font-mono text-xs text-text-tertiary">
-                  {pointer.patternSlug}
-                </span>
-                <span className="text-text-secondary">{pointer.oneLine}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      {r.closingRule && (
-        <div className="rounded-sm border border-border-subtle bg-zinc-50 px-3 py-2.5 dark:bg-zinc-800/60">
-          <SubHeading>Meta-rule</SubHeading>
-          <p className="font-mono text-xs leading-5 text-text-secondary italic">
-            {r.closingRule}
-          </p>
-        </div>
-      )}
-
-      {r.seeAlso && <SeeAlsoBlock seeAlso={r.seeAlso} />}
-    </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Main export
-// ---------------------------------------------------------------------------
-
-export function RealizingDisclosure({ pattern }: RealizingDisclosureProps) {
-  const r = pattern.realizingInClaudeCode
-  if (!r) return null
-
-  return (
-    <DisclosureSection
-      id="realizing-disclosure"
-      label="Realizing in Claude Code"
+    <details
+      open={defaultOpen}
+      className="group rounded-sm border border-border-default bg-bg-elevated dark:border-zinc-700 dark:bg-zinc-900"
     >
-      {r.tier === 'A' && <TierABody r={r} />}
-      {r.tier === 'B' && <TierBBody r={r} />}
-      {r.tier === 'C' && <TierCBody r={r} />}
-      {r.tier === 'U' && <TierUBody r={r} />}
-    </DisclosureSection>
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 [&::-webkit-details-marker]:hidden">
+        <h3 className="text-2xl font-semibold tracking-tight text-text-primary">{label}</h3>
+        <span aria-hidden className="text-text-tertiary transition-transform group-open:rotate-90">›</span>
+      </summary>
+      <div className="border-t border-border-subtle px-4 py-4">
+        {!r ? (
+          <p className="text-base leading-7 text-text-tertiary italic">
+            Realization in {label} is not yet documented for this pattern.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-5">
+            {r.openingFraming && <InlineParagraphs text={r.openingFraming} />}
+
+            {r.keyMoves && r.keyMoves.length > 0 && <KeyMovesList items={r.keyMoves} />}
+
+            {r.ccPrimitives && r.ccPrimitives.length > 0 && (
+              <div>
+                <SubHeading>Primitives</SubHeading>
+                <PillList items={r.ccPrimitives} />
+              </div>
+            )}
+
+            {r.umbrellaPointers && r.umbrellaPointers.length > 0 && (
+              <div>
+                <SubHeading>Pattern index</SubHeading>
+                <ul className="flex flex-col gap-2 text-base leading-7 text-text-primary">
+                  {r.umbrellaPointers.map((pointer) => (
+                    <li key={pointer.patternSlug} className="flex items-baseline gap-2 [text-wrap:pretty]">
+                      <span className="shrink-0 font-mono text-sm text-text-tertiary">{pointer.patternSlug}</span>
+                      <span>{renderInline(pointer.oneLine)}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {r.closingRule && (
+              <div className="rounded-sm border border-border-subtle bg-zinc-50 px-3 py-3 dark:bg-zinc-800/60">
+                <SubHeading>Meta-rule</SubHeading>
+                <p className="text-base leading-7 text-text-secondary italic [text-wrap:pretty]">
+                  {renderInline(r.closingRule)}
+                </p>
+              </div>
+            )}
+
+            {r.seeAlso && <SeeAlsoBlock seeAlso={r.seeAlso} />}
+
+            {r.workedExample && <ExampleChip url={r.workedExample.url} />}
+          </div>
+        )}
+      </div>
+    </details>
   )
 }

--- a/src/components/agentic-patterns/ReferencesSection.tsx
+++ b/src/components/agentic-patterns/ReferencesSection.tsx
@@ -91,7 +91,7 @@ export function ReferencesSection({ pattern }: ReferencesSectionProps) {
     <section id="references" aria-labelledby="references-heading" className="scroll-mt-24">
       <h2
         id="references-heading"
-        className="font-mono text-xl font-semibold tracking-tight text-text-primary"
+        className="text-2xl font-semibold tracking-tight text-text-primary"
       >
         References
       </h2>

--- a/src/data/agentic-design-patterns/patterns/12-factor-agent.ts
+++ b/src/data/agentic-design-patterns/patterns/12-factor-agent.ts
@@ -162,111 +162,43 @@ export {}
   ],
   addedAt: '2026-05-04',
   dateModified: '2026-05-05',
-  lastChangeNote: 'W3.1: add realizingInClaudeCode Tier U umbrella — openingFraming, 24 umbrellaPointers, closingRule (token-economics meta-rule canonical home).',
+  lastChangeNote: 'W3.0 — Update background-agent → cloud-agent URL in realizingInCursor.',
   realizingInClaudeCode: {
-    tier: 'U',
-    openingFraming: `The twelve factors of 12-factor-agent are not abstract ideals — they are the operational constraints that every production agent must satisfy to be legible, durable, and portable. Dexter Horthy's HumanLayer guide names them: own your prompts, own your context window, treat tools as structured outputs, unify execution and business state, expose launch and pause and resume as APIs, contact humans through tool calls, own your control flow, compact errors back into the window, keep agents small and focused, trigger from anywhere, and make the agent a stateless reducer over an event log. Each factor has a realization: a mechanism, a pattern, or a runtime primitive a team reaches for when that factor's constraint bites in production. The sibling patterns in this catalog are those realizations. Context Engineering makes Factor 3 concrete. Checkpointing makes Factors 5 and 12 operational. Human-in-the-Loop is one rigorous implementation of Factor 7. Parallelization and Orchestrator-Workers realize the small-focused-agents principle across different coordination shapes. The index below names each pattern's factor in the catalog. Read this entry as a methodology map: the factors are the requirements, and each sibling is a production implementation a team assembles, selects among, and owns.`,
+    openingFraming: '12-Factor Agent is a methodology, not a single mechanism. Each factor maps to one or more patterns in this catalog; the table below names the most direct correspondence. Apply the factors by reaching for the matching patterns in the order your agent needs them.',
     umbrellaPointers: [
-      {
-        patternSlug: 'context-engineering',
-        oneLine: 'Factor 3 — own your context window: ranks, packs, and lays out tokens before each call.',
-      },
-      {
-        patternSlug: 'memory-management',
-        oneLine: 'Factor 3 + token-economics: tiers working, episodic, and semantic state across session resets.',
-      },
-      {
-        patternSlug: 'checkpointing',
-        oneLine: 'Factor 5 + Factor 12 — unify state and pure reducer: persists run state so restarts lose nothing.',
-      },
-      {
-        patternSlug: 'tool-use-react',
-        oneLine: 'Factor 4 — tools as structured outputs: thought→tool-call→result loop with owned control flow.',
-      },
-      {
-        patternSlug: 'human-in-the-loop',
-        oneLine: 'Factor 7 — contact humans with tool calls: agent pauses and waits for a human signal.',
-      },
-      {
-        patternSlug: 'orchestrator-workers',
-        oneLine: 'Factor 6 — small focused agents: central planner spawns narrow workers rather than one monolith.',
-      },
-      {
-        patternSlug: 'parallelization',
-        oneLine: 'Factor 6 + Factor 8 — own the loop: fans fixed calls out simultaneously and collapses results deterministically.',
-      },
-      {
-        patternSlug: 'planning',
-        oneLine: 'Factor 8 — own your control flow: agent drafts, executes, and rewrites the plan in owned loop code.',
-      },
-      {
-        patternSlug: 'reflexion',
-        oneLine: 'Factor 9 — compact errors into context: writes self-critiques into memory to improve next attempts.',
-      },
-      {
-        patternSlug: 'evaluation-llm-as-judge',
-        oneLine: 'Factor 6 — small focused agents: stronger judge model, rubric-scoped and distinct from the candidate it grades.',
-      },
-      {
-        patternSlug: 'evaluator-optimizer',
-        oneLine: 'Factor 9 — compact errors back into the window: generate, score with rubric, refine until critic stops.',
-      },
-      {
-        patternSlug: 'prompt-chaining',
-        oneLine: 'Factor 2 + Factor 8 — own prompts and the loop: fixed sequence of LLM calls, each consuming prior output.',
-      },
-      {
-        patternSlug: 'routing',
-        oneLine: 'Factor 6 + Factor 11 — small focused agents, trigger from anywhere: classifies input and dispatches to matching handler.',
-      },
-      {
-        patternSlug: 'rag',
-        oneLine: 'Factor 3 adjacent — own the context window: retrieves passages from an external store and conditions the model.',
-      },
-      {
-        patternSlug: 'agentic-rag',
-        oneLine: 'Factor 3 + Factor 8 — own context and loop: agent reads partial passages and decides whether to re-query.',
-      },
-      {
-        patternSlug: 'guardrails',
-        oneLine: 'Factor 8 + safety layer — own the control flow: layered checks block unsafe input and output before either ships.',
-      },
-      {
-        patternSlug: 'mcp',
-        oneLine: 'Factor 4 — tools as structured outputs: open protocol for cross-vendor tool discovery and call.',
-      },
-      {
-        patternSlug: 'a2a',
-        oneLine: 'Factor 11 — trigger from anywhere: cross-runtime agents discover each other by URL and exchange tasks over HTTP+JSON.',
-      },
-      {
-        patternSlug: 'handoffs-swarm',
-        oneLine: 'Factor 6 + Factor 7 — small focused agents: transfer-as-tool-call hands conversation to specialist without shared memory.',
-      },
-      {
-        patternSlug: 'funnel-method',
-        oneLine: 'Factor 5 + Factor 12 — unified state and stateless reducer: disk-anchored phase boundaries over an owned event log.',
-      },
-      {
-        patternSlug: 'identity-separated-review',
-        oneLine: 'Factor 7 — contact humans with tool calls: separate machine-user identity runs rubric review before merge.',
-      },
-      {
-        patternSlug: 'multi-agent-debate',
-        oneLine: 'Factor 6 — small focused agents: several agents argue and critique each other to converge on one answer.',
-      },
-      {
-        patternSlug: 'code-agent',
-        oneLine: 'Factor 8 + Factor 4 — own the loop and tools: codebase-toolkit agent with an owned test runner.',
-      },
-      {
-        patternSlug: 'streaming',
-        oneLine: 'Factor 11 — trigger from anywhere: delivers partial output as generated for any consumer transport.',
-      },
+      { patternSlug: 'context-engineering', oneLine: 'Factor 3 (own your context window) — explicit context assembly over framework defaults.' },
+      { patternSlug: 'checkpointing', oneLine: 'Factor 5 (unify state) + Factor 12 (stateless reducer) — durable state machine the reducer runs over.' },
+      { patternSlug: 'tool-use-react', oneLine: 'Factor 4 (tools as structured outputs) — structured tool call shape the React loop emits.' },
+      { patternSlug: 'human-in-the-loop', oneLine: 'Factor 7 (contact humans via tool calls) — pause-and-resume pattern wired to the human approval gate.' },
+      { patternSlug: 'guardrails', oneLine: 'Factor 6 (own your control flow) — runtime enforcement layer the owning code can audit and update.' },
+      { patternSlug: 'evaluation-llm-as-judge', oneLine: 'Factor 11 (trigger from anywhere) — evaluator running as CI step independent of the agent runtime.' },
     ],
-    closingRule: `If a rule has a trigger ("when adding screenshots", "before committing", "during PR review"), it belongs in a skill, not here.`,
+    closingRule: 'Apply the factors in the order your agent needs them — not all at once. Start with Factor 3 (own your context window) and Factor 12 (stateless reducer); the others follow from there.',
+    ccPrimitives: [
+      'CLAUDE.md (prompt ownership)',
+      'settings.json (loop configuration)',
+      'Task tool (subagent boundaries)',
+      'Disk artifacts (unified state store)',
+    ],
     seeAlso: {
-      siblingPatternSlugs: ['context-engineering', 'memory-management', 'checkpointing', 'tool-use-react'],
+      siblingPatternSlugs: ['checkpointing', 'context-engineering', 'tool-use-react', 'evaluation-llm-as-judge'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Write the agent\'s prompt in a `.cursor/rules/*.mdc` file with `alwaysApply: true` — factor 2: prompt lives in the repo.',
+      'Use Agent mode for the executor loop; write intermediate state to disk files and read them back via `@file` — factor 5.',
+      'Use [Plan mode](https://cursor.com/docs/agent/plan-mode) to draft the step list before execution — factor 8 (own the loop).',
+      'Gate each phase on a CI check via [cloud agents](https://cursor.com/docs/cloud-agent) PR-based flow — factors 9 and 10.',
+    ],
+    ccPrimitives: [
+      '.cursor/rules/*.mdc (prompt ownership)',
+      '@file (unified state between steps)',
+      'Plan mode (explicit step list)',
+      'Cloud agents (CI-gated phases)',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['checkpointing', 'context-engineering', 'tool-use-react', 'evaluation-llm-as-judge'],
     },
   },
 }

--- a/src/data/agentic-design-patterns/patterns/12-factor-agent.ts
+++ b/src/data/agentic-design-patterns/patterns/12-factor-agent.ts
@@ -173,7 +173,7 @@ export {}
       { patternSlug: 'guardrails', oneLine: 'Factor 6 (own your control flow) — runtime enforcement layer the owning code can audit and update.' },
       { patternSlug: 'evaluation-llm-as-judge', oneLine: 'Factor 11 (trigger from anywhere) — evaluator running as CI step independent of the agent runtime.' },
     ],
-    closingRule: 'Apply the factors in the order your agent needs them — not all at once. Start with Factor 3 (own your context window) and Factor 12 (stateless reducer); the others follow from there.',
+    closingRule: 'If a rule has a trigger ("when adding screenshots", "before committing", "during PR review"), it belongs in a skill, not here.',
     ccPrimitives: [
       'CLAUDE.md (prompt ownership)',
       'settings.json (loop configuration)',

--- a/src/data/agentic-design-patterns/patterns/a2a.ts
+++ b/src/data/agentic-design-patterns/patterns/a2a.ts
@@ -153,24 +153,39 @@ export {}
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-05',
-  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — subagent-workflow Task() dispatch as lightweight A2A realization.',
-
+  dateModified: '2026-05-04',
+  lastChangeNote: 'Author A2A satellite: Agent Card discovery, Task lifecycle, distinction from MCP and in-process Handoffs.',
   realizingInClaudeCode: {
-    tier: 'C',
-
-    bodyMarkdown: `
-The [subagent-workflow skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/subagent-workflow/SKILL.md) realizes a lightweight in-process A2A protocol using Claude Code's Task() primitive. Each implementer, spec reviewer, and quality reviewer is dispatched with a structured prompt that functions as an implicit Agent Card: it names the agent's role, working directory, issue number, PR reference, and expected deliverable. The orchestrator sends tasks and receives completions without shared state — each agent is isolated to its worktree. The protocol does not use the Google A2A spec's JSON-over-HTTP Task lifecycle, but mirrors its conceptual shape: structured task dispatch, isolated execution, result surfaced back to the orchestrating agent. [PR #335](https://github.com/julianken/detached-node/pull/335) and [PR #344](https://github.com/julianken/detached-node/pull/344) are instances of this dispatch protocol completing in production.
-`.trim(),
-
-    readerMove: {
-      text: 'Write each Task() prompt as a structured agent card: role, working directory, issue reference, and expected deliverable format.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/subagent-workflow/SKILL.md',
-    },
-
+    keyMoves: [
+      'Expose an A2A endpoint from a Claude Code [subagent](https://docs.claude.com/en/docs/claude-code/sub-agents) by wrapping it in a JSON-RPC server the caller discovers via Agent Card.',
+      'Add the remote agent\'s A2A base URL to a task brief; the calling subagent fetches the Agent Card before posting the first Task.',
+      'Use an [MCP](https://docs.claude.com/en/docs/claude-code/mcp) server as the internal transport if caller and callee share a runtime — A2A is for cross-runtime boundaries only.',
+      'Declare the authentication scheme in the Agent Card; treat A2A endpoints as untrusted RPC surfaces requiring scoped credentials.',
+    ],
+    ccPrimitives: [
+      'Task tool (A2A caller subagent)',
+      'MCP server (same-runtime alternative)',
+      'CLAUDE.md Agent Card URL reference',
+    ],
     seeAlso: {
-      skillPath: '.claude/skills/subagent-workflow/SKILL.md',
-      siblingPatternSlugs: ['orchestrator-workers', 'handoffs-swarm', 'mcp'],
+      siblingPatternSlugs: ['mcp', 'tool-use-react', 'guardrails'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Wrap A2A JSON-RPC calls in an [MCP server](https://cursor.com/docs/mcp) — Cursor calls the MCP tool, which delegates to the remote agent.',
+      'Store the remote agent\'s base URL and auth credentials in `~/.cursor/mcp.json` env vars, not in the rule files.',
+      'Use `@docs` to index the remote agent\'s Agent Card schema; the model then constructs valid Task payloads without hallucinating field names.',
+      'Use Agent mode for A2A-orchestrated tasks; long-running remote Tasks benefit from the iterative polling the agent loop supports natively.',
+    ],
+    ccPrimitives: [
+      '.cursor/mcp.json (A2A transport wrapper)',
+      '~/.cursor/mcp.json (credential env vars)',
+      '@docs (Agent Card schema)',
+      'Agent mode',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['mcp', 'tool-use-react', 'guardrails'],
     },
   },
 }

--- a/src/data/agentic-design-patterns/patterns/agentic-rag.ts
+++ b/src/data/agentic-design-patterns/patterns/agentic-rag.ts
@@ -139,24 +139,40 @@ export {}
     },
   ],
   addedAt: '2026-05-04',
-  dateModified: '2026-05-05',
-  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — decision-funnel MCP-grounded investigation as agentic RAG realization.',
-
+  dateModified: '2026-05-04',
+  lastChangeNote: 'Initial authoring of Agentic RAG pattern (iterative retrieval loop; contrasts with single-shot RAG).',
   realizingInClaudeCode: {
-    tier: 'C',
-
-    bodyMarkdown: `
-The [decision-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md) mandates agentic retrieval throughout every phase: "Throughout every phase, actively use available MCP servers to query for real data rather than relying on assumptions or stale knowledge." Each Phase 1 investigator actively queries Context7 for up-to-date library documentation, GitHub Issues for issue context, and codebase tools for current architecture before generating findings. This is the agentic variant of RAG — retrieval is driven by the agent mid-task via tool calls, not pre-loaded into a static prompt. The phase-0 context packet lists artifact paths and domain scope; investigators retrieve against those anchors on demand. [PR #336](https://github.com/julianken/detached-node/pull/336) shows a funnel run grounded in live codebase queries.
-`.trim(),
-
-    readerMove: {
-      text: 'Instruct each investigator to query MCP tools for real data throughout every phase; never pre-load static context.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md',
-    },
-
+    keyMoves: [
+      'Expose your retrieval index as an [MCP](https://docs.claude.com/en/docs/claude-code/mcp) tool; Claude calls it iteratively inside the normal tool-use loop without extra orchestration.',
+      'Write the retrieval tool description to instruct re-querying — tell the model to refine and re-issue when initial passages are insufficient.',
+      'Use a [subagent](https://docs.claude.com/en/docs/claude-code/sub-agents) for retrieval-heavy tasks; it accumulates passages in its own context and returns a summary, keeping the main session clean.',
+      'Pin the stopping heuristic in [`CLAUDE.md`](https://docs.claude.com/en/docs/claude-code/memory): specify how many retrieval rounds are appropriate before the agent should answer on available evidence.',
+    ],
+    ccPrimitives: [
+      'MCP server (iterative retrieval)',
+      'CLAUDE.md (loop termination guidance)',
+      'Task tool (retrieval subagent)',
+      'settings.json tool allow-list',
+    ],
     seeAlso: {
-      skillPath: '.claude/skills/decision-funnel/SKILL.md',
-      siblingPatternSlugs: ['rag', 'tool-use-react', 'context-engineering'],
+      siblingPatternSlugs: ['rag', 'tool-use-react', 'reflexion'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Add a retrieval MCP server to `.cursor/mcp.json`; in Agent mode, the model issues multiple `retrieve` calls iteratively until it has enough evidence.',
+      'Use `@docs` to pre-index documentation sources; Cursor fetches and re-ranks on each retrieval call automatically.',
+      'Pass the initial query result back via `@file` and prompt the agent to refine the query if the result is insufficient.',
+      'Use [Plan mode](https://cursor.com/docs/agent/plan-mode) to sketch the retrieval strategy before the loop starts so you can review the intended hops.',
+    ],
+    ccPrimitives: [
+      '.cursor/mcp.json (retrieval server)',
+      '@docs (pre-indexed sources)',
+      '@file (intermediate result grounding)',
+      'Plan mode',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['rag', 'tool-use-react', 'reflexion'],
     },
   },
 }

--- a/src/data/agentic-design-patterns/patterns/checkpointing.ts
+++ b/src/data/agentic-design-patterns/patterns/checkpointing.ts
@@ -102,7 +102,7 @@ export {}
   realizingInCursor: {
     keyMoves: [
       'Commit partial work to a dedicated branch after each milestone; [cloud agents](https://cursor.com/docs/cloud-agent) already work on isolated branches by default.',
-      'Use a `STATUS.md` or equivalent file in the repo root as the recovery anchor — reference it via `@file` at the start of a resumed session.',
+      'Use a `STATUS.md` at the repo root as the recovery anchor; reference it via `@file` at the start of a resumed session.',
       'Write task progress to a [`.cursor/rules/*.mdc`](https://cursor.com/docs/rules) file with `alwaysApply: true` so context survives Cursor session restarts.',
       'Reference committed artifacts via `@git` or file references when resuming so the agent reads the actual persisted state, not its in-context assumption.',
     ],

--- a/src/data/agentic-design-patterns/patterns/checkpointing.ts
+++ b/src/data/agentic-design-patterns/patterns/checkpointing.ts
@@ -83,38 +83,37 @@ export {}
   },
   relatedSlugs: [],
   realizingInClaudeCode: {
-    tier: 'A',
+    keyMoves: [
+      'Write each phase\'s outputs to deterministic disk paths before the next [subagent](https://docs.claude.com/en/docs/claude-code/sub-agents) wave dispatches — the filesystem is the checkpoint store.',
+      'Maintain a `STATUS.md` with one row per phase (status, artifact count, timestamp); a fresh session reads it to find the resume point without replaying transcripts.',
+      'Gate each phase transition on a shell assertion that all expected artifact files exist and are non-empty — fail loudly rather than forward silently.',
+      'Forward a compressed context packet (1–2 K tokens) between phases, not raw transcripts; this keeps successor contexts clean and bounded.',
+    ],
     ccPrimitives: [
-      'Disk-checkpoint discipline — each phase boundary writes artifacts to disk (phase-{N}/{role}-{slug}.md) before the next wave is dispatched; the filesystem is the checkpoint store, not an in-memory accumulator',
-      'STATUS.md as the synchronous recovery anchor — a single row per phase updated inline during execution; a fresh-context successor session reads STATUS.md first and reconstructs where the funnel stopped without replaying any prior transcript',
-      'init_funnel.sh boundary-enforcement script — initializes the phase artifact directory tree, writes the initial STATUS.md row, and gates execution: the funnel does not start if the output directories are not writable',
-      'verify_phase.sh phase-exit gate — asserts all expected phase-{N}/{role}-{slug}.md files exist and are non-empty before dispatching the next wave; a missing artifact fails loudly rather than silently forwarding an incomplete context packet',
-      'update_status.py inline STATUS.md writer — called synchronously at each phase boundary to mark the phase complete with a timestamp and artifact count; the STATUS.md row is the only persistent record the orchestrator session needs to resume',
-      'Context-packet forwarding — between phases the orchestrator assembles a 1–2 K token context packet from phase artifacts (not raw transcripts) and passes it as the dispatch payload for the next wave; the packet keeps successor-session contexts clean',
+      'Disk artifact checkpoint protocol',
+      'STATUS.md recovery anchor',
+      'Task tool (phase workers)',
+      'PreToolUse hooks (phase-exit gate)',
     ],
-    scaffolding: [
-      '.claude/skills/analysis-funnel/SKILL.md — the orchestrator prompt encoding the 5+5+3+1 phase structure, the disk-checkpoint rule ("write each phase\'s artifacts before dispatching the next"), the STATUS.md synchronization contract, and the context-packet forwarding convention; the SKILL.md is the boundary-enforcement specification',
-      'STATUS.md recovery anchor — one row per phase: phase number, status (pending / running / complete), artifact count, timestamp, and a one-line summary; the row is updated synchronously by update_status.py at each boundary; a new session that loses its context reads STATUS.md and knows exactly which phase to resume from',
-      'phase-{N}/{role}-{slug}.md artifact convention — each investigator, iterator, and synthesizer writes its output to a deterministic path on disk; the path is the identity of the artifact and the checkpoint; the orchestrator never holds phase outputs in-context after the phase completes',
-      'Context-packets directory — context-packets/phase-{N}-packet.md holds the 1–2 K token summary that crosses the boundary; it is the only inter-phase artifact the next wave\'s workers receive in addition to their brief; the full phase-{N}/ directory is available on disk but not forwarded into worker contexts',
-    ],
-    workedExample: {
-      url: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/analysis-funnel/SKILL.md',
-      description: `The analysis-funnel SKILL.md documents the 5→5→3→1 disk-checkpoint discipline that is Checkpointing realized in Claude Code. The SKILL.md encodes the boundary protocol: write every phase's artifacts to disk before the next wave dispatches, update STATUS.md inline, forward a compressed context packet rather than raw transcripts. The three boundary-enforcement scripts — init_funnel.sh, verify_phase.sh, update_status.py — implement the checkpoint-write and gate-check steps that the pattern requires.
-
-The structural mechanics in the SKILL.md match Checkpointing's core invariant: no phase work is held only in-context. Phase 1 investigators write findings to phase-1/{role}-{slug}.md on disk; verify_phase.sh asserts those files exist before Phase 2 dispatches. Phase 2 iterators read Phase 1 artifacts from disk (not from the orchestrator's in-context memory), produce phase-2/{role}-{slug}.md, and the process repeats. At each boundary, update_status.py marks the phase complete in STATUS.md with a timestamp and artifact count. A fresh-context session that opens STATUS.md can reconstruct the funnel's state entirely from disk — no transcript replay required, no in-context accumulation from the prior phase needed.
-
-This realization is consistent with the durable-state-machine framing that LangGraph (BaseCheckpointSaver, thread_id-keyed snapshots) and Temporal (event-history replay, short-circuiting already-journaled Activities) describe in their documentation. The difference is the storage layer: production orchestration frameworks write to Postgres or a journal service; the analysis-funnel configuration writes to the local filesystem under a git-tracked directory tree. The recovery guarantee is weaker — a disk wipe loses the checkpoint — but the boundary discipline is identical: complete the step, persist the output, gate the next step on the persisted artifact.
-
-STATUS.md as a recovery anchor is convergent practice across software-development tooling. Linear ships a per-issue status field updated synchronously with each transition. GitHub Projects tracks per-card status across board columns. Babel maintained a STATUS.md that documented compatibility-table completion per transform. Vue used a similar STATUS.md convention during the Vue 3 migration to track plugin and library readiness. Rust's tracking issues name per-feature stabilization status with inline checklists. The analysis-funnel configuration adds one specific deployment: using the STATUS.md row as the disk-anchored recovery signal for a fresh-context agent session resuming mid-funnel — the file's name is the prior art; the deployment pattern is what this configuration contributes.`,
-    },
-    readerMove: {
-      text: "Write each phase's artifacts to disk before dispatching the next; sync STATUS.md inline.",
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/analysis-funnel/SKILL.md',
-    },
     seeAlso: {
-      skillPath: '.claude/skills/analysis-funnel/SKILL.md',
-      siblingPatternSlugs: ['orchestrator-workers', 'context-engineering'],
+      siblingPatternSlugs: ['orchestrator-workers', 'context-engineering', 'funnel-method'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Commit partial work to a dedicated branch after each milestone; [cloud agents](https://cursor.com/docs/cloud-agent) already work on isolated branches by default.',
+      'Use a `STATUS.md` or equivalent file in the repo root as the recovery anchor — reference it via `@file` at the start of a resumed session.',
+      'Write task progress to a [`.cursor/rules/*.mdc`](https://cursor.com/docs/rules) file with `alwaysApply: true` so context survives Cursor session restarts.',
+      'Reference committed artifacts via `@git` or file references when resuming so the agent reads the actual persisted state, not its in-context assumption.',
+    ],
+    ccPrimitives: [
+      'Cloud agents (branch isolation)',
+      '.cursor/rules/*.mdc (persistent state)',
+      '@file (recovery anchor)',
+      'Agent mode',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['orchestrator-workers', 'context-engineering', 'funnel-method'],
     },
   },
   frameworks: ['langgraph', 'mastra'],

--- a/src/data/agentic-design-patterns/patterns/code-agent.ts
+++ b/src/data/agentic-design-patterns/patterns/code-agent.ts
@@ -168,35 +168,39 @@ export {}
   ],
   addedAt: '2026-05-03',
   dateModified: '2026-05-05',
-  lastChangeNote: 'W2.3: add realizingInClaudeCode Tier B + worktree-per-issue inline Tier C.',
+  lastChangeNote: 'Editorial scrub: generalize realizingInClaudeCode to general CC voice; add keyMoves; remove repo-specific skill names and PR citations.',
   realizingInClaudeCode: {
-    tier: 'B',
-    ccPrimitives: [
-      'Edit / Bash / Read tool loop (the Agent-Computer Interface Claude Code ships)',
-      'pnpm test:unit → pnpm lint → pnpm typecheck → pnpm test:e2e gate (the test-runner half of the loop)',
-      'subagent-workflow principle 5: "lead agent orchestrates, never edits code directly"',
+    keyMoves: [
+      'Declare in [`CLAUDE.md`](https://docs.claude.com/en/docs/claude-code/memory): the lead agent orchestrates and reviews; implementer [subagents](https://docs.claude.com/en/docs/claude-code/sub-agents) hold the edit tools.',
+      'Define the test-gate sequence (`test:unit → lint → typecheck → test:e2e`) in `CLAUDE.md` — the loop terminates on green, not on the agent\'s assessment.',
+      'Give each issue its own git worktree (`git worktree add`); implementer agents work in isolation and the lead checkout stays clean.',
+      'Scope implementer subagents to file-editing tools only via [`settings.json`](https://docs.claude.com/en/docs/claude-code/settings) `permissions.allow`; the lead holds Bash.',
     ],
-    bodyMarkdown: `
-Claude Code is not a tool that supports the Code Agent pattern — it is the pattern. The CLI wires the read-edit-test loop directly: the model calls \`Read\`, \`Edit\`, and \`Bash\` tools against a real checkout, runs \`pnpm test:unit\` to get feedback, and iterates. No scaffolding is required to enter the loop; opening a terminal session is the Agent-Computer Interface.
-
-Three layers make the loop disciplined rather than merely runnable. First, a **tool layer**: \`Read\`, \`Edit\`, and \`Bash\` are the ACI primitives; the test-gate command sequence (\`pnpm test:unit → pnpm lint → pnpm typecheck → pnpm test:e2e\`) is the success criterion the loop converges on. Second, a **CLAUDE.md rule**: the subagent-workflow skill encodes the convention as principle 5 — "lead agent orchestrates, never edits code directly." The lead agent plans, dispatches, and reviews; implementer subagents hold the edit tools. This is a workflow convention in this repo's [\`.claude/skills/subagent-workflow/SKILL.md\`](https://github.com/julianken/detached-node/blob/main/.claude/skills/subagent-workflow/SKILL.md), not an enforced technical constraint. Third, a **worktree-per-issue discipline**: each GitHub Issue gets its own git worktree so implementer agents work in isolation and the lead agent's main checkout stays clean.
-
-The worked example is [issue #305](https://github.com/julianken/detached-node/issues/305) + [PR #335](https://github.com/julianken/detached-node/pull/335): a W0.1 hooks-restore task dispatched to a subagent that ran the read-edit-test loop in a dedicated worktree, produced a clean diff, and surfaced it for review — the pattern's lifecycle compressed into a single issue.
-
-<details>
-<summary>Cross-link: worktree-per-issue (Tier C)</summary>
-
-Each GitHub Issue in this repo's subagent workflow gets its own git worktree, created with \`git worktree add .claude/worktrees/wt-NNN-<slug> feat/<slug>\`. The naming places worktrees inside the repo at \`.claude/worktrees/\` so the harness sandbox can reach them without leaving the checkout root. The worktree inherits the repo's \`CLAUDE.md\` automatically; no extra config copy step is needed. The pattern prevents implementer agents from stepping on each other's working trees and keeps the lead agent's main checkout unmodified between dispatches. Remove with \`git worktree remove .claude/worktrees/wt-NNN-<slug>\` after the PR merges.
-
-</details>
-`.trim(),
-    readerMove: {
-      text: 'Add a one-line lead-never-edits rule to your CLAUDE.md and try git worktree add on your next issue.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/subagent-workflow/SKILL.md',
-    },
+    ccPrimitives: [
+      'Edit / Bash / Read tool loop (built-in ACI)',
+      'Task tool (implementer subagents)',
+      'Git worktrees (isolation)',
+      'CLAUDE.md test-gate definition',
+    ],
     seeAlso: {
-      skillPath: '.claude/skills/subagent-workflow/SKILL.md',
-      siblingPatternSlugs: ['tool-use-react', 'orchestrator-workers'],
+      siblingPatternSlugs: ['tool-use-react', 'orchestrator-workers', 'guardrails'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Use Agent mode — it ships Read/Edit/Bash equivalents and the read-edit-test loop natively without additional configuration.',
+      'Use [Plan mode](https://cursor.com/docs/agent/plan-mode) before implementation to produce an inspectable step list; review it before the agent touches files.',
+      'Add a `.cursor/rules/*.mdc` rule defining the test-gate sequence (`pnpm test:unit`, etc.) as the success criterion the loop targets.',
+      'Launch [Cloud Agents](https://cursor.com/docs/cloud-agent) for longer-running code tasks; they run in isolated VMs and surface a diff for review on completion.',
+    ],
+    ccPrimitives: [
+      'Agent mode (built-in read-edit-run loop)',
+      'Plan mode (pre-implementation review)',
+      'Cloud Agents (isolated VM execution)',
+      '.cursor/rules/*.mdc (test-gate definition)',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['tool-use-react', 'orchestrator-workers', 'guardrails'],
     },
   },
 }

--- a/src/data/agentic-design-patterns/patterns/context-engineering.ts
+++ b/src/data/agentic-design-patterns/patterns/context-engineering.ts
@@ -145,7 +145,7 @@ export {}
       'Move trigger-bearing rules into [skills](https://docs.claude.com/en/docs/claude-code/skills) — a `SKILL.md` loads only when its trigger fires, preserving always-on budget.',
       'Keep `CLAUDE.md` under 3 K tokens. Count with `wc -w × 1.8`; every extra line crowds out the actual task context.',
       'Use [`settings.json`](https://docs.claude.com/en/docs/claude-code/settings) to scope tool permissions per project — pin invariant config at the head so it cache-hits every session.',
-      'When a rule starts with "when X" or "before Y", that is a signal it belongs in a skill, not in always-on memory.',
+      'When a rule starts with "when X" or "before Y", it belongs in a skill, not here — keep `CLAUDE.md` to invariants.',
     ],
     ccPrimitives: [
       'CLAUDE.md (always-on context)',

--- a/src/data/agentic-design-patterns/patterns/context-engineering.ts
+++ b/src/data/agentic-design-patterns/patterns/context-engineering.ts
@@ -138,52 +138,40 @@ export {}
   ],
   addedAt: '2026-05-03',
   dateModified: '2026-05-05',
-  lastChangeNote: 'W3.1 additive: add 12-factor-agent to seeAlso.siblingPatternSlugs, resolving W1.2 forward-reference.',
+  lastChangeNote: 'W2.9 additive: 5-section PR body as reviewer context packet cross-link.',
   realizingInClaudeCode: {
-    tier: 'A',
+    keyMoves: [
+      'Put always-on project rules in [`CLAUDE.md`](https://docs.claude.com/en/docs/claude-code/memory). Claude reads it at the start of every session before any tool call.',
+      'Move trigger-bearing rules into [skills](https://docs.claude.com/en/docs/claude-code/skills) — a `SKILL.md` loads only when its trigger fires, preserving always-on budget.',
+      'Keep `CLAUDE.md` under 3 K tokens. Count with `wc -w × 1.8`; every extra line crowds out the actual task context.',
+      'Use [`settings.json`](https://docs.claude.com/en/docs/claude-code/settings) to scope tool permissions per project — pin invariant config at the head so it cache-hits every session.',
+      'When a rule starts with "when X" or "before Y", that is a signal it belongs in a skill, not in always-on memory.',
+    ],
     ccPrimitives: [
-      'CLAUDE.md always-on-files trio (CLAUDE.md, settings.json, .claude/skills/)',
-      'prompt-caching prefix pinning (invariant system prompt at window head)',
-      'tiktoken cl100k_base token counting / wc -w × 1.8 fallback',
+      'CLAUDE.md (always-on context)',
+      'SKILL.md (trigger-conditional context)',
+      'settings.json (tool scoping)',
+      'Prompt-caching prefix pinning',
     ],
-    scaffolding: [
-      'CLAUDE.md (always-on project-level instructions)',
-      '.claude/skills/analysis-funnel/SKILL.md (carry-forward context structure)',
-    ],
-    workedExample: {
-      url: 'https://github.com/julianken/detached-node/blob/main/CLAUDE.md',
-      description: 'The project-root CLAUDE.md is itself a worked example of context engineering: it loads on every Claude Code session as always-on context, before any tool call or task instruction. Its contents enact the editorial discipline the pattern describes — unconditional project facts (framework, conventions, design system) stay in the file; trigger-bearing rules migrate to `.claude/skills/` so they consume window budget only when the trigger fires. Reading the file end-to-end shows what survives the always-on slot and what is structured to load on demand.',
-    },
-    readerMove: {
-      text: 'Count your three always-on files with tiktoken cl100k_base or wc -w × 1.8; if over 3 K tokens, move trigger-bearing rules into skills.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/CLAUDE.md',
-    },
     seeAlso: {
-      skillPath: '.claude/skills/analysis-funnel/SKILL.md',
       siblingPatternSlugs: ['memory-management', 'checkpointing', '12-factor-agent'],
     },
-    bodyMarkdown: `Context engineering in a Claude Code setup begins with the three files that load on every session — \`CLAUDE.md\`, \`settings.json\`, and the skills directory. These are the always-on context: they arrive before any tool call, before any task instruction, before any retrieved content. The user-level \`~/.claude/CLAUDE.md\` token-economics meta-rule captures the load-bearing editorial discipline for this file class: "If a rule has a trigger ("when adding screenshots", "before committing", "during PR review"), it belongs in a skill, not here." ([source](https://github.com/julianken/detached-node/blob/main/CLAUDE.md)). Rules without triggers stay in \`CLAUDE.md\`; rules with triggers migrate to skills. The discipline is token-economic: every unconditional rule that migrates to a skill is a line evicted from the always-on budget.
-
-### Realization in this repo
-
-The project-root [\`CLAUDE.md\`](https://github.com/julianken/detached-node/blob/main/CLAUDE.md) is the worked example: every Claude Code session in this repo loads it before any tool call, so its contents define what the model sees while answering. Read end-to-end, the file is a deliberately curated set of unconditional project facts — framework choice, design-system pointers, content-model summary, phase status — and a "Files to Read First" pointer list that nominates the next budgeted reads. Trigger-bearing behaviors are absent by design: pre-commit checks, screenshot procedures, and PR review rubrics live in \`.claude/skills/\` and load only when invoked. The split is the pattern in action — selection happens upstream of generation, and the always-on slot pays its rent in signal per token.
-
-The three-move mechanical implementation mirrors the pattern's abstract structure. A relevance signal — the editorial test "does this rule have a trigger?" — orders candidates between the always-on file and the on-demand skills. A budget — the target token count for the three-file always-on slot, calibrated so retrieved content and task instructions still fit the session's practical limit — caps what survives in \`CLAUDE.md\`. A layout — project invariants pinned at the \`CLAUDE.md\` head, then any phase-boundary summary the user has produced, then the live task — places surviving tokens where attention is strongest.
-
-Measuring the always-on budget is the prerequisite step. Count tokens in \`CLAUDE.md\` + \`settings.json\` + the relevant skill using tiktoken \`cl100k_base\`, or multiply the raw word count by 1.8 as a fast proxy (tiktoken cl100k_base is the canonical measure; wc -w × 1.8 is the fast fallback). If the total exceeds 3 K tokens, the always-on context is consuming budget that limits how much retrieved or task-specific content can be packed in. The repair is the meta-rule: any rule with a trigger migrates to a skill so it loads only when the trigger fires.
-
-<details>
-<summary>Cross-link: minimal-CLAUDE.md pattern</summary>
-
-The minimal-CLAUDE.md configuration applies the same token-economics meta-rule at the file level. The editorial split is: unconditional facts about the project (framework, conventions, non-goals) stay in \`CLAUDE.md\`; triggered behaviors (pre-commit checks, screenshot procedures, PR review rubrics) live in \`.claude/skills/\` and load only when invoked. The result is a \`CLAUDE.md\` that is dense with signal per token rather than exhaustive. The user-level meta-rule — "If a rule has a trigger, it belongs in a skill, not here" — is the one-sentence specification for this configuration. Context Engineering names the budget rationale; minimal-CLAUDE.md names the file-level split that implements it.
-
-</details>
-
-<details>
-<summary>Cross-link: 5-section PR body as reviewer context packet</summary>
-
-The five-section PR body (Diagrams / Summary / Screenshots / Test plan / Plan reference) is an engineered context packet for the reviewer's first read. Each section maps to a distinct attention slot: Diagrams anchors visual changes before the diff is opened; Summary compresses scope to a single scroll; Test plan itemizes the pre-review checklist the bot is expected to verify claim-by-claim before scoring the implementation. Placing Test plan before Plan reference is a layout choice, not convention — the sections that require active checking arrive before the sections that are reference-only, matching the U-shape recall curve the pattern documents. [PR #339 (W1.1 Orchestrator-Workers)](https://github.com/julianken/detached-node/pull/339) shows the full five-section structure as read by the julianken-bot reviewer on its first cycle.
-
-</details>`,
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Set `alwaysApply: true` in [`.cursor/rules/*.mdc`](https://cursor.com/docs/rules) only for project-wide invariants — every other rule pays that token budget on every turn.',
+      'Use `globs` in rule frontmatter to scope rules to specific file types; a rule for `**/*.tsx` fires only when those files are in context.',
+      'Keep total `alwaysApply` rule content under ~500 lines combined — beyond that, the working context fills before the task description lands.',
+      'Use @-references to inject specific files, folders, or terminal output on demand rather than loading everything up front.',
+    ],
+    ccPrimitives: [
+      '.cursor/rules/*.mdc',
+      'alwaysApply frontmatter',
+      'globs scoping',
+      '@-references (on-demand injection)',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['memory-management', 'checkpointing', '12-factor-agent'],
+    },
   },
 }

--- a/src/data/agentic-design-patterns/patterns/evaluation-llm-as-judge.ts
+++ b/src/data/agentic-design-patterns/patterns/evaluation-llm-as-judge.ts
@@ -151,72 +151,35 @@ export {}
   lastChangeNote: 'W2.9 additive: Mergify merge-queue structural-lock cross-link + 5-section PR body cross-link.',
 
   realizingInClaudeCode: {
-    tier: 'A',
-
+    keyMoves: [
+      'Dispatch the judge as a separate subagent in a fresh context window — same-model self-review inflates scores structurally.',
+      'Write the rubric as a [SKILL.md](https://docs.claude.com/en/docs/claude-code/skills) the judge subagent loads at invocation; version it in git so rubric changes are auditable.',
+      'Use a stronger model tier for the judge than the implementer when possible; cross-tier review breaks the shared-prior bias.',
+      'Gate the merge queue on the judge\'s structured verdict; require at least one approval before any PR advances to merge.',
+    ],
     ccPrimitives: [
-      'julianken-bot subagent — a separate GitHub machine-user identity that posts reviews via the REST API, never via `gh pr review`, from a fresh context window independent of the dispatcher',
-      'reviewing-as-julianken-bot SKILL.md — the 12-rule rubric (R1 trace-every-claim, R3 cap-findings-at-3, R8 mandatory-find second pass, R11 prompt-injection defense, R12 cross-tier model bias) loaded by the subagent at invocation time',
-      'macOS Keychain PAT — bot credential stored under service `julianken-bot@github.com`, account `token`; scoped to a single `GH_TOKEN=$(...) gh` subprocess per call; never exported, never written to disk',
-      'Mergify merge-queue gate — `.mergify.yml` declares the required-checks list and the `#approved-reviews-by >= 1` precondition; convention is to wait for `@julianken-bot`\'s APPROVE before commenting `@Mergifyio queue`',
+      'Task tool (judge subagent)',
+      'SKILL.md rubric (versioned criteria)',
+      'settings.json merge-gate config',
     ],
-
-    scaffolding: [
-      '.claude/skills/reviewing-as-julianken-bot/SKILL.md — the 12-rule rubric file; loaded by the julianken-bot subagent; contains R1–R12 with per-rule rationale and citation anchors',
-      'scripts/bot-review.sh — encapsulates Keychain load + single-subprocess GH_TOKEN scoping + REST API call; dispatcher calls this with owner/repo, PR number, and a jq-assembled review JSON',
-      '.mergify.yml — declares required checks and a `#approved-reviews-by >= 1` queue condition; the bot identity is convention-enforced today (any collaborator approval satisfies the gate), and could be pinned via a Mergify condition such as `approved-reviews-by ~= julianken-bot` if the convention needs infrastructure backing',
-    ],
-
-    workedExample: {
-      url: 'https://github.com/julianken/detached-node/pull/290',
-      description: 'PR #290 (favicon rebrand) completed a full 2-cycle bot review. Cycle 1: julianken-bot (model: opus, fresh context) posted REQUEST_CHANGES with 1 IMPORTANT finding (splash background merge) and 1 SUGGESTION (short_name truncation), each traced to a specific manifest field per R1. The mandatory R8 second pass surfaced both findings; no filler praise appeared. Cycle 2: fixes applied; bot re-reviewed the delta-only diff, confirmed both findings resolved, ran the mandatory R8 second pass on a 4-character change set, and posted APPROVE. The same-tier risk flag was noted in the verdict per R12. Total review time across both cycles: under 4 minutes.',
-    },
-
-    bodyMarkdown: `
-The abstract pattern — a separate model reads a candidate output, applies a written rubric, and emits a structured verdict — appears in the research literature as LLM-as-Judge (Zheng et al., NeurIPS 2023) and in the observability ecosystem as first-class evaluator types (LangSmith, OpenAI Evals). Anthropic shipped a managed version of this pattern in April 2026 as multi-agent code review built into Claude Code: a separate critic agent in fresh context, cross-provider model selection, and sycophancy-bias mitigation as a named design goal (InfoQ; The New Stack). The mechanics are structurally identical to what this section describes.
-
-The self-hosted realization documented here predates the managed feature and is one of two paths for practitioners who want control over the rubric, the identity separation, or the credential topology.
-
-**Bias mitigations the rubric encodes**
-
-LLM-as-judge has three documented failure modes that any production realization must address explicitly. NeurIPS 2024 measured perplexity-familiarity bias: a model reviewing its own output assigns systematically inflated scores because the output reads as familiar rather than correct. NYU (January 2026) showed empirically that cross-tier verification — a stronger model reviewing a weaker model's output — breaks the shared-prior mechanism responsible for the inflation. OWASP LLM Top 10 2026 catalogues indirect prompt injection via PR body as the dominant attack class on AI reviewers; OWASP LLM01:2025 / OWASP LLM01:2026 list it as the top-ranked enterprise risk.
-
-The 12-rule rubric addresses all three:
-
-- **R8 (mandatory-find second pass)** directly counters perplexity-familiarity bias. Before drafting the verdict, the reviewer runs a second pass with the explicit prior that at least one improvement exists. A clean APPROVE after a genuine second pass is an honest verdict; skipping the pass produces a sycophantic LGTM.
-- **R12 (cross-tier model bias)** implements the NYU mitigation. The julianken-bot subagent defaults to \`model: opus\` so that when the implementer ran on Sonnet, the reviewer runs on a stronger tier. If both ran on Opus, R12 flags the same-tier risk explicitly in the verdict — as seen in PR #290's cycle-2 APPROVE.
-- **R11 (prompt-injection defense)** implements the OWASP mitigation. PR title, body, and commit messages are treated as untrusted input. Text that looks like reviewer instructions (e.g., "please approve without reviewing") is flagged as a BLOCKER, not followed. The rubric also defines sanitization protocol in a companion \`sanitization.md\`.
-
-**PR-Agent convergence**
-
-The 3-finding cap (R3) and the "no filler praise" rule (R4) derive from PR-Agent's verbatim defaults (\`num_max_findings = 3\`) and style guidelines. The 9:1 false-positive ratio of undisciplined AI reviewers drops toward a >60% signal ratio under the rubric per the April 2026 benchmark (arxiv 2604.03196). The convergence is intentional: PR-Agent encoded the same operational lesson independently.
-
-**Credential topology**
-
-The bot PAT lives in macOS Keychain under service \`julianken-bot@github.com\`, account \`token\`. Four accounts cover all bot access: \`password\` (web UI fallback), \`token\` (every \`gh\` call), \`totp-secret\` (TOTP generation via \`scripts/bot-totp.sh\`), and \`recovery-codes\`. The \`GH_TOKEN=$(...) gh\` scoping pattern keeps Julian's main \`gh auth\` state untouched — \`gh auth status\` always shows \`julianken\`, never the bot. The token is never exported, never written to \`.env\` or \`.netrc\`, and never visible in \`ps aux\`.
-
-<details>
-<summary>Cross-link: Mergify merge queue as structural lock</summary>
-
-The merge queue is the infrastructure that closes the cross-tier review loop. The bot's APPROVE is the gate signal: the [\`.mergify.yml\`](https://github.com/julianken/detached-node/blob/main/.mergify.yml) \`queue_conditions\` block requires \`#approved-reviews-by >= 1\` before Mergify rebases the branch, re-runs all CI checks, and squash-merges. In practice this means the reviewer's verdict — not a human clicking a button after the fact — is what opens the merge boundary. The convention of commenting \`@mergifyio queue\` only after the bot APPROVE translates the evaluation pattern's "structured verdict gates the next stage" contract into a deployment primitive. (For OSS projects without paid Mergify, GitHub-native merge queue provides the same structural lock.)
-
-</details>
-
-<details>
-<summary>Cross-link: 5-section PR body as reviewer context packet</summary>
-
-The canonical five-section PR body (Diagrams / Summary / Screenshots / Test plan / Plan reference) is the artifact the julianken-bot reviewer reads before opening the diff. Each section serves the rubric: Diagrams surfaces render changes so R1 (trace-every-claim) has visual evidence; Test plan provides a deterministic checklist the reviewer can verify claim-by-claim; Plan reference anchors the PR to its action-plan entry so scope is auditable. [PR #342 (W2.2 Checkpointing)](https://github.com/julianken/detached-node/pull/342) demonstrates the full shape: five sections, all populated, first-cycle APPROVE with zero BLOCKER findings.
-
-</details>
-`.trim(),
-
-    readerMove: {
-      text: "Mint a machine-user account, write a 12-rule rubric, and adopt the convention of waiting for the bot's APPROVE before queueing the merge.",
-      anchorUrl:
-        'https://github.com/julianken/detached-node/blob/main/.mergify.yml',
-    },
-
     seeAlso: {
-      articleSlug: 'cross-identity-code-review',
+      siblingPatternSlugs: ['guardrails', 'human-in-the-loop', 'identity-separated-review'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Open a second Agent chat as the judge — pass the candidate output via `@file`; the judge reads it cold without the implementer\'s framing.',
+      'Write the evaluation rubric in a `.cursor/rules/*.mdc` file; reference it explicitly in the judge chat opening prompt.',
+      'Use a different model in the judge chat than the implementer chat when Cursor\'s model picker allows — reduces same-model self-preference.',
+      'Record the judge\'s verdict in a file and reference it via `@file` in the implementer chat to close the feedback loop.',
+    ],
+    ccPrimitives: [
+      'Multiple Agent chats (implementer + judge)',
+      '.cursor/rules/*.mdc (rubric file)',
+      '@file (candidate and verdict sharing)',
+      'Model picker (cross-tier selection)',
+    ],
+    seeAlso: {
       siblingPatternSlugs: ['guardrails', 'human-in-the-loop', 'identity-separated-review'],
     },
   },

--- a/src/data/agentic-design-patterns/patterns/evaluator-optimizer.ts
+++ b/src/data/agentic-design-patterns/patterns/evaluator-optimizer.ts
@@ -151,23 +151,39 @@ export {}
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-05',
-  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — creative-funnel spec+quality review cycle as evaluator-optimizer realization.',
-
+  dateModified: '2026-05-04',
+  lastChangeNote: 'Author Evaluator-Optimizer satellite: within-attempt generator-critic loop, contrast with Reflexion, base-capability-ceiling gotcha.',
   realizingInClaudeCode: {
-    tier: 'C',
-
-    bodyMarkdown: `
-The [creative-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/creative-funnel/SKILL.md) is evaluator-optimizer with two named critic roles and a capped iteration budget. Phase 1 creates N artifacts (generator). Phase 2 dispatches N spec reviewers who each return APPROVED or REVISION NEEDED with actionable instructions (evaluator pass 1). Failed items are revised and re-reviewed; maximum two cycles. Phase 3 dispatches N quality reviewers who rate craft and return APPROVED or POLISH NEEDED (evaluator pass 2). Failed items are polished and re-reviewed; maximum two cycles. After two failures the item is flagged for human attention rather than looped — the skill names the cap explicitly as an anti-drift measure. The two-gate structure separates correctness evaluation (spec) from quality evaluation (craft), matching the pattern's requirement that the evaluator produce actionable feedback the generator can act on. [PR #341](https://github.com/julianken/detached-node/pull/341) used this review structure.
-`.trim(),
-
-    readerMove: {
-      text: 'Separate spec review (correctness) from quality review (craft); cap each at two cycles; flag rather than loop after two failures.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/creative-funnel/SKILL.md',
-    },
-
+    keyMoves: [
+      'Write the rubric in [`CLAUDE.md`](https://docs.claude.com/en/docs/claude-code/memory) as named acceptance criteria the critic prompt references verbatim.',
+      'Use a [PreToolUse hook](https://docs.claude.com/en/docs/claude-code/hooks) as the critic for tool-verifiable criteria — exit non-zero forces a retry without consuming a model call.',
+      'Run generator and critic in separate [subagents](https://docs.claude.com/en/docs/claude-code/sub-agents) so the critic reads the draft cold without the generator\'s framing.',
+      'Declare a hard iteration cap in the orchestrating [`SKILL.md`](https://docs.claude.com/en/docs/claude-code/skills) prompt; a loop without a cap burns tokens on diminishing returns.',
+    ],
+    ccPrimitives: [
+      'CLAUDE.md rubric definitions',
+      'PreToolUse hooks (deterministic critic)',
+      'Task tool (isolated critic subagent)',
+      'SKILL.md iteration cap (declared in prompt)',
+    ],
     seeAlso: {
-      skillPath: '.claude/skills/creative-funnel/SKILL.md',
+      siblingPatternSlugs: ['reflexion', 'evaluation-llm-as-judge', 'guardrails'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Write acceptance criteria in a `.cursor/rules/*.mdc` file; reference it explicitly in both the generator and reviewer prompts.',
+      'Use [Plan mode](https://cursor.com/docs/agent/plan-mode) to draft the rubric before starting the generate-critique loop.',
+      'Invoke a second Agent chat as the critic — pass the draft via `@file` so it reads the output without the generation context.',
+      'Set a manual turn limit in the chat; close and re-open when iterations stop improving the verdict.',
+    ],
+    ccPrimitives: [
+      '.cursor/rules/*.mdc (rubric)',
+      'Plan mode',
+      '@file (draft reference)',
+      'Agent mode',
+    ],
+    seeAlso: {
       siblingPatternSlugs: ['reflexion', 'evaluation-llm-as-judge', 'guardrails'],
     },
   },

--- a/src/data/agentic-design-patterns/patterns/funnel-method.ts
+++ b/src/data/agentic-design-patterns/patterns/funnel-method.ts
@@ -9,7 +9,7 @@ export const pattern: Pattern = {
   bodySummary: [
     'The Funnel Method is a four-phase multi-agent investigation and synthesis loop. Phase 1 fans out five parallel investigators, each exploring an independent facet of the problem space. Phase 2 fans out five iterators that develop, challenge, and extend the Phase 1 findings. Phase 3 fans out three synthesizers that converge through different analytical lenses. Phase 4 runs a single unifier that produces the final deliverable. Every phase boundary writes artifacts to disk before the next wave dispatches; a STATUS.md row updates synchronously at each transition; a compressed context packet (1–2 K tokens, not raw transcripts) flows forward as the dispatch payload. The next wave reads the packet plus its own brief — never the prior wave\'s full transcript.',
     'The 5+5+3+1 cardinality is one specific composition of well-established antecedents. The four-phase funnel shape is consistent with the Double Diamond framework (British Design Council, 2005), which names Discover, Define, Develop, and Deliver as the four moves in a design process. The parallel-then-converge dispatch mechanic draws on Nominal Group Technique (NGT, Delbecq and Van de Ven, 1971), which prescribes silent individual idea generation followed by group ranking — the same structural logic applied to agent waves. Anthropic\'s multi-agent research blog describes the lead-spawns-3-5-subagents primitive that is the direct computational ancestor of the parallel dispatch waves. LangGraph and Temporal own the durable-state-machine and phase-boundary-checkpoint framing that the disk-artifact protocol realizes at a simpler storage layer.',
-    'Three Claude Code skills encode the funnel as executable configuration: analysis-funnel (open-ended investigation), decision-funnel (option evaluation), and creative-funnel (parallel creative production). The same 5+5+3+1 structure appears across all three, applied to different triggering domains. The shared shape across three independent triggering domains is the practical validation that the cardinality is stable rather than accidental. The disk-artifact protocol — STATUS.md, phase-{N}/{role}-{slug}.md artifacts, context-packets/phase-{N}-packet.md — is the shared scaffolding that makes each skill resumable, inspectable, and auditable across domains.',
+    'Claude Code [skills](https://docs.claude.com/en/docs/claude-code/skills) encode the funnel as executable configuration, with variants for investigation, option evaluation, and creative production. The same 5+5+3+1 structure appears across all variants, applied to different triggering domains. The shared shape across independent triggering domains is the practical validation that the cardinality is stable rather than accidental. The disk-artifact protocol — STATUS.md, phase-{N}/{role}-{slug}.md artifacts, context-packets/phase-{N}-packet.md — is the shared scaffolding that makes each skill resumable, inspectable, and auditable across domains.',
   ],
   mermaidSource: `graph LR
   A[Brief + question] --> B[Phase 0: Frame]
@@ -47,7 +47,7 @@ export const pattern: Pattern = {
       sourceUrl: 'https://www.designcouncil.org.uk/our-resources/framework-for-innovation/',
     },
   ],
-  implementationSketch: `// Pseudocode — the actual implementation uses the analysis-funnel SKILL.md
+  implementationSketch: `// Pseudocode — the actual implementation uses a funnel SKILL.md
 // and the single-message multi-Task() dispatch mechanic.
 
 // Phase 0: frame the question, carve investigation areas
@@ -91,8 +91,8 @@ export {}
 `,
   sdkAvailability: 'no-sdk',
   readerGotcha: {
-    text: 'The context packet between phases must be a compressed summary (1–2 K tokens), never a dump of raw phase artifacts. Passing raw artifacts forward bloats each wave\'s context and re-exposes details the prior wave already resolved. The context packet is a design artifact: it encodes what the next wave needs to know, not everything the prior wave produced. Analysis-funnel SKILL.md encodes this as a hard constraint — context packet is the only inter-phase payload; the raw artifact directory stays on disk but is not forwarded into worker contexts.',
-    sourceUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/analysis-funnel/SKILL.md',
+    text: 'The context packet between phases must be a compressed summary (1–2 K tokens), never a dump of raw phase artifacts. Passing raw artifacts forward bloats each wave\'s context and re-exposes details the prior wave already resolved. The context packet is a design artifact: it encodes what the next wave needs to know, not everything the prior wave produced. Funnel SKILL.md encodes this as a hard constraint — the context packet is the only inter-phase payload; the raw artifact directory stays on disk but is not forwarded into worker contexts.',
+    sourceUrl: 'https://www.anthropic.com/engineering/multi-agent-research-system',
   },
   relatedSlugs: ['orchestrator-workers', 'parallelization', 'checkpointing', 'context-engineering'],
   frameworks: [],
@@ -170,73 +170,49 @@ export {}
   ],
   addedAt: '2026-05-05',
   dateModified: '2026-05-05',
-  lastChangeNote: 'W2.7 — New Layer-5 funnel-method satellite; Tier A realizingInClaudeCode populated from the start; companion bridge essay.',
+  lastChangeNote: 'W3.0 — Generalize skill-name references to generic framing; update Cursor cloud-agent URL; fix readerGotcha sourceUrl.',
 
   realizingInClaudeCode: {
-    tier: 'A',
-
+    keyMoves: [
+      'Dispatch all Phase 1 investigators in one assistant message so Claude Code runs them concurrently; wall-clock is bounded by the slowest, not the sum.',
+      'Write each wave\'s outputs to deterministic disk paths before dispatching the next wave — the filesystem is the checkpoint store and the phase boundary.',
+      'Forward a 1–2 K token context packet between waves, not raw phase transcripts; workers read the packet plus their own brief, keeping worker contexts independent.',
+      'Update a `STATUS.md` row synchronously at each phase boundary so a fresh-context session can reconstruct which phase to resume from without replaying transcripts.',
+    ],
     ccPrimitives: [
-      'single-message multi-Task() dispatch — all five Phase 1 investigators, all five Phase 2 iterators, and all three Phase 3 synthesizers are dispatched in a single assistant message each wave; Claude Code executes all Task() calls in the message concurrently, so wall-clock is bounded by the slowest agent in the wave rather than their sum',
-      'Task tool (sub-agent context isolation) — each investigator, iterator, and synthesizer runs in its own context window with its own brief and tool surface; agents within a wave do not see each other\'s intermediate work, which is the structural property that makes each wave\'s output an independent perspective rather than a consensus echo',
-      'Phase-boundary disk checkpoint — each wave writes its outputs to deterministic paths (phase-{N}/{role}-{slug}.md) before the next wave dispatches; the filesystem is the checkpoint store; verify_phase.sh asserts all expected files exist before the next wave fires, so a missing artifact halts the funnel loudly rather than forwarding a silent gap',
-      'STATUS.md synchronous update — update_status.py is called inline at each phase boundary to mark the phase complete with a timestamp and artifact count; a fresh-context session reading STATUS.md can reconstruct exactly which phase to resume from without replaying any prior transcript',
-      'Context-packet forwarding — between waves the orchestrator assembles a 1–2 K token summary from the phase artifacts and passes it as the dispatch payload for the next wave; workers read the packet plus their own brief, never the raw prior-phase artifacts; this keeps worker contexts clean and prevents the orchestrator context from growing unbounded across phases',
+      'Task tool (parallel wave dispatch)',
+      'Single-message multi-Task() dispatch',
+      'Disk phase checkpoints',
+      'STATUS.md phase tracking',
     ],
-
-    scaffolding: [
-      '.claude/skills/analysis-funnel/SKILL.md — the orchestrator prompt encoding the 5+5+3+1 phase structure, the single-message dispatch constraint ("dispatching Phase 1 investigators one at a time is treated as a defect, not a style preference"), the disk-checkpoint rule, the STATUS.md synchronization contract, and the context-packet forwarding convention; the SKILL.md is the boundary-enforcement specification and the artifact-naming convention source',
-      '.claude/skills/decision-funnel/SKILL.md — the same 5+5+3+1 structure applied to option evaluation: Phase 1 investigators explore option viability, Phase 2 iterators stress-test and develop the top options, Phase 3 synthesizers evaluate through cost/risk/timing lenses, Phase 4 unifier produces a decision recommendation; demonstrates that the cardinality is stable across triggering domains',
-      '.claude/skills/creative-funnel/SKILL.md — the same structure applied to parallel creative production: Phase 1 produces N independent creative variants, Phase 2 iterates and develops the strongest, Phase 3 synthesizes across style/structure/voice lenses; the third domain that validates the cross-domain stability of the 5+5+3+1 shape',
-      'phase-{N}/{role}-{slug}.md artifact convention — each worker writes its output to a deterministic file path; the path is the identity of the artifact and the checkpoint; the orchestrator never holds phase outputs in-context after the phase completes; the docs/agentic-bridge/funnel/ directory is the canonical in-repo instance of this artifact tree, with phase-1/ through phase-4/ directories and a STATUS.md tracking 5+5+3+1 completion',
-      'context-packets/phase-{N}-packet.md — the compressed inter-phase payload; the only artifact that crosses the phase boundary into worker contexts; full phase artifact directories are available on disk but not forwarded; the packet format (1–2 K tokens, prose summary, 3–5 key findings, open questions for next phase) is encoded in the SKILL.md',
-    ],
-
-    workedExample: {
-      url: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/analysis-funnel/SKILL.md',
-      description: `The analysis-funnel SKILL.md is the primary realization of the Funnel Method in this repository. The docs/agentic-bridge/funnel/ directory is the artifact tree produced by a complete analysis-funnel run: phase-1/ through phase-4/ directories, STATUS.md tracking completion across all five phases (Phase 4 COMPLETE as of 2026-05-05T02:48:00Z), and context-packets/ holding the inter-phase summaries. The run analyzed the agentic bridge documentation strategy across five investigation areas (structure, voice, prior art, audience, scope), five iteration angles, three synthesis lenses (strategic, editorial, implementation), and produced a 481-line ~6,950-word final report at phase-4/analysis-report.md.
-
-The single-message multi-Task() dispatch is the structural primitive that made Phase 1's five-investigator run a parallel fan-out rather than a sequential chain. All five Task() calls appeared in one assistant message. Claude Code executed all five tool_use blocks concurrently. Each investigator wrote its findings to phase-1/{role}-{slug}.md before the orchestrator read them back. The elapsed time was bounded by the slowest investigator, not the sum of all five.
-
-The docs/read-along-feature/ directory is a second in-repo artifact tree from an earlier analysis-funnel run (read-along feature scope and implementation analysis), demonstrating that the same artifact convention applies across different triggering domains. Both trees follow the same phase-{N}/{role}-{slug}.md naming, the same STATUS.md structure, and the same context-packet forwarding between phases.
-
-This worked example also shows where the context-packet design matters in practice. The context-packets/phase-{N}-packet.md files in docs/agentic-bridge/funnel/ are each 300–500 words — deliberately compressed from the 3,000–5,000-word phase artifact trees they summarize. The compression is not a convenience; it is what keeps Phase 2 worker contexts clean enough to produce independent iterations rather than restatements of Phase 1 content. Workers that receive raw Phase 1 transcripts tend to elaborate rather than iterate; workers that receive a context packet tend to challenge and extend.`,
-    },
-
-    bodyMarkdown: `
-The Funnel Method in Claude Code reduces to a single structural discipline applied at every phase boundary: write the phase outputs to disk before dispatching the next wave. Everything else — the 5+5+3+1 cardinality, the context-packet compression, the STATUS.md synchronization — is scaffolding that makes that boundary discipline reliable across multiple phases and across sessions that may not be continuous.
-
-**Why the boundary is the primitive**
-
-A multi-phase agent loop without a hard phase boundary is a context-accumulation loop. The orchestrator's context grows with each wave's output; workers in later phases inherit a prompt that is weighted toward whatever the earlier phases produced. The investigation funnel becomes a confirmation funnel: Phase 2 iterators who read Phase 1 investigators' transcripts in-context tend to extend rather than challenge, because the transcripts are the most recent and most weighted tokens in their context. The phase boundary breaks this structural bias. Investigators write to disk; their transcripts leave the orchestrator's context; the context packet is the compressed summary of what mattered, not what was said.
-
-**The disk-artifact protocol**
-
-Three artifacts cross the phase boundary. The phase-{N}/{role}-{slug}.md files are each worker's output, written to disk synchronously before the orchestrator reads them. The STATUS.md row is updated inline at each boundary — one row per phase, with timestamp and artifact count — and is the only record a fresh-context session needs to reconstruct where a stopped funnel left off. The context-packets/phase-{N}-packet.md is assembled from the phase artifacts by the orchestrator and forwarded as the dispatch payload for the next wave's workers. Workers read the packet plus their own brief. They do not see the raw artifact directory. The compression is the design.
-
-**Cross-domain stability**
-
-The analysis-funnel, decision-funnel, and creative-funnel skills all encode 5+5+3+1 applied to different triggering domains. The shared cardinality is a pragmatic finding: five independent investigators cover a problem space without significant overlap; five iterators can each take a distinct angle on the findings without redundancy; three synthesizers can apply three genuinely different analytical lenses; one unifier can hold the synthesis outputs in context and produce a coherent final deliverable. The specific numbers come from running the structure across a range of inputs and finding that fewer investigators tend to miss important facets while more investigators tend to produce significant overlap. The cardinality is a configuration, not a theorem.
-
-**Prior art**
-
-The four-phase funnel shape is consistent with the British Design Council's Double Diamond (Discover, Define, Develop, Deliver) and draws on the NGT (Nominal Group Technique) parallel-then-converge mechanic for the investigator and iterator waves. Anthropic's multi-agent research blog describes the lead-spawns-3-5-subagents primitive at production scale. LangGraph and Temporal own the durable-state-machine and journal-based-recovery framing that the disk-artifact protocol approximates at a simpler storage layer. Microsoft and Google both document parallel and checkpoint patterns for multi-agent systems in their architecture guides. The 5+5+3+1 Funnel Method is one specific composition of those antecedents — what this repository converged on after running the structure across analysis, decision, and creative triggering domains.
-`.trim(),
-
-    readerMove: {
-      text: 'Load analysis-funnel SKILL.md, dispatch all five Phase 1 investigators in one message, write artifacts to disk before Phase 2.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/analysis-funnel/SKILL.md',
-    },
-
     seeAlso: {
-      skillPath: '.claude/skills/analysis-funnel/SKILL.md',
-      articleSlug: 'phase-boundary-loop',
       siblingPatternSlugs: [
         'orchestrator-workers',
         'parallelization',
         'checkpointing',
         'context-engineering',
-        '12-factor-agent',
-        'identity-separated-review',
+      ],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Use [cloud agents](https://cursor.com/docs/cloud-agent) to run parallel investigation branches — each agent works in its own cloud session without seeing the others\' work.',
+      'Write phase outputs to a shared branch; reference them via `@branch` in the synthesis session so the synthesizer reads committed artifacts, not in-memory chat.',
+      'Compress each phase\'s findings into a handoff file before the next phase; pass it via `@file` to keep synthesizer contexts clean and independent.',
+      'Use [Plan mode](https://cursor.com/docs/agent/plan-mode) to draft the 5+5+3+1 phase structure before execution; review the plan and adjust cardinality before any agents fire.',
+    ],
+    ccPrimitives: [
+      'Cloud agents (parallel phase waves)',
+      '@branch (phase artifact access)',
+      '@file (context packet forwarding)',
+      'Plan mode (phase structure review)',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: [
+        'orchestrator-workers',
+        'parallelization',
+        'checkpointing',
+        'context-engineering',
       ],
     },
   },

--- a/src/data/agentic-design-patterns/patterns/guardrails.ts
+++ b/src/data/agentic-design-patterns/patterns/guardrails.ts
@@ -146,62 +146,38 @@ export {}
   ],
   addedAt: '2026-05-03',
   dateModified: '2026-05-05',
-  lastChangeNote: 'W2.4 — Populate realizingInClaudeCode Tier A: three-layer realization (hooks + skill-tables + branch-protection), PR #335 worked example.',
+  lastChangeNote: 'W2.4 — Populate realizingInClaudeCode Tier A: three-layer realization (hooks + CLAUDE.md + branch-protection).',
   realizingInClaudeCode: {
-    tier: 'A',
+    keyMoves: [
+      'Write [PreToolUse hooks](https://docs.claude.com/en/docs/claude-code/hooks) as shell scripts in `.claude/hooks/`; track them in git and reference them in [`settings.json`](https://docs.claude.com/en/docs/claude-code/settings).',
+      'Exit non-zero from a hook to block the tool call — the hook intercepts the model\'s Bash calls before they execute.',
+      'Declare soft constraints in [`CLAUDE.md`](https://docs.claude.com/en/docs/claude-code/memory) — convention-layer rules that shape behavior without blocking tool calls.',
+      'Gate the merge queue on CI checks (lint, typecheck, tests) so the model cannot land code that bypasses those checks via the commit path.',
+    ],
     ccPrimitives: [
-      'PreToolUse hooks (Layer 1) — shell scripts wired into Claude Code\'s settings.json that intercept Bash tool calls before they execute; .claude/hooks/block-debug-artifacts.sh and .claude/hooks/block-console-log.sh are the canonical Layer-1 instances in this repo: they fire on every git commit attempt and exit non-zero to abort the commit if a disallowed artifact or console.log is staged',
-      'settings.json hook schema — the JSON object under "PreToolUse" that declares the matcher ("Bash") and the hook command array; this is the CC-native wiring point that connects a shell script to a tool event; the hook fires inside the Claude Code process, not as a git pre-commit hook, so it intercepts the model\'s own commit attempts rather than a human\'s',
-      'CLAUDE.md / SKILL.md skill-table rules (Layer 2) — structured constraints the model reads as policy before it acts; the "Skill Ownership" section in CLAUDE.md and the frontmatter tables in .claude/skills/*.md are the convention layer: they tell the model what patterns to follow and what scaffolding to reach for, but they do not block any tool call at the process level',
+      'PreToolUse hooks (process-level enforcement)',
+      'settings.json hook schema',
+      'CLAUDE.md (convention layer)',
+      'CI merge-queue gate (infrastructure layer)',
     ],
-    scaffolding: [
-      '.claude/hooks/block-debug-artifacts.sh — PreToolUse script that exits 2 when git commit would stage debug-*.spec.ts or *.bak files; tracked in git so it exists on every fresh clone',
-      '.claude/hooks/block-console-log.sh — PreToolUse script that exits 2 when a staged file outside the allowlist (tests/, e2e/, scripts/, *.test.*, *.spec.*) contains console.log; tracked in git, executable bit set',
-      '.mergify.yml required-checks list (Layer 3) — the queue_conditions block gates the merge queue on ESLint, TypeScript, Vitest, Next.js Build, Analyze Bundle, CodeQL Analysis, and four E2E shards; a PR cannot merge until all checks pass regardless of approvals; this is the infrastructure enforcement layer that the model cannot bypass',
-      'CLAUDE.md Skill Ownership section — documents which skills are global-canonical vs. repo-canonical and constrains how the model reasons about drift; a convention-layer guardrail that shapes model behavior without blocking tool calls',
-      '.claude/skills/*/SKILL.md frontmatter — skill tables that name permitted tools, phase cardinalities, and dispatch constraints; loaded into the orchestrator context before Task() dispatch and act as the read-time policy layer between the model and the hook layer',
-    ],
-    workedExample: {
-      url: 'https://github.com/julianken/detached-node/pull/335',
-      description: `PR #335 — "infra(hooks): restore PreToolUse enforcement + remove worktree-agent dead code" — is the canonical Layer-1 realization of the Guardrails pattern in this repository. It demonstrates the complete lifecycle of an operational hook layer: .claude/hooks/block-debug-artifacts.sh and .claude/hooks/block-console-log.sh are tracked in git, carry the executable bit, and are referenced by settings.json so they fire on every git commit attempt the model makes. The PR also removed the dead block-worktree-push.sh reference and the CLAUDE.md documentation that pointed to a non-existent clean-worktree-branches.sh script, keeping the convention layer in sync with the actual tool surface.
-
-The structural mechanics visible in PR #335 map directly to the three-layer framing this satellite describes. Layer 1 is operational: the two scripts exist on every clone, both hooks fire on every git commit attempt the model makes, and a non-zero exit aborts the commit before the staged artifact ships. Layer 2 was adjusted simultaneously — the stale CLAUDE.md section was removed so the model's read-time policy matched the actual tool surface. Layer 3 (the .mergify.yml required-checks queue) was already in place and remained unchanged; the PR had to pass all CI gates before Mergify advanced it.
-
-The test plan in PR #335 includes smoke tests that confirm the hooks fire as specified: staging debug-foo.spec.ts exits 2; staging a clean src/foo.ts exits 0; staging an allowlisted tests/_smoketest.ts with console.log exits 0. These are the observable signals of an operational guardrail: the script is present, executable, reachable from settings.json, and verified by a smoke test. The PR is evidence for the Layer-1 guardrail pattern because it demonstrates the full lifecycle: authoring the script, tracking it in git, confirming it fires, and gating the merge on CI. All three layers are in view in a single PR — the hooks became operational (Layer 1), the CLAUDE.md policy section was updated to reflect the actual tool surface (Layer 2), and the merge queue required all CI gates to pass before Mergify advanced the PR (Layer 3).`,
-    },
-    readerMove: {
-      text: 'Write your .claude/hooks/ scripts; track them in git; gate the merge queue on the lint check.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/hooks/block-debug-artifacts.sh',
-    },
     seeAlso: {
-      siblingPatternSlugs: ['evaluation-llm-as-judge', 'human-in-the-loop'],
+      siblingPatternSlugs: ['evaluation-llm-as-judge', 'human-in-the-loop', 'tool-use-react'],
     },
-    bodyMarkdown: `Guardrails in Claude Code realize as three distinct layers, each operating at a different scope: instant (process-level hooks), session (read-time model policy), and repo-wide (merge-queue infrastructure). The practitioner's job is to instrument all three, because each layer governs a different surface.
-
-### Layer 1: PreToolUse hooks
-
-PreToolUse hooks are shell scripts declared in .claude/settings.json under the "PreToolUse" key with a tool matcher. When the matcher fires — "Bash" matches any Bash tool call — Claude Code runs the hook command before the tool executes. A non-zero exit aborts the tool call. The hook fires inside the Claude Code process, not as a git pre-commit hook, which means it intercepts the model's own commit attempts before they reach git.
-
-This repo's two hook scripts enforce artifact hygiene at the commit boundary. .claude/hooks/block-debug-artifacts.sh exits 2 when git commit would stage debug-*.spec.ts or *.bak files. .claude/hooks/block-console-log.sh exits 2 when a staged file outside the allowlist (tests/, e2e/, scripts/, *.test.*, *.spec.*) contains console.log. Both scripts are tracked in git and carry the executable bit; PR #335 is the canonical demonstration of this lifecycle: the scripts are present on every fresh clone, referenced in settings.json, smoke-tested, and gated through the Mergify required-checks list.
-
-The Layer-1 guarantee is process-level: the hook runs in the Claude Code process and the model cannot skip it by rephrasing the Bash command. It is also scope-limited: hooks fire only on the tool events their matcher matches. A PreToolUse hook on Bash does not intercept Write tool calls, Edit tool calls, or actions outside Claude Code. Layer 1 guards the model's own actions within the session; it does not govern what ships through the merge queue.
-
-### Layer 2: skill-table rules
-
-Skill-table rules are structured constraints the model reads as policy before it acts. The "Skill Ownership" section in this repo's CLAUDE.md declares which skills are global-canonical versus repo-canonical and constrains how the model reasons about drift. The SKILL.md files in .claude/skills/ carry phase cardinalities, dispatch constraints, and tool surface declarations that shape model behavior at read time.
-
-Layer 2 is the convention layer. It operates by telling the model what to do, not by blocking it from doing otherwise. A well-authored CLAUDE.md constraint is fast (no process overhead), broad (applies to any tool call the model reads about), and brittle (the model can reason past it under pressure or when the context window is full). Layer 2 is not a substitute for Layer 1; it is the layer that shapes model behavior on the large class of actions that do not touch a hook-matched tool event.
-
-The Layer-2 guarantee is probabilistic: the model is more likely to follow a clearly stated rule than to violate it, and the rule is auditable as plaintext. It is not a hard stop.
-
-### Layer 3: branch-protection infrastructure
-
-The .mergify.yml queue_conditions block is the infrastructure enforcement layer. It gates the merge queue on ESLint, TypeScript, Vitest, Next.js Build, Analyze Bundle, CodeQL Analysis, and four E2E shards. A PR cannot advance in the queue until all checks pass and at least one approval is recorded. This runs in GitHub's infrastructure, not in Claude Code, and the model cannot bypass it by any in-session action.
-
-Layer 3 is the highest-trust layer because it is fully outside the model's control surface. Its scope is also the narrowest: it governs what merges into main, not what the model does within a session. A session that produces malformed output, leaks secrets into a file that is never committed, or calls a disallowed tool does not touch Layer 3 at all. Layer 3 is the last line of defense, not the only one.
-
-### The three layers as a system
-
-The layers are complementary because each covers a different scope. Layer 1 (process-level hooks) governs the model's own tool calls within the active session — instant enforcement, hard stop on non-zero exit. Layer 2 (read-time model policy) shapes the model's reasoning across the full action space before any tool call fires — broad coverage, probabilistic enforcement. Layer 3 (merge-queue infrastructure) governs what reaches main — the narrowest scope, the highest trust, fully outside the model's control surface. Instrumenting all three — confirming hooks fire on smoke tests, auditing CLAUDE.md for drift, reviewing .mergify.yml conditions on each major scope addition — is what keeps the system operational rather than merely configured.`,
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Add policy rules to `.cursor/rules/*.mdc` with `alwaysApply: true` so the agent reads constraints before every action.',
+      'Review every file change via Agent mode\'s diff UI before accepting — the diff step is a soft guardrail built into the workflow.',
+      'Add a `.cursor/rules/*.mdc` with explicit `do not` instructions for high-risk operations (deletion, config changes, credential handling).',
+      'Gate merges via a branch protection rule or merge queue — CI checks run outside Cursor and the model cannot bypass them.',
+    ],
+    ccPrimitives: [
+      '.cursor/rules/*.mdc (policy rules)',
+      'Agent mode diff review',
+      'Branch protection (infrastructure layer)',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['evaluation-llm-as-judge', 'human-in-the-loop', 'tool-use-react'],
+    },
   },
 }

--- a/src/data/agentic-design-patterns/patterns/handoffs-swarm.ts
+++ b/src/data/agentic-design-patterns/patterns/handoffs-swarm.ts
@@ -148,24 +148,40 @@ export async function runSwarm(messages: { role: 'user' | 'assistant'; content: 
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-05',
-  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — subagent-workflow handoff chain as Handoffs/Swarm realization.',
-
+  dateModified: '2026-05-04',
+  lastChangeNote: 'Author Handoffs / Swarm satellite: sequential conversation ownership, transfer-as-tool-call, supervisor variant.',
   realizingInClaudeCode: {
-    tier: 'C',
-
-    bodyMarkdown: `
-The [subagent-workflow skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/subagent-workflow/SKILL.md) wires a three-agent handoff chain for every GitHub Issue. Step 3 dispatches an implementer who owns the worktree and produces the PR. Step 4 hands off to a spec-compliance reviewer who reads the acceptance criteria and checks the diff. Step 5 hands off to a quality reviewer who checks conventions, security, and test coverage. Each handoff is explicit — the next agent receives the PR number and the preceding review's verdict as structured context. The chain is sequential within each issue and parallel across issues (all implementers run in one dispatch message). Principle 6 enforces handoff integrity: "Fixes stay in the same worktree/PR — never create a new PR for review fixes." [PR #344](https://github.com/julianken/detached-node/pull/344) and [PR #350](https://github.com/julianken/detached-node/pull/350) are instances of this chain completing in production.
-`.trim(),
-
-    readerMove: {
-      text: 'Model the implementer → spec-reviewer → quality-reviewer chain as three sequential dispatches per issue; never split fixes to a new PR.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/subagent-workflow/SKILL.md',
-    },
-
+    keyMoves: [
+      'Define each specialist as a separate [SKILL.md](https://docs.claude.com/en/docs/claude-code/skills) with its own tool surface and trigger condition.',
+      'Encode the handoff decision as a structured output step; the triage [subagent](https://docs.claude.com/en/docs/claude-code/sub-agents) emits the target skill name as a JSON field.',
+      'Pass a compact written context packet (not the full transcript) to the specialist at handoff — prevents the new agent re-interpreting prior framing.',
+      'Cap handoff depth in the orchestrator\'s instructions — declare a maximum count and treat exceeding it as a task-completion error.',
+    ],
+    ccPrimitives: [
+      'SKILL.md per specialist',
+      'Task tool (specialist subagents)',
+      'permissions.deny (scope guard)',
+      'Structured handoff output',
+    ],
     seeAlso: {
-      skillPath: '.claude/skills/subagent-workflow/SKILL.md',
-      siblingPatternSlugs: ['routing', 'orchestrator-workers', 'human-in-the-loop'],
+      siblingPatternSlugs: ['routing', 'orchestrator-workers', 'planning'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Create one `.cursor/rules/*.mdc` per specialist with `alwaysApply: false` and activate via `@rule-name` when handing off.',
+      'Use Agent mode as the triage layer — it decides when to switch context; activate the specialist rule after the classification.',
+      'Pass a summary of the conversation to the specialist at handoff via `@file` rather than relying on the raw chat history.',
+      'Use [Plan mode](https://cursor.com/docs/agent/plan-mode) to draft the handoff sequence upfront for complex multi-specialist tasks.',
+    ],
+    ccPrimitives: [
+      '.cursor/rules/*.mdc (per-specialist rules)',
+      '@rule-name activation',
+      '@file (handoff context packet)',
+      'Agent mode',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['routing', 'orchestrator-workers', 'planning'],
     },
   },
 }

--- a/src/data/agentic-design-patterns/patterns/human-in-the-loop.ts
+++ b/src/data/agentic-design-patterns/patterns/human-in-the-loop.ts
@@ -155,25 +155,40 @@ export {}
   ],
   addedAt: '2026-05-04',
   dateModified: '2026-05-05',
-  lastChangeNote: 'W3.3 additive over W2.9: second HITL realization — subagent-workflow within-task review gates.',
+  lastChangeNote: 'W2.9 additive: Tier C realizingInClaudeCode — Mergify merge-queue as deployment-layer HITL gate.',
 
   realizingInClaudeCode: {
-    tier: 'C',
-
-    bodyMarkdown: `
-The merge queue is the deployment-layer realization of Human in the Loop at the merge boundary. In this repo, Mergify enforces the gate structurally: the [\`.mergify.yml\`](https://github.com/julianken/detached-node/blob/main/.mergify.yml) declares a \`queue_conditions\` block requiring \`#approved-reviews-by >= 1\` and all CI checks passing before a squash-merge proceeds. The human signal — an explicit collaborator approval — is the precondition the queue checks before the run continues. No approval, no merge; the pending PR sits in the queue until the signal arrives, exactly the pause-and-resume contract the pattern names. The convention in this repo is to wait for the julianken-bot APPROVE before commenting \`@mergifyio queue\`, making the reviewer's verdict the trigger that opens the merge boundary. (Mergify is paid SaaS; GitHub-native merge queue is the OSS substitute.)
-
-**Within-task review gates (W3.3 addition).** The [subagent-workflow skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/subagent-workflow/SKILL.md) adds two earlier HITL gates inside the per-issue loop. After the implementer completes the PR, a spec-compliance reviewer explicitly reads acceptance criteria and reports SPEC COMPLIANT or SPEC GAPS FOUND — the operator reads this verdict before quality review proceeds. After quality review passes, the operator comments \`@mergifyio queue\` to trigger the merge boundary gate. The pattern runs twice per issue: once as an agent-to-agent handoff signal, and once as the human-signal merge gate. Both are pause-and-resume; neither is optional. [PR #349](https://github.com/julianken/detached-node/pull/349) documents a completed cycle of both gates in a single merge.
-`.trim(),
-
-    readerMove: {
-      text: 'Add `#approved-reviews-by >= 1` to `.mergify.yml` queue_conditions; comment `@mergifyio queue` after the bot approves.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.mergify.yml',
-    },
-
+    keyMoves: [
+      'Use a [PreToolUse hook](https://docs.claude.com/en/docs/claude-code/hooks) to pause execution before side-effecting tool calls — exit non-zero blocks the call until a human allows it.',
+      'List sensitive tool patterns in [`settings.json`](https://docs.claude.com/en/docs/claude-code/settings) `permissions.deny`; Claude prompts for approval before each match.',
+      'Use the GitHub merge queue as the deployment-layer HITL gate — require at least one human approval before any PR advances to merge.',
+      'Expose the agent\'s rationale alongside the approval request — reviewers who cannot see the reasoning default to rubber-stamping.',
+    ],
+    ccPrimitives: [
+      'PreToolUse hooks (pause gate)',
+      'settings.json permissions.deny',
+      'Claude Code approval prompts',
+      'Merge queue (deployment HITL)',
+    ],
     seeAlso: {
-      skillPath: '.claude/skills/subagent-workflow/SKILL.md',
-      siblingPatternSlugs: ['evaluation-llm-as-judge', 'guardrails', 'checkpointing'],
+      siblingPatternSlugs: ['guardrails', 'checkpointing', 'evaluation-llm-as-judge'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Use Agent mode with Cursor\'s diff-review UI — every file edit surfaces as a reviewable diff; accept or reject each change individually before it lands.',
+      'For destructive operations (file deletions, config changes), add a `.cursor/rules/*.mdc` instruction to ask for confirmation before proceeding.',
+      'Use [cloud agents](https://cursor.com/docs/cloud-agent) for long tasks — they push to a branch and open a PR for human review before any merge occurs.',
+      'Use [Plan mode](https://cursor.com/docs/agent/plan-mode) as the lightweight HITL step for complex tasks — review and edit the plan before execution begins.',
+    ],
+    ccPrimitives: [
+      'Diff-by-diff review UI',
+      'Cloud agents (PR-based HITL)',
+      'Plan mode (pre-execution approval)',
+      '.cursor/rules/*.mdc (confirmation rules)',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['guardrails', 'checkpointing', 'evaluation-llm-as-judge'],
     },
   },
 }

--- a/src/data/agentic-design-patterns/patterns/identity-separated-review.ts
+++ b/src/data/agentic-design-patterns/patterns/identity-separated-review.ts
@@ -8,21 +8,21 @@ export const pattern: Pattern = {
   oneLineSummary: 'Route every PR through a separate machine-user identity running a different model tier.',
   bodySummary: [
     'Identity-Separated Review routes every code-review step through a dedicated machine-user identity that is structurally isolated from the implementer: separate GitHub account, separate macOS Keychain credential scoped to a single subprocess, and a different model tier loaded in a fresh context window. The separation is not organizational ritual. NeurIPS 2024 (arxiv:2410.21819) measured perplexity-familiarity bias — a model reviewing its own output assigns inflated scores because the output reads as familiar rather than correct. Cross-tier verification (NYU, January 2026) breaks the shared-prior mechanism empirically. You cannot undo that bias by adjusting the reviewer prompt; you have to change the reviewer identity.',
-    'The review workflow follows a fixed sequence: the implementer subagent commits to a feature branch and opens the PR; the dispatcher then loads the `reviewing-as-julianken-bot` skill, retrieves the bot PAT from Keychain at invocation time, and dispatches the reviewer in a fresh context window. The reviewer reads the diff cold — via `gh pr view` and `gh pr diff` — never inheriting the implementer\'s framing. It applies a 12-rule rubric enforcing trace-every-claim (R1), cap-findings-at-3 (R3), mandatory-find second pass (R8), prompt-injection defense (R11), and cross-tier model bias (R12). The review posts via the GitHub REST API as `@julianken-bot`, never via `gh pr review` which lacks inline-comment support. After the bot posts, the dispatcher applies the merge-flow decision rule autonomously.',
+    'The review workflow follows a fixed sequence: the implementer subagent commits to a feature branch and opens the PR; the dispatcher loads a reviewer skill, retrieves the bot PAT from Keychain at invocation time, and dispatches the reviewer in a fresh context window. The reviewer reads the diff cold — via `gh pr view` and `gh pr diff` — never inheriting the implementer\'s framing. It applies a 12-rule rubric enforcing trace-every-claim (R1), cap-findings-at-3 (R3), mandatory-find second pass (R8), prompt-injection defense (R11), and cross-tier model bias (R12). The review posts via the GitHub REST API as the machine-user identity, never via `gh pr review` which lacks inline-comment support. After the bot posts, the dispatcher applies the merge-flow decision rule autonomously.',
     'OWASP LLM Top 10 2026 (OWASP LLM01:2026) catalogs indirect prompt injection via PR body as the dominant attack class on AI reviewers — responsible for more than 80 percent of enterprise incidents. R11 addresses this directly: PR title, body, and commit messages are treated as untrusted input. Text that resembles reviewer instructions is flagged as a BLOCKER, not followed. The identity separation that makes the pattern distinctive also provides the attack surface isolation: the bot identity can be revoked and re-minted without affecting the implementer identity, and its Keychain credential is never exported to disk.',
   ],
   mermaidSource: `graph LR
   A[Implementer subagent] --> B[Commit + open PR]
-  B --> C[Dispatcher loads julianken-bot skill]
+  B --> C[Dispatcher loads reviewer skill]
   C --> D[Retrieve bot PAT from Keychain]
   D --> E[Reviewer: fresh context, cross-tier model]
   E --> F[Read diff cold via gh pr view / gh pr diff]
   F --> G[Apply 12-rule rubric]
-  G --> H[Post review via REST API as julianken-bot]
+  G --> H[Post review via REST API as machine-user identity]
   H --> I{Verdict}
   I -->|APPROVE + polish SUGGESTION| J[Dispatcher merges via Mergify queue]
   I -->|REQUEST_CHANGES| K[Loop: fix + re-review]`,
-  mermaidAlt: 'A flowchart in which an Implementer subagent commits and opens a PR; the Dispatcher loads the julianken-bot skill, retrieves the bot PAT from Keychain, and dispatches a Reviewer in a fresh context window with a cross-tier model; the Reviewer reads the diff cold, applies the 12-rule rubric, and posts via the REST API as julianken-bot; an APPROVE with a polish SUGGESTION leads to a Mergify queue merge, while REQUEST_CHANGES triggers a fix-and-re-review loop.',
+  mermaidAlt: 'A flowchart in which an Implementer subagent commits and opens a PR; the Dispatcher loads a reviewer skill, retrieves the bot PAT from Keychain, and dispatches a Reviewer in a fresh context window with a cross-tier model; the Reviewer reads the diff cold, applies the 12-rule rubric, and posts via the REST API as the machine-user identity; an APPROVE with a polish SUGGESTION leads to a Mergify queue merge, while REQUEST_CHANGES triggers a fix-and-re-review loop.',
   whenToUse: [
     'Apply when the implementer and reviewer share a model family — same-model self-verification is measurably worse than cross-tier verification, and the bias cannot be corrected by rubric adjustments alone.',
     'Use where PR review is a gate before merge and the consequences of a missed defect (broken public contract, security issue, silent regression) justify the cost of a separate reviewing identity.',
@@ -40,7 +40,7 @@ export const pattern: Pattern = {
       sourceUrl: 'https://www.infoq.com/news/2026/04/claude-code-review/',
     },
     {
-      text: 'PR-Agent (Codium) encodes the same operational lesson independently: a default of num_max_findings = 3 and a "no filler praise" style rule to combat the 9:1 false-positive ratio of undisciplined AI reviewers — the same invariants encoded in R3 and R4 of the julianken-bot rubric.',
+      text: 'PR-Agent (Codium) encodes the same operational lesson independently: a default of num_max_findings = 3 and a "no filler praise" style rule to combat the 9:1 false-positive ratio of undisciplined AI reviewers — the same invariants encoded in R3 and R4 of a disciplined review rubric.',
       sourceUrl: 'https://github.com/Codium-ai/pr-agent',
     },
     {
@@ -48,11 +48,11 @@ export const pattern: Pattern = {
       sourceUrl: 'https://arxiv.org/abs/2601.19072',
     },
   ],
-  implementationSketch: `// Pseudocode — the actual implementation uses the reviewing-as-julianken-bot
-// SKILL.md, ~/.claude/skills/reviewing-as-julianken-bot/scripts/bot-review.sh (global skill bundle, not in-repo), and macOS Keychain credential scoping.
+  implementationSketch: `// Pseudocode — the actual implementation uses a reviewer SKILL.md
+// and macOS Keychain credential scoping.
 
 // 1. Dispatcher retrieves bot PAT (never exported, scoped to one subprocess)
-// const token = execSync('security find-generic-password -s julianken-bot@github.com -a token -w').toString().trim()
+// const token = execSync('security find-generic-password -s reviewer-bot@github.com -a token -w').toString().trim()
 
 // 2. Reviewer reads diff cold (never trusts dispatcher's narrative)
 // const diff = execSync(\`GH_TOKEN=\${token} gh pr diff \${prNumber}\`).toString()
@@ -149,58 +149,38 @@ export {}
   ],
   addedAt: '2026-05-05',
   dateModified: '2026-05-05',
-  lastChangeNote: 'W2.6 — New Layer-5 identity-separated-review satellite; Tier A realizingInClaudeCode populated from the start.',
+  lastChangeNote: 'W3.0 — Generalize machine-user and reviewer-skill framing; remove internal implementation identifiers.',
 
   realizingInClaudeCode: {
-    tier: 'A',
-
+    keyMoves: [
+      'Dispatch the reviewer as a separate [subagent](https://docs.claude.com/en/docs/claude-code/sub-agents) in a fresh context window so it reads the diff cold, without the implementer\'s framing.',
+      'Load a [SKILL.md](https://docs.claude.com/en/docs/claude-code/skills) rubric into the reviewer subagent at invocation — cap findings, require a second pass, treat PR body as untrusted input.',
+      'Use a stronger model tier for the reviewer than the implementer; cross-tier review breaks the shared-prior bias documented in NeurIPS 2024.',
+      'Gate the merge queue on the reviewer\'s structured verdict via branch protection; a CI-enforced gate means the review cannot be bypassed.',
+    ],
     ccPrimitives: [
-      'julianken-bot subagent — a separate GitHub machine-user identity (`@julianken-bot`) that posts reviews via the GitHub REST API, never via `gh pr review`, from a fresh context window loaded with the reviewing-as-julianken-bot skill',
-      'reviewing-as-julianken-bot SKILL.md — the 12-rule rubric (R1 trace-every-claim, R3 cap-findings-at-3, R8 mandatory-find second pass, R11 prompt-injection defense, R12 cross-tier model bias) loaded by the bot subagent at invocation time',
-      'macOS Keychain PAT scoping — bot credential stored under service `julianken-bot@github.com`, account `token`; loaded via `security find-generic-password` at invocation time; scoped to a single `GH_TOKEN=$(...) gh` subprocess per call; never exported, never written to disk, never visible in `ps aux`',
-      'Mergify merge-queue gate — `.mergify.yml` declares the required-checks list; the convention is to wait for `@julianken-bot`\'s APPROVE before commenting `@mergifyio queue`; the gate is the final lock, not a human approval step',
+      'Task tool (reviewer subagent)',
+      'SKILL.md rubric (versioned criteria)',
+      'Branch protection (merge gate)',
     ],
-
-    scaffolding: [
-      '.claude/skills/subagent-workflow/SKILL.md — in-repo skill encoding the orchestrator/implementer/reviewer separation discipline; the reviewing-as-julianken-bot rubric (a user-level global skill at ~/.claude/skills/reviewing-as-julianken-bot/SKILL.md, not checked into this repo) extends this discipline with identity separation and the 12-rule review protocol',
-      '~/.claude/skills/reviewing-as-julianken-bot/scripts/bot-review.sh — bundled with the global reviewing-as-julianken-bot skill (not checked into this repo); encapsulates Keychain PAT retrieval, single-subprocess GH_TOKEN scoping, and REST API review posting; dispatcher invokes the wrapper with owner/repo, PR number, and a jq-assembled review JSON; the script is the only place the bot token is ever handled',
-      '.mergify.yml — declares required checks and a `#approved-reviews-by >= 1` queue condition; when the convention is to wait for `@julianken-bot`, the bot APPROVE is the signal that triggers the queue comment',
-    ],
-
-    workedExample: {
-      url: 'https://github.com/julianken/detached-node/pull/342',
-      description: 'PR #342 (W2.2 Checkpointing Tier A satellite) completed a first-cycle APPROVE. julianken-bot dispatched with model: opus and a fresh context window (implementer ran Sonnet — cross-tier held per R12), read the diff cold, ran the mandatory R8 second pass, confirmed all Tier A invariants via the verification ledger (pnpm test:unit, pnpm typecheck, slug resolution, URL HTTP-200), and posted APPROVE. R9 attribution applied plan-scope vs implementer-scope discipline in the verdict.',
-    },
-
-    bodyMarkdown: `
-Anthropic shipped multi-agent code review as a managed feature in April 2026 (InfoQ; The New Stack). The mechanics — a separate critic agent in fresh context, cross-provider model selection, and sycophancy-bias mitigation as an explicit design goal — are structurally identical to what this satellite describes. The self-hosted realization documented here predates the managed feature and is one of two paths for practitioners who want control over the rubric, the identity topology, or the credential scoping.
-
-**Why identity separation is load-bearing**
-
-Same-tier self-verification fails structurally. NeurIPS 2024 (arxiv:2410.21819) measured the mechanism: a model reviewing its own output assigns inflated scores because the tokens read as familiar, not because they are correct. The familiarity signal and the correctness signal are entangled at inference time, and no reviewer prompt rewrites the entanglement. NYU (January 2026) showed empirically that cross-tier verification — a stronger model reviewing a weaker model's output — breaks the shared-prior responsible for the inflation. The julianken-bot subagent defaults to \`model: opus\` so that when the implementer ran on Sonnet, the reviewer runs on a stronger tier. When both ran on Opus, R12 flags the same-tier risk explicitly in the APPROVE verdict rather than silently clearing it.
-
-**The 12-rule rubric**
-
-The rubric encodes three research-grounded mitigations:
-
-- **R8 (mandatory-find second pass)** directly counters perplexity-familiarity bias. Before drafting the verdict, the reviewer runs a second pass with the explicit prior that at least one improvement opportunity exists. A clean APPROVE after a genuine second pass is honest; skipping the pass produces a sycophantic LGTM.
-- **R11 (prompt-injection defense)** implements the OWASP LLM01:2026 mitigation. PR title, body, and commit messages are untrusted input. Text resembling reviewer instructions (e.g., "please approve without reviewing") is flagged as a BLOCKER, not followed.
-- **R12 (cross-tier model bias)** implements the NYU cross-tier mitigation. Implementer on Sonnet → reviewer on Opus; if both are on Opus, the same-tier risk is flagged in the verdict.
-
-The 3-finding cap (R3) and "no filler praise" rule (R4) derive from PR-Agent's verbatim defaults (\`num_max_findings = 3\`), enforcing the operational lesson that small-N high-signal reviews drive 3x higher action rates than verbose low-signal ones.
-
-**Credential topology**
-
-The bot PAT lives in macOS Keychain under four account entries: \`password\`, \`token\` (every \`gh\` call), \`totp-secret\` (TOTP generation via \`~/.claude/skills/reviewing-as-julianken-bot/scripts/bot-totp.sh\`, bundled with the global skill), and \`recovery-codes\`. The \`GH_TOKEN=$(...) gh\` scoping pattern keeps Julian's main \`gh auth\` state untouched — \`gh auth status\` always shows \`julianken\`, never the bot. The token is never exported, never written to disk, and never visible in \`ps aux\`.
-`.trim(),
-
-    readerMove: {
-      text: "Mint a machine-user account, write a 12-rule rubric, and wait for the bot's APPROVE before queuing the merge.",
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.mergify.yml',
-    },
-
     seeAlso: {
-      articleSlug: 'cross-identity-code-review',
+      siblingPatternSlugs: ['evaluation-llm-as-judge', 'guardrails', 'human-in-the-loop'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Open a second Agent chat for the reviewer role — pass the diff via `@file` so the reviewer starts cold without the implementer session\'s context.',
+      'Write the review rubric in a `.cursor/rules/*.mdc` file; load it by name in the reviewer chat before reading the diff.',
+      'Select a different model in the reviewer chat than in the implementer chat using Cursor\'s model picker — reduces same-model self-preference.',
+      'Commit review findings to a verdict file and reference it via `@file` in the implementer chat to close the feedback loop.',
+    ],
+    ccPrimitives: [
+      'Multiple Agent chats (implementer + reviewer)',
+      '.cursor/rules/*.mdc (rubric file)',
+      '@file (diff and verdict sharing)',
+      'Model picker (cross-tier selection)',
+    ],
+    seeAlso: {
       siblingPatternSlugs: ['evaluation-llm-as-judge', 'guardrails', 'human-in-the-loop'],
     },
   },

--- a/src/data/agentic-design-patterns/patterns/mcp.ts
+++ b/src/data/agentic-design-patterns/patterns/mcp.ts
@@ -153,25 +153,39 @@ export {}
   ],
   addedAt: '2026-05-03',
   dateModified: '2026-05-05',
-  lastChangeNote: 'W2.5: add realizingInClaudeCode Tier B (MCP in active Claude Code config; PR #287 cited as decommissioning-maintenance evidence).',
+  lastChangeNote: 'W2.5: add realizingInClaudeCode Tier B (MCP in active Claude Code config; stale-allowlist maintenance note added).',
   realizingInClaudeCode: {
-    tier: 'B',
-    bodyMarkdown: `
-In a working Claude Code setup, MCP shows up as the contents of the \`enabledPlugins\` and \`permissions.allow\` sections of \`~/.claude/settings.json\`. Five servers are active in this repo's config at authoring time: **context7** (documentation lookup), **github** (PR/issue operations), **playwright** (browser automation), **linear-server** (issue tracking), and **chrome-devtools-mcp** (runtime debugging). Each exposes its catalog over the same wire format; Claude Code calls \`list_tools\` on session start and the full catalog is available without any host-side adapter code.
-
-MCP configs require periodic maintenance as servers are added or decommissioned. [PR #287](https://github.com/julianken/detached-node/pull/287) is a routine instance of that discipline: it strips 13 stale \`mcp__vercel__*\` permission entries from \`.claude/settings.local.json\` after the Vercel MCP server was removed from the active set. The entries had accumulated silently — the protocol adds tools on connect, but nothing removes stale allow-list entries when a server is decommissioned. The pattern's value proposition (write the connector once, consume everywhere) carries a corresponding maintenance commitment: every server in the config is a standing permission surface that benefits from periodic review when the active server set changes.
-`.trim(),
-    workedExample: {
-      url: 'https://github.com/julianken/detached-node/pull/287',
-      description: 'PR #287 strips 13 stale mcp__vercel__* permission entries after the Vercel MCP server was removed — a routine maintenance pass demonstrating the standing-permission-surface review that MCP allow-lists benefit from when the active server set changes.',
-    },
-    readerMove: {
-      text: 'Add context7 + your equivalents to your CC config; reload session; new tool appears.',
-      anchorUrl: 'https://code.claude.com/docs/en/mcp',
-    },
+    keyMoves: [
+      'Add MCP servers to [`~/.claude/settings.json`](https://docs.claude.com/en/docs/claude-code/mcp) under `mcpServers`; Claude Code calls `list_tools` on session start and the catalog is immediately available.',
+      'Allowlist each server\'s tools in `permissions.allow` via [`settings.json`](https://docs.claude.com/en/docs/claude-code/settings) to avoid per-call prompts for trusted servers.',
+      'Review the allow-list periodically — stale entries from removed servers accumulate silently and expand the permission surface without active use.',
+      'Prefer project-level `~/.claude/settings.json` for project-specific servers; global `~/` config for servers used across all projects.',
+    ],
+    ccPrimitives: [
+      'settings.json mcpServers config',
+      'permissions.allow (tool allow-list)',
+      'MCP stdio transport (local)',
+      'MCP HTTP transport (remote)',
+    ],
     seeAlso: {
-      articleSlug: 'rethinking-systems-in-the-agentic-age',
-      siblingPatternSlugs: ['tool-use-react', 'guardrails'],
+      siblingPatternSlugs: ['tool-use-react', 'guardrails', 'context-engineering'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Add servers to `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global) in the `mcpServers` object with `command` and `args`.',
+      'Remote servers use a `url` field instead of `command`; Cursor handles OAuth automatically for marketplace-installed servers.',
+      'Enable auto-run for trusted servers in Cursor settings to avoid per-call approval prompts during Agent sessions.',
+      'Review `.cursor/mcp.json` when removing servers — Cursor does not automatically remove stale tool entries from the active session.',
+    ],
+    ccPrimitives: [
+      '.cursor/mcp.json (project MCP config)',
+      '~/.cursor/mcp.json (global MCP config)',
+      'Cursor Marketplace (one-click install)',
+      'Agent mode (MCP tool consumer)',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['tool-use-react', 'guardrails', 'context-engineering'],
     },
   },
 }

--- a/src/data/agentic-design-patterns/patterns/memory-management.ts
+++ b/src/data/agentic-design-patterns/patterns/memory-management.ts
@@ -157,7 +157,7 @@ export {}
       'Keep [`CLAUDE.md`](https://docs.claude.com/en/docs/claude-code/memory) small — it is working memory loaded on every session. Move trigger-bearing rules into [skills](https://docs.claude.com/en/docs/claude-code/skills) so they load only when needed.',
       'Use `.claude/skills/*/SKILL.md` as procedural memory — each skill loads only when its trigger fires, preserving the working-tier budget for task context.',
       'Write episodic state (progress, decisions, artifact lists) to disk files between sessions; read them back at session start via file references.',
-      'Audit always-on files with `wc -w × 1.8`; if the total exceeds 3 K tokens, migrate trigger-bearing rules to skills or `.claude/rules/*.md` path-scoped files.',
+      'Audit always-on files with `wc -w × 1.8`; if a rule has a trigger, it belongs in a skill, not here — migrate to skills.',
     ],
     ccPrimitives: [
       'CLAUDE.md (working memory)',

--- a/src/data/agentic-design-patterns/patterns/memory-management.ts
+++ b/src/data/agentic-design-patterns/patterns/memory-management.ts
@@ -153,20 +153,37 @@ export {}
   dateModified: '2026-05-05',
   lastChangeNote: 'W3.1 additive: seeAlso already includes 12-factor-agent; W1.4 forward-reference resolved by umbrella landing.',
   realizingInClaudeCode: {
-    tier: 'B',
-    bodyMarkdown: `
-In Claude Code, Memory Management resolves into three concrete layers: the **context window** (working memory — your \`CLAUDE.md\` files, recent turns, active tool outputs), **skills** (procedural memory — trigger-bearing rules externalised into \`.claude/skills/*/SKILL.md\` files loaded on demand), and **disk artifacts** (episodic memory — \`STATUS.md\`, phase packets, and context-packet files written between agent phases so the next session picks up where the last one left off).
-
-The practical constraint is the always-on token budget. Claude Code loads three files on every session start: the user-level \`~/.claude/CLAUDE.md\`, the repo \`CLAUDE.md\`, and (when present) \`AGENTS.md\`. Their combined token cost is fixed overhead, charged on every invocation regardless of task. When that overhead climbs above roughly 3 000 tokens, the working tier is already crowded before the first tool call. The audit move is the entry point: measure the combined token total with tiktoken \`cl100k_base\` or the proxy \`wc -w × 1.8\`, then lift any rule that carries a trigger condition ("when X", "before X", "each time X") into a skill. A rule that only fires in one context earns its keep in a skill file, not in always-on overhead.
-
-This pattern deliberately overlaps with Context Engineering — Memory Management names the audit; Context Engineering provides the budget rationale. The 12-factor-agent umbrella's closing rule captures the meta-principle: if a rule has a trigger, it belongs in a skill, not here.
-`.trim(),
-    readerMove: {
-      text: 'Audit your three always-on files; sum their Claude-token total via tiktoken cl100k_base or wc -w × 1.8; if > 3K, lift trigger-bearing rules into skills.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/CLAUDE.md',
-    },
+    keyMoves: [
+      'Keep [`CLAUDE.md`](https://docs.claude.com/en/docs/claude-code/memory) small — it is working memory loaded on every session. Move trigger-bearing rules into [skills](https://docs.claude.com/en/docs/claude-code/skills) so they load only when needed.',
+      'Use `.claude/skills/*/SKILL.md` as procedural memory — each skill loads only when its trigger fires, preserving the working-tier budget for task context.',
+      'Write episodic state (progress, decisions, artifact lists) to disk files between sessions; read them back at session start via file references.',
+      'Audit always-on files with `wc -w × 1.8`; if the total exceeds 3 K tokens, migrate trigger-bearing rules to skills or `.claude/rules/*.md` path-scoped files.',
+    ],
+    ccPrimitives: [
+      'CLAUDE.md (working memory)',
+      'SKILL.md (procedural memory)',
+      'Disk artifacts (episodic memory)',
+      'Task tool (isolated recall subagents)',
+    ],
     seeAlso: {
-      siblingPatternSlugs: ['context-engineering', '12-factor-agent'],
+      siblingPatternSlugs: ['context-engineering', '12-factor-agent', 'checkpointing'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Use [`.cursor/rules/*.mdc`](https://cursor.com/docs/rules) with `alwaysApply: true` for stable project facts that constitute semantic memory; scope domain-specific facts with `globs` so they load only on matching files.',
+      'Write learned facts explicitly into a dedicated `memory.mdc` rule file after each session — Cursor has no automatic fact-extraction; the write step is manual.',
+      'Reference prior session output files via `@file` at session start to restore episodic context without repeating prior work.',
+      'Keep all `alwaysApply: true` rules under 500 lines combined to avoid crowding the working context on every turn.',
+    ],
+    ccPrimitives: [
+      '.cursor/rules/*.mdc (semantic/procedural memory)',
+      'alwaysApply rule loading',
+      'globs-scoped rules (domain memory)',
+      '@file references (episodic recall)',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['context-engineering', '12-factor-agent', 'checkpointing'],
     },
   },
 }

--- a/src/data/agentic-design-patterns/patterns/multi-agent-debate.ts
+++ b/src/data/agentic-design-patterns/patterns/multi-agent-debate.ts
@@ -141,24 +141,39 @@ export {}
     },
   ],
   addedAt: '2026-05-04',
-  dateModified: '2026-05-05',
-  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — decision-funnel Phase 3 synthesizers as multi-agent debate realization.',
-
+  dateModified: '2026-05-04',
+  lastChangeNote: 'Author Multi-Agent Debate satellite: parallel-agent answers, peer-critique rounds, deterministic aggregation; degeneration-of-thought gotcha.',
   realizingInClaudeCode: {
-    tier: 'C',
-
-    bodyMarkdown: `
-Phase 3 of the [decision-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md) is structured multi-agent debate with deterministic aggregation. Three synthesizers receive the same phase-2 packet; the orchestrator assigns each a specific task for that run — tasks are decided dynamically based on what Phase 2 produced, not fixed in advance. They run in parallel (dispatched in a single message) so their outputs are independent, then the orchestrator reads all three and produces the phase-3-packet comparing areas of agreement and divergence. Phase 4 resolves disagreements into a final plan. [PR #347](https://github.com/julianken/detached-node/pull/347) and [PR #348](https://github.com/julianken/detached-node/pull/348) both used the Phase 3 synthesis structure.
-`.trim(),
-
-    readerMove: {
-      text: 'Assign each synthesizer a distinct task against the shared phase-2-packet; dispatch all three in one message; aggregate in a separate orchestrator step.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md',
-    },
-
+    keyMoves: [
+      'Dispatch N debater [subagents](https://docs.claude.com/en/docs/claude-code/sub-agents) in a single message — they produce independent first-round answers without seeing each other.',
+      'Write each debater\'s first-round output to a named disk file; the second round reads all files and produces a revised answer.',
+      'Assign distinct roles or temperatures to debaters via their [`SKILL.md`](https://docs.claude.com/en/docs/claude-code/skills) or brief — identical prompts converge, not debate.',
+      'Run the final aggregation as a separate judge subagent that reads all revised answers cold, without the debate transcript in context.',
+    ],
+    ccPrimitives: [
+      'Task tool (parallel debater subagents)',
+      'Single-message dispatch (isolation)',
+      'Disk-written round outputs',
+      'Judge subagent (final aggregation)',
+    ],
     seeAlso: {
-      skillPath: '.claude/skills/decision-funnel/SKILL.md',
-      siblingPatternSlugs: ['orchestrator-workers', 'evaluation-llm-as-judge', 'identity-separated-review'],
+      siblingPatternSlugs: ['parallelization', 'evaluation-llm-as-judge', 'orchestrator-workers'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Open N independent Agent chats on the same question — each produces a first-round answer without seeing the others.',
+      'Paste all first-round answers into a new Agent chat and ask for critique and revision; reference each via `@file` if saved to disk.',
+      'Assign different perspectives or constraints to each debater chat via the opening prompt to break the degeneration-of-thought pattern.',
+      'Use a final Agent session as the judge — provide only the closing statements, not the full debate transcript, to keep the verdict unbiased.',
+    ],
+    ccPrimitives: [
+      'Multiple Agent chats (parallel debaters)',
+      '@file (cross-chat answer sharing)',
+      'Agent mode',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['parallelization', 'evaluation-llm-as-judge', 'orchestrator-workers'],
     },
   },
 }

--- a/src/data/agentic-design-patterns/patterns/orchestrator-workers.ts
+++ b/src/data/agentic-design-patterns/patterns/orchestrator-workers.ts
@@ -87,42 +87,37 @@ export {}
   },
   relatedSlugs: [],
   realizingInClaudeCode: {
-    tier: 'A',
+    keyMoves: [
+      'Keep the orchestrator session as a planner only — it issues [`Task()`](https://docs.claude.com/en/docs/claude-code/sub-agents) calls and reads outputs; it never edits files.',
+      'Dispatch all workers in a single assistant message so they run concurrently; serial dispatch multiplies wall-clock by N.',
+      'Write each worker\'s output to a deterministic path on disk; the orchestrator reads those files for aggregation.',
+      'Encode the decomposition policy in a [SKILL.md](https://docs.claude.com/en/docs/claude-code/skills) loaded before dispatch so the planner prompt is versioned and reviewable.',
+    ],
     ccPrimitives: [
-      'Task tool dispatch — each worker is spawned via a Task() call in a single assistant message; Claude Code runs concurrent tool_use blocks for all workers in parallel',
-      'Subagent (type: general-purpose) — each worker runs in its own context window with its own prompt, tool surface, and scratch space; context isolation is the default, not opt-in',
-      'Orchestrator role (lead agent) — the invoking Claude Code session holds the plan, dispatches all workers, and performs the aggregation step; the lead never edits files during a worker wave',
-      'Parallel fan-out mechanic — dispatching N Task() calls in one assistant message is the single structural move that converts serial token cost into parallel wall-clock; every worker pays its own prompt overhead, but the elapsed time is the longest worker, not the sum',
-      'SKILL.md context injection — the analysis-funnel SKILL.md is loaded into the orchestrator context before dispatch; it carries the phase cardinality (5+5+3+1), the disk-checkpoint rule, and the single-message dispatch constraint; workers receive only their brief plus the tools they need',
+      'Task tool (worker dispatch)',
+      'Single-message parallel fan-out',
+      'SKILL.md orchestrator prompt',
+      'Disk artifact convention',
     ],
-    scaffolding: [
-      '.claude/skills/analysis-funnel/SKILL.md — the orchestrator prompt that encodes the 5+5+3+1 phase structure, the parallel-dispatch constraint, the disk-checkpoint protocol between phases, and the context-packet forwarding convention',
-      'Worktree-per-issue branch convention — each subagent workflow runs on a dedicated branch (e.g. feat/orchestrator-workers-realizing) and a dedicated git worktree so lead agent and worker agents do not share a working tree',
-      'Phase artifact directories — Phase 1 investigators write findings to phase-1/{role}-{slug}.md; Phase 2 iterators read those files, produce phase-2/{role}-{slug}.md; Phase 3 synthesizers produce phase-3/{lens}-synthesis.md; Phase 4 unifier reads all three and produces the final report',
-      'Context-packet forwarding — between phases the orchestrator assembles a 1–2 K token context packet (not raw worker transcripts) and passes it as the dispatch payload for the next wave; this keeps worker contexts clean and prevents the orchestrator context from growing with intermediate detail',
-      'GitHub PR as the delivery artifact — the orchestrator opens a PR once all workers finish and the aggregation step is complete; the PR body follows a five-section structure (Diagrams / Summary / Screenshots / Test plan / Plan reference)',
-      'Mergify required-checks queue — CI gates (ESLint, TypeScript, Vitest, Next.js Build, four E2E shards, CodeQL) must pass before the merge queue advances; the orchestrator-workers pattern is realized at the merge boundary as well as the dispatch boundary',
-    ],
-    workedExample: {
-      url: 'https://github.com/julianken/detached-node/pull/218',
-      description: `PR #218 — "feat: agentic design patterns reference — 23 satellites" — is the canonical instance of the Orchestrator-Workers pattern in this repository. The configuration that produced it ran the analysis-funnel skill, dispatching five parallel investigators in a single assistant message to explore distinct facets of the ADP catalog question: schema design, satellite page layout, mermaid rendering, reference validation, and E2E coverage. Each investigator wrote findings to a phase-1 artifact file on disk before the orchestrator assembled a context packet and dispatched five parallel iterators in Phase 2. Three synthesizers ran in parallel during Phase 3; one unifier produced the implementation plan that the lead agent executed in Phase 4.
-
-The structural mechanics visible in PR #218 match the pattern this satellite describes. The orchestrator (the Claude Code session invoking the skill) never edited files during the worker waves — it held the plan, dispatched all Task() calls in single messages, and aggregated outputs via disk reads rather than in-context accumulation. The 23-satellite scope illustrates why the decomposition had to be dynamic: the orchestrator chose at runtime which facets to assign to which investigator based on the input scope, not from a fixed template. Workers operated in isolation — no worker read another worker's transcript; context pollution between workers was prevented by design.
-
-The token economics visible here match the pattern's gotcha note: the orchestrator paid its own prompt overhead once; each of the five Phase 1 workers paid the prompt overhead for its brief plus the skill context; the aggregation step paid over the merged phase-1 artifacts. Anthropic's multi-agent research blog (https://www.anthropic.com/engineering/multi-agent-research-system) describes structurally identical mechanics at larger scale — a lead Claude agent plans the search, spawns subagents that explore branches in parallel with their own context windows, and a final agent synthesises the report. The mechanics described in that post and the mechanics that produced PR #218 are the same pattern at different cardinalities: one repo's five-investigator run versus Anthropic's research system running at production scale.
-
-The wall-clock gain from single-message parallel dispatch is the configuration's primary leverage point. Dispatching five investigators sequentially — one per assistant message — would produce identical output but take five times the elapsed time, because each worker must wait for the prior one to complete before the next tool_use block starts. The single-message fan-out is what makes the orchestrator-workers shape worth its token multiplier in latency-sensitive contexts. PR #218 shipped 23 satellite pages, schema validation, four lint guardrails, six E2E tests, and OG image generation; the scope was tractable because parallel dispatch made the investigation phase finish in one wall-clock window rather than five.
-
-The configuration described here — analysis-funnel SKILL.md, phase-artifact disk checkpoints, context-packet forwarding, five-section PR body — is what worked in this repo across this domain. The abstract pattern (dynamic decomposition, parallel dispatch, tree topology, aggregation step) is what Anthropic names as the right answer "when you can't predict the subtasks." PR #218 is one evidence anchor for that claim.`,
-    },
-    readerMove: {
-      text: 'Spawn one Task() per worker in a single message; never serialize when work is independent.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/analysis-funnel/SKILL.md',
-    },
     seeAlso: {
-      skillPath: '.claude/skills/analysis-funnel/SKILL.md',
-      articleSlug: 'subagent-orchestration-workflow',
-      siblingPatternSlugs: ['parallelization', 'planning'],
+      siblingPatternSlugs: ['parallelization', 'planning', 'funnel-method'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Use [Plan mode](https://cursor.com/docs/agent/plan-mode) to draft the worker decomposition before any code changes; review the step list before execution.',
+      'Launch one [Cloud Agent](https://cursor.com/docs/cloud-agent) per worker task — each runs in an isolated VM on its own branch.',
+      'Set shared invariants in a `.cursor/rules/*.mdc` file with `alwaysApply: true` so every worker context loads the same constraints.',
+      'Aggregate by opening an Agent chat that references all worker branches via `@branch` after workers complete.',
+    ],
+    ccPrimitives: [
+      'Plan mode (orchestrator decomposition)',
+      'Cloud Agents (worker isolation)',
+      '@branch references (aggregation)',
+      '.cursor/rules/*.mdc',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['parallelization', 'planning', 'funnel-method'],
     },
   },
   frameworks: ['langgraph', 'crew-ai', 'autogen', 'vercel-ai-sdk'],

--- a/src/data/agentic-design-patterns/patterns/parallelization.ts
+++ b/src/data/agentic-design-patterns/patterns/parallelization.ts
@@ -150,59 +150,36 @@ export {}
   dateModified: '2026-05-05',
   lastChangeNote: 'W2.1: add realizingInClaudeCode Tier A — dispatch-mechanic altitude, PR #218 worked example, single-message multi-Task() mechanic.',
   realizingInClaudeCode: {
-    tier: 'A',
+    keyMoves: [
+      'Dispatch all N [subagents](https://docs.claude.com/en/docs/claude-code/sub-agents) in a single assistant message — Claude Code runs concurrent `Task()` blocks; serial messages serialize the wall-clock.',
+      'Write each worker\'s output to a deterministic disk path before the orchestrator reads results back.',
+      'Encode the aggregation rule in the orchestrator prompt before dispatching; don\'t let the aggregator be another model decision.',
+      'Use [`git worktree add`](https://git-scm.com/docs/git-worktree) per worker to prevent filesystem race conditions during parallel writes.',
+    ],
     ccPrimitives: [
-      'single-message multi-Task() mechanic — dispatching all N Task() calls inside one assistant message is the primitive that converts N serial round-trips into one parallel wall-clock window; Claude Code executes concurrent tool_use blocks for every call in the message simultaneously',
-      'Task tool (sub-agent dispatch) — each branch runs in its own context window with its own prompt, tool subset, and scratch space; branches are isolated by construction, not by opt-in configuration',
-      'Deterministic aggregation step — the dispatching session reads worker output files from disk after all Task() calls complete; the aggregation rule (concatenate by section, pick majority answer, schema-typed merge) is encoded in the orchestrator prompt, not delegated back to a model call',
+      'Task tool (parallel dispatch)',
+      'Single-message multi-Task() mechanic',
+      'Git worktrees (isolation)',
     ],
-    scaffolding: [
-      '.claude/skills/analysis-funnel/SKILL.md — the orchestrator prompt that encodes the phase cardinality (5+5+3+1), the single-message dispatch constraint, and the disk-checkpoint protocol between phases; loaded into the dispatching session before any Task() call fires',
-      'phase-{N}/{role}-{slug}.md artifact convention — each worker writes its output to a deterministic file path before the wave ends; the aggregation step reads these files rather than accumulating worker transcripts in the orchestrator context',
-      'context-packet forwarding — between phases the orchestrator assembles a 1–2 K token summary from the current-phase artifacts and passes it as the dispatch payload for the next wave; keeps worker contexts clean and prevents the orchestrator context from growing unbounded',
-      'Worktree-per-issue branch convention — each subagent workflow runs on a dedicated branch and a dedicated git worktree; the dispatching session and worker sessions do not share a working tree, which prevents file-system race conditions during parallel writes',
-      'Parallel fan-out cardinality — five investigators in Phase 1, five iterators in Phase 2, three synthesizers in Phase 3 (5+5+3+1 cardinality); the specific cardinality is a choice encoded in the analysis-funnel skill, not a CC-native primitive',
-      'Phase-boundary disk checkpoint — workers write findings to disk before the next phase dispatches; the checkpoint protocol is a convention encoded in the analysis-funnel SKILL.md, not a feature of Claude Code itself',
-    ],
-    workedExample: {
-      url: 'https://github.com/julianken/detached-node/pull/218',
-      description: `PR #218 — "feat: agentic design patterns reference — 23 satellites" — is the canonical instance of the Parallelization pattern at dispatch-mechanic altitude in this repository. The configuration that produced it ran the analysis-funnel skill and dispatched five parallel investigators in a single assistant message: schema design, satellite page layout, mermaid rendering, reference validation, and E2E coverage. All five Task() calls were issued in one message. Claude Code executed all five tool_use blocks concurrently. Each investigator wrote findings to a phase-1 artifact file on disk before the orchestrator read them back.
-
-The single-message dispatch is the structural detail that makes PR #218 evidence for Parallelization rather than for a sequential chain. The same five investigators run serially — one Task() call per assistant message — would produce identical output files and identical final PR content, but the elapsed time would be five times longer, because each investigator would have to wait for the prior one to complete before its tool_use block could start. The single-message fan-out is the specific mechanic that buys the latency reduction; everything else — the phase structure, the disk checkpoints, the context-packet forwarding — is scaffolding that makes the mechanic reliable across multiple waves.
-
-Anthropic's multi-agent research blog (https://www.anthropic.com/engineering/multi-agent-research-system) describes structurally identical mechanics at production scale. Their research system dispatches parallel subagents that explore branches of a search question concurrently, each in its own context window, with outputs later aggregated by a synthesis pass. The claimed ~90% latency reduction relative to a sequential search reflects the same arithmetic: wall-clock is bounded by the slowest branch, not the sum of all branches. The five-investigator run in PR #218 is the same shape at smaller cardinality — same parallel dispatch, same context isolation, same disk-read aggregation.
-
-The distinction from the Orchestrator-Workers framing is altitude, not mechanics. The Orchestrator-Workers realization frames PR #218 at the architecture altitude: a central planner decided at runtime how many workers to spawn and what each one was asked to do, based on the input scope. This section frames the same PR at the dispatch-mechanic altitude: the single-message multi-Task() block is the specific Claude Code primitive that realizes the fan-out topology, and the parallel-wall-clock arithmetic is the reason the mechanic is worth using. Both framings cite the same evidence anchor; they describe different questions about it.
-
-The worked example also shows where the pattern's aggregation discipline matters in practice. Phase 1 produces five artifact files; the aggregation step must read all five and produce a coherent context packet before Phase 2 can dispatch. If the aggregation rule is underspecified — if the orchestrator prompt does not tell the session how to resolve disagreements between investigators or how to weight their outputs — the context packet for Phase 2 will carry conflicting signals that downstream workers have to untangle. In PR #218, the analysis-funnel SKILL.md encodes the aggregation rule alongside the dispatch constraint, so both halves of the pattern are expressed in one artifact.`,
-    },
-    readerMove: {
-      text: 'Inspect every dispatch message: N Task() calls in one message buys parallel wall-clock; N messages × 1 call serializes the work.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/analysis-funnel/SKILL.md',
-    },
     seeAlso: {
-      skillPath: '.claude/skills/analysis-funnel/SKILL.md',
-      articleSlug: 'phase-boundary-loop',
       siblingPatternSlugs: ['orchestrator-workers', 'checkpointing', 'funnel-method'],
     },
-    bodyMarkdown: `Parallelization in Claude Code reduces to one structural choice: how many Task() calls appear in a single assistant message. Dispatching N workers in one message tells Claude Code to execute all N tool_use blocks concurrently — wall-clock is bounded by the slowest worker, not the sum. Dispatching one worker per message serializes the work and multiplies wall-clock by N. The fan-out shape, the context isolation, and the deterministic aggregator that the abstract pattern describes all depend on that single dispatch decision being made correctly.
-
-### The single-message mechanic
-
-A Task() call issues a sub-agent into its own context window with its own prompt, tool surface, and scratch space. When multiple Task() calls appear in the same assistant message, Claude Code runs them as concurrent tool_use blocks. The parallelism is not opt-in and requires no framework configuration — it is the default behavior when the dispatch message contains more than one tool call. The practitioner's job is to ensure that the N workers actually arrive in one message rather than being issued sequentially across N messages.
-
-The analysis-funnel SKILL.md encodes this as an explicit constraint: dispatching Phase 1 investigators one at a time is treated as a defect, not a style preference. The SKILL.md carries the phase cardinality (5+5+3+1), the disk-checkpoint protocol between phases, and the context-packet forwarding convention — but the single-message dispatch constraint is the load-bearing rule the skill exists to enforce.
-
-### Why the Anthropic blog arithmetic holds
-
-Anthropic's multi-agent research blog (https://www.anthropic.com/engineering/multi-agent-research-system) reports roughly 90% latency reduction from parallel dispatch relative to sequential search. The arithmetic is straightforward: if each worker takes time T and you dispatch N workers, sequential execution takes N × T while parallel execution takes max(T₁, T₂, … Tₙ). At five workers of roughly equal cost, the parallel wall-clock approaches 20% of the sequential wall-clock — the reported ~90% reduction is the same bound from the other side. The blog describes structurally identical mechanics at production scale; PR #218 is the same pattern at five-investigator cardinality.
-
-The token economics run in the opposite direction. N concurrent workers pay N times the prompt overhead. That cost is unavoidable and worth instrumenting: the analysis-funnel configuration pays five times the Phase 1 brief cost plus the skill context cost, and the aggregation step pays again over the merged artifacts. The pattern earns its token multiplier when the task is parallelisable enough that the wall-clock savings justify the cost — and when the fan-out topology maps cleanly to the actual sub-task structure.
-
-### Aggregation discipline
-
-A parallel fan-out without a specified aggregation rule is a pattern fragment. The outputs arrive on disk from all N workers; something has to read them and produce a single committable result. In the analysis-funnel configuration, the aggregation rule is encoded in the SKILL.md alongside the dispatch constraint: the orchestrator assembles a 1–2 K token context packet from the phase artifacts and passes it as the dispatch payload for the next wave. The rule is deterministic (the same N artifact files always collapse to the same context packet structure) and the context packet is what isolates the next wave's workers from each other's intermediate details.
-
-Parallelization is the abstract pattern. The single-message multi-Task() mechanic, the phase-artifact disk checkpoint, and the context-packet forwarding are the configuration that has realized it in this repository. The mechanics generalize; the 5+5+3+1 cardinality is one specific composition suited to the investigation-and-synthesis shape of the analysis-funnel skill.`,
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Open multiple [Cloud Agents](https://cursor.com/docs/cloud-agent) in parallel — each runs in its own isolated VM on a separate branch.',
+      'Scope each agent\'s task brief so workers do not overlap; write outputs to deterministic file paths or branches.',
+      'Aggregate by opening a new Agent chat that references the parallel branches via `@branch` after all workers complete.',
+      'Use `.cursor/rules/*.mdc` with `alwaysApply: true` for invariants that every parallel worker must respect.',
+    ],
+    ccPrimitives: [
+      'Cloud Agents (parallel isolated VMs)',
+      '@branch references',
+      '.cursor/rules/*.mdc (shared invariants)',
+      'Agent mode',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['orchestrator-workers', 'checkpointing', 'funnel-method'],
+    },
   },
 }

--- a/src/data/agentic-design-patterns/patterns/planning.ts
+++ b/src/data/agentic-design-patterns/patterns/planning.ts
@@ -152,6 +152,39 @@ export {}
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-03',
-  lastChangeNote: 'Author Planning satellite: planner-executor split, re-plan loop, ToT/HuggingGPT/Plan-and-Solve variants.',
+  dateModified: '2026-05-05',
+  lastChangeNote: 'W3.0 — Update background-agent → cloud-agent URL in realizingInCursor.',
+  realizingInClaudeCode: {
+    keyMoves: [
+      'Write the step list to a `plan.md` file before executing any steps — the plan is a disk artifact a reviewer can inspect.',
+      'Execute each step as a separate [subagent](https://docs.claude.com/en/docs/claude-code/sub-agents) dispatch; pass only the current step brief and prior observations, not the full plan.',
+      'Assert step success before advancing — a [PreToolUse hook](https://docs.claude.com/en/docs/claude-code/hooks) or a structured tool result gates the next dispatch.',
+      'Rewrite the tail of `plan.md` when a step fails; preserve completed steps so the resume starts from the last successful checkpoint.',
+    ],
+    ccPrimitives: [
+      'Disk plan.md (inspectable step list)',
+      'Task tool (per-step executor)',
+      'PreToolUse hooks (step gate)',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['orchestrator-workers', 'checkpointing', 'tool-use-react'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Use [Plan mode](https://cursor.com/docs/agent/plan-mode) to generate the step list; review and edit it before execution begins — the plan is the contract.',
+      'Execute one step at a time in Agent mode; review each diff before accepting and moving to the next step.',
+      'Write step outputs to named files; reference them via `@file` in the next step\'s prompt to carry context forward without relying on chat history.',
+      'Use [cloud agents](https://cursor.com/docs/cloud-agent) for long-running plans; the branch-and-PR shape gives you a review gate at each phase boundary.',
+    ],
+    ccPrimitives: [
+      'Plan mode (step list generation and review)',
+      'Agent mode (step executor)',
+      '@file (step output forwarding)',
+      'Cloud agents (long-running plans)',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['orchestrator-workers', 'checkpointing', 'tool-use-react'],
+    },
+  },
 }

--- a/src/data/agentic-design-patterns/patterns/prompt-chaining.ts
+++ b/src/data/agentic-design-patterns/patterns/prompt-chaining.ts
@@ -136,24 +136,40 @@ export {}
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-05',
-  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — decision-funnel skill as prompt-chaining realization.',
-
+  dateModified: '2026-05-03',
+  lastChangeNote: 'Initial authoring of Prompt Chaining pattern (wave 1).',
   realizingInClaudeCode: {
-    tier: 'C',
-
-    bodyMarkdown: `
-The [decision-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md) in this repo is prompt chaining at scale. Each phase produces a context packet that is the prompt for the next: Phase 0 frames the problem, Phase 1's five investigators receive the phase-0-packet as their context, Phase 2's iterators receive the compressed phase-1-packet, Phase 3 synthesizers receive the phase-2-packet, and Phase 4 takes the phase-3-packet plus full Phase 3 artifacts to produce the execution plan. The key discipline is that the raw artifacts never flow forward — only the compressed packet flows to the next phase, preventing context bloat as the chain deepens. [PR #342](https://github.com/julianken/detached-node/pull/342) and [PR #343](https://github.com/julianken/detached-node/pull/343) are instances of the execution leg of this chain.
-`.trim(),
-
-    readerMove: {
-      text: 'Wire each phase\'s output as a compressed context packet that becomes the next phase\'s input prompt; never forward raw artifacts.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md',
-    },
-
+    keyMoves: [
+      'Define each pipeline stage as a named step in [`CLAUDE.md`](https://docs.claude.com/en/docs/claude-code/memory) so the agent follows the same decomposition every run.',
+      'Use a [hook](https://docs.claude.com/en/docs/claude-code/hooks) to validate structured output between stages; exit non-zero to retry the failing stage.',
+      'Pin the stage order in [`settings.json`](https://docs.claude.com/en/docs/claude-code/settings) via an allowed tool sequence — prevents the agent skipping gates under time pressure.',
+      'Keep each stage in a separate [subagent](https://docs.claude.com/en/docs/claude-code/sub-agents) when stages need clean context isolation from one another.',
+    ],
+    ccPrimitives: [
+      'CLAUDE.md stage definitions',
+      'PreToolUse hooks (inter-stage gates)',
+      'Task tool (per-stage subagents)',
+      'settings.json tool allow-list',
+    ],
     seeAlso: {
-      skillPath: '.claude/skills/decision-funnel/SKILL.md',
-      siblingPatternSlugs: ['orchestrator-workers', 'parallelization', 'context-engineering'],
+      siblingPatternSlugs: ['routing', 'parallelization', 'orchestrator-workers'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Add a `.cursor/rules/*.mdc` file listing each pipeline stage and its acceptance criteria.',
+      'Use Agent mode with [Plan mode](https://cursor.com/docs/agent/plan-mode) first — review the generated step list before execution begins.',
+      'Reference the output schema of each stage with `@file` so the next stage prompt sees the contract.',
+      'Set `alwaysApply: false` on stage rules and trigger them via `@rule-name` only when that stage is active.',
+    ],
+    ccPrimitives: [
+      '.cursor/rules/*.mdc (stage rules)',
+      'Plan mode (upfront step review)',
+      '@file references',
+      'Agent mode',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['routing', 'parallelization', 'orchestrator-workers'],
     },
   },
 }

--- a/src/data/agentic-design-patterns/patterns/rag.ts
+++ b/src/data/agentic-design-patterns/patterns/rag.ts
@@ -135,24 +135,40 @@ export {}
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-05',
-  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — analysis-funnel context packets as structured RAG realization.',
-
+  dateModified: '2026-05-03',
+  lastChangeNote: 'Authored RAG pattern (vanilla retrieve-and-generate; agentic variant remains separate).',
   realizingInClaudeCode: {
-    tier: 'C',
-
-    bodyMarkdown: `
-The [analysis-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/analysis-funnel/SKILL.md) practices structured RAG at every phase transition. Each wave produces detailed artifacts on disk; what flows to the next wave is not those artifacts but a compressed **context packet** — a purpose-built retrieval unit distilled from the raw output. The packet carries problem summary, key findings, carry-forward concerns, and artifact paths. Downstream agents receive the packet as pre-loaded context (retrieve) alongside their specific task (generate), following the classic RAG contract. The anti-bloat rules in the skill's Context Management section enforce the retrieval discipline: sending raw artifacts instead of packets is the named failure mode. [PR #339](https://github.com/julianken/detached-node/pull/339) is an instance of this pipeline operating in production.
-`.trim(),
-
-    readerMove: {
-      text: 'Write a compressed context packet after each phase; send the packet, not the raw artifacts, to the next phase\'s agents.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/analysis-funnel/SKILL.md',
-    },
-
+    keyMoves: [
+      'Use a [MCP](https://docs.claude.com/en/docs/claude-code/mcp) server to expose your retrieval index as a `search` tool; Claude calls it inside the normal tool-use loop.',
+      'Declare the retrieval tool in [`settings.json`](https://docs.claude.com/en/docs/claude-code/settings) `permissions.allow` so it fires without prompting on every session.',
+      'Pin the prompt template (evidence layout, citation instruction) in [`CLAUDE.md`](https://docs.claude.com/en/docs/claude-code/memory) so the grounding format is consistent across calls.',
+      'Use a [subagent](https://docs.claude.com/en/docs/claude-code/sub-agents) for retrieval-heavy tasks so the main session context stays clean from bulk passage text.',
+    ],
+    ccPrimitives: [
+      'MCP server (retrieval tool)',
+      'settings.json tool allow-list',
+      'CLAUDE.md prompt template',
+      'Task tool (retrieval subagent)',
+    ],
     seeAlso: {
-      skillPath: '.claude/skills/analysis-funnel/SKILL.md',
-      siblingPatternSlugs: ['agentic-rag', 'context-engineering', 'checkpointing'],
+      siblingPatternSlugs: ['agentic-rag', 'context-engineering', 'mcp'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Add a retrieval MCP server to `.cursor/mcp.json`; the agent calls it as a tool inside the standard Agent mode loop.',
+      'Use `@docs` to index a documentation URL directly into Cursor\'s context — no embedding pipeline setup required for known doc sites.',
+      'Reference retrieved files via `@file` to give the model grounding passages without embedding them in the prompt by hand.',
+      'Use `@codebase` for codebase-native retrieval — Cursor indexes the repo and retrieves relevant snippets automatically.',
+    ],
+    ccPrimitives: [
+      '.cursor/mcp.json (retrieval server)',
+      '@docs (URL indexing)',
+      '@codebase (repo retrieval)',
+      '@file (explicit grounding)',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['agentic-rag', 'context-engineering', 'mcp'],
     },
   },
 }

--- a/src/data/agentic-design-patterns/patterns/reflexion.ts
+++ b/src/data/agentic-design-patterns/patterns/reflexion.ts
@@ -11,7 +11,7 @@ export const pattern: Pattern = {
   bodySummary: [
     'Reflexion teaches a language agent to learn from its own trajectories without touching model weights. After each attempt, the agent inspects the trajectory and any environment feedback, then writes a short verbal critique — a paragraph that names what went wrong and what to try next. That critique is appended to an episodic memory buffer keyed by task or task class. On the next attempt, the agent retrieves the most recent and most relevant critiques and conditions its plan on them, treating prior failures as instructions rather than as silent gradient signal.',
     'The pattern straddles two layers. As Topology it shapes the control flow: a generator-execute-evaluate loop that, on failure, branches into a critique step before retrying. As State it maintains durable, retrievable memory whose unit is a natural-language lesson, not an embedding of a previous answer. The mechanism only earns its keep when failures are diagnosable from the trajectory itself — the agent must be able to articulate, in words, what an outside observer could also see. Tasks where failure is invisible (a stale tool, a wrong premise the agent never questioned) defeat the loop, because the critique is grounded in nothing.',
-    'Reflexion sits next to but distinct from a within-attempt generator-critic loop. Self-Refine iterates on a single output until a critic stops complaining; Reflexion iterates across attempts, so the lesson outlives the run and the next encounter with the same problem class starts informed. The cost is operational, not algorithmic: someone has to decide what counts as the same task, how many critiques to retrieve, when to compact the buffer, and which model writes the critique. The default of having the same model judge its own work is the hazard the pattern is most often deployed without noticing. Reflexion does not have its own Claude Code realization in this catalog yet; the closest in-repo realization of the critic-feedback loop is `evaluation-llm-as-judge` — both patterns turn on an identity-separated judge over generated output, differing mainly in time-scale (per-PR rather than per-iteration) and in whether the lesson persists across runs.',
+    'Reflexion sits next to but distinct from a within-attempt generator-critic loop. Self-Refine iterates on a single output until a critic stops complaining; Reflexion iterates across attempts, so the lesson outlives the run and the next encounter with the same problem class starts informed. The cost is operational, not algorithmic: someone has to decide what counts as the same task, how many critiques to retrieve, when to compact the buffer, and which model writes the critique. The default of having the same model judge its own work is the hazard the pattern is most often deployed without noticing.',
   ],
   mermaidSource: `graph LR
   A[Task] --> B[Generate]
@@ -143,6 +143,39 @@ export {}
     },
   ],
   addedAt: '2026-05-02',
-  dateModified: '2026-05-05',
-  lastChangeNote: 'W3.2 — Tier D honest-absence pointer: adjacent realization → evaluation-llm-as-judge.',
+  dateModified: '2026-05-03',
+  lastChangeNote: 'Initial authoring as the Phase-1 exemplar.',
+  realizingInClaudeCode: {
+    keyMoves: [
+      'Write verbal critiques to a named file after each failed attempt; load that file at the top of the next attempt\'s [`CLAUDE.md`](https://docs.claude.com/en/docs/claude-code/memory) context.',
+      'Scope critique storage to the task class — a per-project directory in `.claude/` works; key by task type, not by individual run.',
+      'Use a separate [subagent](https://docs.claude.com/en/docs/claude-code/sub-agents) as the critic to avoid same-model self-approval; pass it the trajectory as a file reference.',
+      'Compact the critique buffer periodically — a long-term store of all failures degrades retrieval quality for the next attempt.',
+    ],
+    ccPrimitives: [
+      'CLAUDE.md lesson injection',
+      'Task tool (isolated critic)',
+      'Disk-stored critique files',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['evaluator-optimizer', 'memory-management', 'evaluation-llm-as-judge'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Append critique notes to a [`.cursor/rules/*.mdc`](https://cursor.com/docs/rules) file after each failed attempt; `alwaysApply: true` loads them on the next session.',
+      'Reference the critique file explicitly via `@file` at the start of the retry attempt so the agent reads it first.',
+      'Scope critique rules by task class — one `.mdc` file per problem domain keeps lessons targeted and avoids stale notes diluting unrelated tasks.',
+      'Limit each critique rule file to under 100 lines; split by task class if the file grows beyond that to preserve retrieval quality.',
+    ],
+    ccPrimitives: [
+      '.cursor/rules/*.mdc (critique rules)',
+      'alwaysApply rule loading',
+      '@file references',
+      'Agent mode',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['evaluator-optimizer', 'memory-management', 'evaluation-llm-as-judge'],
+    },
+  },
 }

--- a/src/data/agentic-design-patterns/patterns/routing.ts
+++ b/src/data/agentic-design-patterns/patterns/routing.ts
@@ -141,24 +141,39 @@ export {}
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-05',
-  lastChangeNote: 'W3.3: add realizingInClaudeCode Tier C — decision-funnel domain detection as routing realization.',
-
+  dateModified: '2026-05-03',
+  lastChangeNote: 'Initial authoring of the Routing pattern (wave-1, issue #173).',
   realizingInClaudeCode: {
-    tier: 'C',
-
-    bodyMarkdown: `
-The [decision-funnel skill](https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md) encodes a routing table as its Domain Detection section: twelve domains (UI/Visual, React/Components, Auth/Security, and more) each map to a preferred \`subagent_type\` value. Phase 0 classifies the problem against that table and the classification determines which specialist agent receives each investigation area in Phase 1. No separate router agent is required — the orchestrator reads the table and routes directly. The domain-to-agent-type mapping in the skill's D.4 Agent Type Selection section is the routing logic; the phase-0 domain tags are the runtime signal that triggers it. [PR #337](https://github.com/julianken/detached-node/pull/337) introduced the dispatch mechanic this routing table feeds.
-`.trim(),
-
-    readerMove: {
-      text: 'Build a domain-to-agent-type table in your SKILL.md; route Phase 1 investigators by domain tag, not by model default.',
-      anchorUrl: 'https://github.com/julianken/detached-node/blob/main/.claude/skills/decision-funnel/SKILL.md',
-    },
-
+    keyMoves: [
+      'Declare each handler as a separate [SKILL.md](https://docs.claude.com/en/docs/claude-code/skills) with a `description` matching its intent class.',
+      'Use structured output in the classifier step; write the label to a scratchpad file the routing logic reads.',
+      'Pin classifier and each handler to separate [subagents](https://docs.claude.com/en/docs/claude-code/sub-agents) so tool surfaces stay narrow per handler.',
+      'Log the chosen label and handler in [`CLAUDE.md`](https://docs.claude.com/en/docs/claude-code/memory) telemetry notes to surface misclassification over time.',
+    ],
+    ccPrimitives: [
+      'SKILL.md description-based dispatch',
+      'Task tool (handler subagents)',
+      'settings.json tool scoping per handler',
+    ],
     seeAlso: {
-      skillPath: '.claude/skills/decision-funnel/SKILL.md',
-      siblingPatternSlugs: ['orchestrator-workers', 'handoffs-swarm', 'planning'],
+      siblingPatternSlugs: ['prompt-chaining', 'orchestrator-workers', 'handoffs-swarm'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Create one `.cursor/rules/*.mdc` file per handler with `globs` scoped to the files that handler edits.',
+      'Use Agent mode for the classifier turn; pin model selection per route via Cursor\'s model picker if cost tiers differ.',
+      'Reference handler-specific docs with `@docs` so each handler has the right context without cross-contamination.',
+      'Set `alwaysApply: false` on handler rules; activate via `@rule-name` after the classifier emits its label.',
+    ],
+    ccPrimitives: [
+      '.cursor/rules/*.mdc (per-handler rules)',
+      'globs scoping',
+      '@docs references',
+      'Agent mode',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['prompt-chaining', 'orchestrator-workers', 'handoffs-swarm'],
     },
   },
 }

--- a/src/data/agentic-design-patterns/patterns/streaming.ts
+++ b/src/data/agentic-design-patterns/patterns/streaming.ts
@@ -9,7 +9,7 @@ export const pattern: Pattern = {
   bodySummary: [
     'Streaming changes when the model\'s output reaches the consumer: bytes leave the inference server the moment they are generated, rather than accumulating until the full response is ready. The transport is almost always Server-Sent Events — a long-lived HTTP response whose body is a sequence of newline-delimited data frames the client parses as it reads. Each frame carries a small typed delta: a chunk of generated text, a partial JSON fragment of a tool call, an updated finish reason, or a terminal event that closes the stream. The consumer reconstructs the final state by accumulating deltas in order; nothing is broadcast and nothing is replayed.',
     'Three sub-variants share the same wire shape but differ in what is being incrementally revealed. Token streaming emits text deltas one fragment at a time and is what every chat UI renders character-by-character. Structured streaming emits a partial JSON object whose shape is fixed by a schema — the Vercel AI SDK\'s streamObject exposes the partial as a typed value at every step, so a form fills in field-by-field instead of appearing all at once. Tool-call streaming emits the arguments of a function call as they are generated; a long argument list becomes visible before the model has finished writing it, and a UI can begin rendering the call before dispatch.',
-    'The pattern is a UX contract change as much as a transport detail. A thirty-second response that streams feels usable because the user sees evidence of work within the first hundred milliseconds; the same thirty seconds behind a single blocking request reads as a hung connection. Streaming is distinct from polling, where the client repeatedly asks whether the result is ready, and from progress events, which are out-of-band metadata about an otherwise-blocking operation. With streaming, the partial output is the operation. Streaming does not have its own Claude Code realization in this catalog yet; the closest in-repo realization of incremental tool-call output is `tool-use-react` — that pattern\'s PreToolUse hook intercepts the call at the argument-complete boundary, which is the harness-level equivalent of acting on a stream at the moment the argument delta closes rather than after the full response returns.',
+    'The pattern is a UX contract change as much as a transport detail. A thirty-second response that streams feels usable because the user sees evidence of work within the first hundred milliseconds; the same thirty seconds behind a single blocking request reads as a hung connection. Streaming is distinct from polling, where the client repeatedly asks whether the result is ready, and from progress events, which are out-of-band metadata about an otherwise-blocking operation. With streaming, the partial output is the operation.',
   ],
   mermaidSource: `graph LR
   A[Client request] --> B[Inference server]
@@ -137,6 +137,39 @@ export {}
     },
   ],
   addedAt: '2026-05-03',
-  dateModified: '2026-05-05',
-  lastChangeNote: 'W3.2 — Tier D honest-absence pointer: adjacent realization → tool-use-react.',
+  dateModified: '2026-05-04',
+  lastChangeNote: 'Author Streaming satellite: SSE event-flow, token vs structured vs tool-call variants, mid-stream-error gotcha.',
+  realizingInClaudeCode: {
+    keyMoves: [
+      'Claude Code streams tool output to the terminal by default — no configuration needed for the core streaming UX.',
+      'Use [hooks](https://docs.claude.com/en/docs/claude-code/hooks) to intercept `PostToolUse` events and act on completed tool results before the next model call.',
+      'In custom agent code, use `streamText` from the AI SDK and inspect mid-stream `error` frames — an HTTP 200 does not guarantee a clean stream.',
+      'Pin `maxRetries` on your streaming client; a buffering reverse proxy holds the response until the stream closes, defeating incremental delivery.',
+    ],
+    ccPrimitives: [
+      'PostToolUse hooks (post-tool event handling)',
+      'Terminal streaming (built-in)',
+      'Vercel AI SDK streamText',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['tool-use-react', 'mcp', 'a2a'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Cursor streams tokens in the chat panel by default — the incremental UX is built-in for all Agent and Ask mode responses.',
+      'Reference large files via `@file` rather than pasting content; Cursor fetches and injects context on demand without pre-loading everything.',
+      'Use Ask mode for read-only queries where you want to inspect the partial output before any edits are applied.',
+      'Use [cloud agents](https://cursor.com/docs/cloud-agent) for long-running tasks; they run in isolated cloud environments and surface progress through the Cursor web interface.',
+    ],
+    ccPrimitives: [
+      'Built-in chat streaming',
+      'Ask mode (read-only stream)',
+      'Cloud agents (async long-running tasks)',
+      '@file references',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['tool-use-react', 'mcp', 'a2a'],
+    },
+  },
 }

--- a/src/data/agentic-design-patterns/patterns/tool-use-react.ts
+++ b/src/data/agentic-design-patterns/patterns/tool-use-react.ts
@@ -143,14 +143,35 @@ export {}
   dateModified: '2026-05-05',
   lastChangeNote: 'W2.8 — Add realizingInClaudeCode Tier C cross-link: PreToolUse as harness-level enforcement primitive.',
   realizingInClaudeCode: {
-    tier: 'C',
-    bodyMarkdown: `Claude Code exposes PreToolUse hooks as a harness-level enforcement primitive: shell scripts declared in .claude/settings.json intercept Bash tool calls before they execute and abort on non-zero exit. This makes the hook a process-level guardrail around the Tool Use / ReAct loop itself — not a prompt constraint, but a runtime intercept that fires before the model's chosen action reaches the shell. The scripts are tracked in git and carry the executable bit; [PR #335](https://github.com/julianken/detached-node/pull/335) is the canonical demonstration. A hook script is a no-op by design when the file is absent — enforcement is gated by script presence on disk, which is why git tracking is the activation step.`,
-    readerMove: {
-      text: 'Add a PreToolUse hook to .claude/settings.json; track the script in git so enforcement is present on every clone.',
-      anchorUrl: 'https://github.com/julianken/detached-node/pull/335',
-    },
+    keyMoves: [
+      'Use a [PreToolUse hook](https://docs.claude.com/en/docs/claude-code/hooks) to intercept every tool call in the loop — exit non-zero to block the action before it fires.',
+      'Declare hooks in [`settings.json`](https://docs.claude.com/en/docs/claude-code/settings); track the hook scripts in git so they apply on every clone.',
+      'Scope the tool catalog with `permissions.allow` in [`settings.json`](https://docs.claude.com/en/docs/claude-code/settings) — narrow the catalog per project so the agent only sees actions it should take.',
+      'Use [`CLAUDE.md`](https://docs.claude.com/en/docs/claude-code/memory) for soft conventions; use hooks for hard runtime enforcement that fires regardless of model compliance.',
+    ],
+    ccPrimitives: [
+      'PreToolUse hooks (action intercept)',
+      'settings.json tool allow-list',
+      'CLAUDE.md (soft conventions)',
+    ],
     seeAlso: {
-      siblingPatternSlugs: ['code-agent', 'guardrails'],
+      siblingPatternSlugs: ['code-agent', 'guardrails', 'human-in-the-loop'],
+    },
+  },
+  realizingInCursor: {
+    keyMoves: [
+      'Use Agent mode — it runs the full Thought-Action-Observation loop autonomously across files and terminal commands.',
+      'Scope available tools via `.cursor/rules/*.mdc` instructions; tell the agent which commands it should and should not run.',
+      'Add a `.cursor/rules/*.mdc` with `alwaysApply: true` declaring tool-use constraints that apply on every turn.',
+      'Use [Plan mode](https://cursor.com/docs/agent/plan-mode) before complex multi-tool tasks to review the intended action sequence before execution begins.',
+    ],
+    ccPrimitives: [
+      'Agent mode (ReAct loop)',
+      '.cursor/rules/*.mdc (tool constraints)',
+      'Plan mode (pre-execution review)',
+    ],
+    seeAlso: {
+      siblingPatternSlugs: ['code-agent', 'guardrails', 'human-in-the-loop'],
     },
   },
 }

--- a/src/data/agentic-design-patterns/types.ts
+++ b/src/data/agentic-design-patterns/types.ts
@@ -92,31 +92,29 @@ export type CcUmbrellaPointer = {
 }
 
 /**
- * Discriminated union over four tiers:
- * - Tier A: full satellite (ccPrimitives + scaffolding + workedExample + readerMove + seeAlso)
- * - Tier B: compact (readerMove + seeAlso; bodyMarkdown optional)
- * - Tier C: cross-link paragraph (readerMove + seeAlso + bodyMarkdown)
- * - Tier U: umbrella index (openingFraming + umbrellaPointers ≥10 + closingRule + seeAlso)
+ * Reader-facing reference content for a pattern's Claude Code realization.
+ * All fields are optional; the renderer surfaces whatever is present.
  */
 export type RealizingInClaudeCode = {
-  tier: 'A' | 'B' | 'C' | 'U'
-  /** Required Tier A: CC primitive names that realize this pattern */
+  /** Top-of-card scannable bullets. Action-verb-led, plain technical voice. */
+  keyMoves?: string[]
+  /** Claude Code feature names that realize this pattern (rendered as pills). */
   ccPrimitives?: CcPrimitive[]
-  /** Required Tier A: scaffolding artifacts (SKILL.md paths, config files) */
+  /** Optional repo-shape artifacts. No longer rendered in the reader UI. */
   scaffolding?: CcScaffolding[]
-  /** Required Tier A: one verified worked-example PR or tree URL */
+  /** Optional concrete example link (rendered as a small footer chip). */
   workedExample?: CcWorkedExample
-  /** Required Tier A, B, C: the Monday-morning reader move */
+  /** Deprecated authoring field; no longer rendered. */
   readerMove?: CcReaderMove
-  /** Required all tiers: cross-link block */
+  /** Cross-link block: sibling slugs and optional article slug. */
   seeAlso?: CcSeeAlso
-  /** Tier C (and Tier A supplementary): compact paragraph prose */
+  /** Optional deep-dive prose. Collapsed inside a "Why this works" sub-disclosure. */
   bodyMarkdown?: string
-  /** Tier U only: ≥10 umbrella pointer rows */
+  /** Umbrella patterns only: pointer rows mapping each sibling to a one-liner. */
   umbrellaPointers?: CcUmbrellaPointer[]
-  /** Tier U only: opening framing paragraph (~100w) */
+  /** Umbrella patterns only: opening framing paragraph. */
   openingFraming?: string
-  /** Tier U only: closing rule sentence (verbatim meta-rule) */
+  /** Umbrella patterns only: closing rule sentence. */
   closingRule?: string
 }
 
@@ -145,8 +143,10 @@ export type Pattern = {
   dateModified: string        // ISO date — last meaningful content edit
   lastChangeNote?: string     // 1-line description of last edit
   archived?: boolean          // true when retired
-  /** W1.0: optional bridge field; absent for all 23 patterns until W1.1+ fills them */
+  /** Claude Code realization of this pattern (renders as a collapsible card under the diagram). */
   realizingInClaudeCode?: RealizingInClaudeCode
+  /** Cursor realization of this pattern (parallel to Claude Code; empty for most patterns until populated). */
+  realizingInCursor?: RealizingInClaudeCode
 }
 
 export type ChangelogEntryType = 'added' | 'edited' | 'retired'

--- a/tests/unit/data/agentic-design-patterns/realizing.test.ts
+++ b/tests/unit/data/agentic-design-patterns/realizing.test.ts
@@ -1,12 +1,13 @@
 // ---------------------------------------------------------------------------
-// Realizing-in-Claude-Code validator
+// Realizing-in-IDE validator
 // ---------------------------------------------------------------------------
-// Iterates every pattern in the catalog. If realizingInClaudeCode is absent,
-// the test passes with no assertions. When the field is present, optional
-// fields are validated when populated.
+// Iterates every pattern in the catalog and validates BOTH `realizingInClaudeCode`
+// and `realizingInCursor` blocks. If a block is absent, the test passes with
+// no assertions on it. When present, fields are validated.
 // ---------------------------------------------------------------------------
 
 import { describe, it, expect } from 'vitest'
+import type { RealizingInClaudeCode } from '@/data/agentic-design-patterns/types'
 import { PATTERNS, getPatternSlugs } from '@/data/agentic-design-patterns/index'
 
 const ALL_SLUGS = new Set(getPatternSlugs())
@@ -19,69 +20,81 @@ function assertValidUrl(url: string, label: string): void {
   expect(() => new URL(url), `${label} must be a parseable URL: "${url}"`).not.toThrow()
 }
 
-describe('realizingInClaudeCode invariants', () => {
-  for (const pattern of PATTERNS) {
-    const { slug, realizingInClaudeCode: r } = pattern
+function assertBlockInvariants(label: string, r: RealizingInClaudeCode): void {
+  if (r.keyMoves) {
+    it(`${label} — keyMoves has 3-5 entries, each ≤25 words`, () => {
+      expect(r.keyMoves!.length).toBeGreaterThanOrEqual(3)
+      expect(r.keyMoves!.length).toBeLessThanOrEqual(5)
+      for (const move of r.keyMoves!) {
+        expect(
+          wordCount(move),
+          `keyMove "${move.slice(0, 40)}..." exceeds 25 words`,
+        ).toBeLessThanOrEqual(25)
+      }
+    })
+  }
 
-    if (!r) {
-      it(`${slug} — absent field passes (graceful-absent)`, () => {
-        expect(r).toBeUndefined()
+  if (r.ccPrimitives) {
+    it(`${label} — ccPrimitives is non-empty`, () => {
+      expect(r.ccPrimitives!.length).toBeGreaterThan(0)
+    })
+  }
+
+  if (r.workedExample) {
+    it(`${label} — workedExample.url parses`, () => {
+      assertValidUrl(r.workedExample!.url, `${label}.workedExample.url`)
+      expect(r.workedExample!.description.trim().length).toBeGreaterThan(0)
+    })
+  }
+
+  // seeAlso is required when a block is populated — keeps related-patterns
+  // chips from silently disappearing on a future pattern.
+  it(`${label} — seeAlso is present`, () => {
+    expect(r.seeAlso, `${label} must declare a seeAlso block`).toBeDefined()
+  })
+
+  if (r.seeAlso?.siblingPatternSlugs) {
+    it(`${label} — seeAlso.siblingPatternSlugs all resolve`, () => {
+      for (const siblingSlug of r.seeAlso!.siblingPatternSlugs!) {
+        expect(
+          ALL_SLUGS.has(siblingSlug),
+          `siblingPatternSlug "${siblingSlug}" not found in catalog`,
+        ).toBe(true)
+      }
+    })
+  }
+
+  if (r.umbrellaPointers) {
+    it(`${label} — umbrellaPointers slugs all resolve and oneLine is non-empty`, () => {
+      for (const pointer of r.umbrellaPointers!) {
+        expect(
+          ALL_SLUGS.has(pointer.patternSlug),
+          `umbrellaPointer.patternSlug "${pointer.patternSlug}" not found in catalog`,
+        ).toBe(true)
+        expect(
+          pointer.oneLine.trim().length,
+          `umbrellaPointer.oneLine for "${pointer.patternSlug}" must be non-empty`,
+        ).toBeGreaterThan(0)
+      }
+    })
+  }
+}
+
+describe('realizing-in-IDE invariants', () => {
+  for (const pattern of PATTERNS) {
+    const { slug, realizingInClaudeCode: rcc, realizingInCursor: rcursor } = pattern
+
+    if (!rcc && !rcursor) {
+      it(`${slug} — both IDE blocks absent (graceful-absent)`, () => {
+        expect(rcc).toBeUndefined()
+        expect(rcursor).toBeUndefined()
       })
       continue
     }
 
     describe(slug, () => {
-      if (r.keyMoves) {
-        it('keyMoves has 3-5 entries, each ≤25 words', () => {
-          expect(r.keyMoves!.length).toBeGreaterThanOrEqual(3)
-          expect(r.keyMoves!.length).toBeLessThanOrEqual(5)
-          for (const move of r.keyMoves!) {
-            expect(
-              wordCount(move),
-              `keyMove "${move.slice(0, 40)}..." exceeds 25 words`,
-            ).toBeLessThanOrEqual(25)
-          }
-        })
-      }
-
-      if (r.ccPrimitives) {
-        it('ccPrimitives is non-empty', () => {
-          expect(r.ccPrimitives!.length).toBeGreaterThan(0)
-        })
-      }
-
-      if (r.workedExample) {
-        it('workedExample.url parses', () => {
-          assertValidUrl(r.workedExample!.url, `${slug}.workedExample.url`)
-          expect(r.workedExample!.description.trim().length).toBeGreaterThan(0)
-        })
-      }
-
-      if (r.seeAlso?.siblingPatternSlugs) {
-        it('seeAlso.siblingPatternSlugs all resolve in the catalog', () => {
-          for (const siblingSlug of r.seeAlso!.siblingPatternSlugs!) {
-            expect(
-              ALL_SLUGS.has(siblingSlug),
-              `siblingPatternSlug "${siblingSlug}" not found in catalog`,
-            ).toBe(true)
-          }
-        })
-      }
-
-      if (r.umbrellaPointers) {
-        it('umbrellaPointers slugs all resolve and oneLine is non-empty', () => {
-          for (const pointer of r.umbrellaPointers!) {
-            expect(
-              ALL_SLUGS.has(pointer.patternSlug),
-              `umbrellaPointer.patternSlug "${pointer.patternSlug}" not found in catalog`,
-            ).toBe(true)
-            expect(
-              pointer.oneLine.trim().length,
-              `umbrellaPointer.oneLine for "${pointer.patternSlug}" must be non-empty`,
-            ).toBeGreaterThan(0)
-          }
-        })
-      }
+      if (rcc) assertBlockInvariants(`${slug}.realizingInClaudeCode`, rcc)
+      if (rcursor) assertBlockInvariants(`${slug}.realizingInCursor`, rcursor)
     })
   }
 })

--- a/tests/unit/data/agentic-design-patterns/realizing.test.ts
+++ b/tests/unit/data/agentic-design-patterns/realizing.test.ts
@@ -1,32 +1,15 @@
 // ---------------------------------------------------------------------------
-// Realizing-in-Claude-Code validator — W1.0
+// Realizing-in-Claude-Code validator
 // ---------------------------------------------------------------------------
-// Iterates every pattern in the catalog. If realizingInClaudeCode is absent
-// (graceful-absent migration), the test passes with no assertions. When the
-// field is present, per-tier required-field invariants are enforced.
-//
-// Tier A: ccPrimitives + scaffolding + workedExample + readerMove + seeAlso
-// Tier B: readerMove + seeAlso (bodyMarkdown optional)
-// Tier C: readerMove + seeAlso (bodyMarkdown present)
-// Tier U: openingFraming + closingRule + umbrellaPointers (≥10) + seeAlso
-//
-// Additional cross-tier assertions:
-//   - tier field is one of A|B|C|U
-//   - readerMove.text word count ≤ 25
-//   - workedExample.url parses via new URL()
-//   - seeAlso.siblingPatternSlugs all resolve in getPatternSlugs()
-//   - umbrellaPointers[].patternSlug all resolve in getPatternSlugs()
+// Iterates every pattern in the catalog. If realizingInClaudeCode is absent,
+// the test passes with no assertions. When the field is present, optional
+// fields are validated when populated.
 // ---------------------------------------------------------------------------
 
 import { describe, it, expect } from 'vitest'
 import { PATTERNS, getPatternSlugs } from '@/data/agentic-design-patterns/index'
 
-const VALID_TIERS = new Set(['A', 'B', 'C', 'U'])
 const ALL_SLUGS = new Set(getPatternSlugs())
-
-// ---------------------------------------------------------------------------
-// helpers
-// ---------------------------------------------------------------------------
 
 function wordCount(text: string): number {
   return text.trim().split(/\s+/).length
@@ -36,124 +19,68 @@ function assertValidUrl(url: string, label: string): void {
   expect(() => new URL(url), `${label} must be a parseable URL: "${url}"`).not.toThrow()
 }
 
-// ---------------------------------------------------------------------------
-// per-pattern loop
-// ---------------------------------------------------------------------------
-
-describe('realizingInClaudeCode — per-tier invariants', () => {
+describe('realizingInClaudeCode invariants', () => {
   for (const pattern of PATTERNS) {
     const { slug, realizingInClaudeCode: r } = pattern
 
     if (!r) {
-      // Graceful-absent: field not yet populated. No assertions.
-      it(`${slug} — absent field passes (graceful-absent migration)`, () => {
+      it(`${slug} — absent field passes (graceful-absent)`, () => {
         expect(r).toBeUndefined()
       })
       continue
     }
 
-    describe(`${slug} (Tier ${r.tier})`, () => {
-      // ── All tiers ──────────────────────────────────────────────────────────
-
-      it('tier is one of A|B|C|U', () => {
-        expect(VALID_TIERS.has(r.tier)).toBe(true)
-      })
-
-      it('seeAlso is present', () => {
-        expect(r.seeAlso).toBeDefined()
-      })
-
-      if (r.seeAlso?.siblingPatternSlugs) {
-        it('seeAlso.siblingPatternSlugs all resolve in the catalog', () => {
-          for (const siblingSlug of r.seeAlso!.siblingPatternSlugs!) {
-            expect(ALL_SLUGS.has(siblingSlug), `siblingPatternSlug "${siblingSlug}" not found in catalog`).toBe(true)
+    describe(slug, () => {
+      if (r.keyMoves) {
+        it('keyMoves has 3-5 entries, each ≤25 words', () => {
+          expect(r.keyMoves!.length).toBeGreaterThanOrEqual(3)
+          expect(r.keyMoves!.length).toBeLessThanOrEqual(5)
+          for (const move of r.keyMoves!) {
+            expect(
+              wordCount(move),
+              `keyMove "${move.slice(0, 40)}..." exceeds 25 words`,
+            ).toBeLessThanOrEqual(25)
           }
         })
       }
 
-      // ── Tier A ─────────────────────────────────────────────────────────────
-
-      if (r.tier === 'A') {
-        it('ccPrimitives is present and non-empty', () => {
-          expect(r.ccPrimitives).toBeDefined()
+      if (r.ccPrimitives) {
+        it('ccPrimitives is non-empty', () => {
           expect(r.ccPrimitives!.length).toBeGreaterThan(0)
         })
+      }
 
-        it('scaffolding is present and non-empty', () => {
-          expect(r.scaffolding).toBeDefined()
-          expect(r.scaffolding!.length).toBeGreaterThan(0)
-        })
-
-        it('workedExample is present with a valid URL', () => {
-          expect(r.workedExample).toBeDefined()
+      if (r.workedExample) {
+        it('workedExample.url parses', () => {
           assertValidUrl(r.workedExample!.url, `${slug}.workedExample.url`)
           expect(r.workedExample!.description.trim().length).toBeGreaterThan(0)
         })
+      }
 
-        it('readerMove is present with text ≤25 words and a valid anchorUrl', () => {
-          expect(r.readerMove).toBeDefined()
-          expect(wordCount(r.readerMove!.text)).toBeLessThanOrEqual(25)
-          assertValidUrl(r.readerMove!.anchorUrl, `${slug}.readerMove.anchorUrl`)
+      if (r.seeAlso?.siblingPatternSlugs) {
+        it('seeAlso.siblingPatternSlugs all resolve in the catalog', () => {
+          for (const siblingSlug of r.seeAlso!.siblingPatternSlugs!) {
+            expect(
+              ALL_SLUGS.has(siblingSlug),
+              `siblingPatternSlug "${siblingSlug}" not found in catalog`,
+            ).toBe(true)
+          }
         })
       }
 
-      // ── Tier B ─────────────────────────────────────────────────────────────
-
-      if (r.tier === 'B') {
-        it('readerMove is present with text ≤25 words and a valid anchorUrl', () => {
-          expect(r.readerMove).toBeDefined()
-          expect(wordCount(r.readerMove!.text)).toBeLessThanOrEqual(25)
-          assertValidUrl(r.readerMove!.anchorUrl, `${slug}.readerMove.anchorUrl`)
+      if (r.umbrellaPointers) {
+        it('umbrellaPointers slugs all resolve and oneLine is non-empty', () => {
+          for (const pointer of r.umbrellaPointers!) {
+            expect(
+              ALL_SLUGS.has(pointer.patternSlug),
+              `umbrellaPointer.patternSlug "${pointer.patternSlug}" not found in catalog`,
+            ).toBe(true)
+            expect(
+              pointer.oneLine.trim().length,
+              `umbrellaPointer.oneLine for "${pointer.patternSlug}" must be non-empty`,
+            ).toBeGreaterThan(0)
+          }
         })
-      }
-
-      // ── Tier C ─────────────────────────────────────────────────────────────
-
-      if (r.tier === 'C') {
-        it('readerMove is present with text ≤25 words and a valid anchorUrl', () => {
-          expect(r.readerMove).toBeDefined()
-          expect(wordCount(r.readerMove!.text)).toBeLessThanOrEqual(25)
-          assertValidUrl(r.readerMove!.anchorUrl, `${slug}.readerMove.anchorUrl`)
-        })
-
-        it('bodyMarkdown is present and non-empty for Tier C', () => {
-          expect(r.bodyMarkdown).toBeDefined()
-          expect(r.bodyMarkdown!.trim().length).toBeGreaterThan(0)
-        })
-      }
-
-      // ── Tier U ─────────────────────────────────────────────────────────────
-
-      if (r.tier === 'U') {
-        it('openingFraming is present and non-empty', () => {
-          expect(r.openingFraming).toBeDefined()
-          expect(r.openingFraming!.trim().length).toBeGreaterThan(0)
-        })
-
-        it('closingRule is present and non-empty', () => {
-          expect(r.closingRule).toBeDefined()
-          expect(r.closingRule!.trim().length).toBeGreaterThan(0)
-        })
-
-        it('umbrellaPointers is present with ≥10 entries', () => {
-          expect(r.umbrellaPointers).toBeDefined()
-          expect(r.umbrellaPointers!.length).toBeGreaterThanOrEqual(10)
-        })
-
-        if (r.umbrellaPointers) {
-          it('all umbrellaPointers[].patternSlug resolve in the catalog', () => {
-            for (const pointer of r.umbrellaPointers!) {
-              expect(
-                ALL_SLUGS.has(pointer.patternSlug),
-                `umbrellaPointer.patternSlug "${pointer.patternSlug}" not found in catalog`,
-              ).toBe(true)
-              expect(
-                pointer.oneLine.trim().length,
-                `umbrellaPointer.oneLine for "${pointer.patternSlug}" must be non-empty`,
-              ).toBeGreaterThan(0)
-            }
-          })
-        }
       }
     })
   }


### PR DESCRIPTION
## Diagrams

The redesigned card sits directly under each pattern's Mermaid diagram. Two collapsible IDE sections (Claude Code, Cursor), both collapsed by default. Inside each: bulleted `keyMoves` (action-verb-led, ≤25 words each, doc URLs linked), `ccPrimitives` pills, sibling-pattern link chips, optional Example footer.

## Summary

Replaces the prose-heavy disclosure that was buried below 5 other sections on each pattern page. New shape is a scannable reference card with bullets at top, real `<ul>` disc lists, semibold subheadings, plain technical voice, and zero in-repo identity leaks. Tier classification field removed entirely. Two parallel IDE blocks (`realizingInClaudeCode` + `realizingInCursor`) populated across all 25 patterns via research-grade verification.

- Schema, component, slug page reposition, References heading bump, test rewrite
- 25 pattern files: every block research-verified by per-pattern investigation subagents that web-fetched both Claude Code + Cursor docs to validate every cited primitive and URL
- Real fixes during verification: 3 fake `maxTurns`/`maxSteps` settings.json claims, 7 stale Cursor "Background Agents" → "Cloud Agents" URLs, 3 broken `cursor.com/docs/context/memories` URLs, broken `/context/mcp` URL, 5 bot-identity leaks, skill-name leaks in funnel-method's wider body, 2 stray PR-number references in lastChangeNotes

## Screenshots

Visual preview was iterated on `localhost:3000/agentic-design-patterns/<slug>` before commit. Verified across `context-engineering`, `tool-use-react`, `12-factor-agent`, and 6 others.

## Test plan

- [x] `pnpm test:unit` — 399/399 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors
- [x] Banned-token grep inside `realizingIn*` blocks — 0 hits across all 25 patterns
- [x] Every doc URL cited verified HTTP 200 (manually + via investigation subagents)
- [x] Spot-checked 9 random patterns at `localhost:3000/agentic-design-patterns/<slug>` — both IDE sections render correctly, sibling links navigate

## Plan reference

Closes #359. Editorial standard documented in the issue body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)