### PR TITLE
feat(posts): editorial hero — summary above, 4:1 lock, accent scanlines

### DIFF
--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -130,20 +130,21 @@ export default async function PostPage({ params }: PostPageProps) {
           )}
         </header>
 
+        {post.summary && (
+          <p className="text-lg leading-relaxed text-text-secondary">{post.summary}</p>
+        )}
+
         {isMediaObject(post.featuredImageLight) && isMediaObject(post.featuredImageDark) && (
-          <div className="my-8 -mx-4 sm:-mx-8 overflow-hidden rounded-sm">
+          <div className="hero-filter -mx-4 sm:-mx-8 overflow-hidden rounded-sm">
             <ThemeAwareHero
               light={post.featuredImageLight}
               dark={post.featuredImageDark}
               alt={post.title}
               sizes="(max-width: 768px) 100vw, (max-width: 1200px) 720px, 768px"
               focalPoint={post.focalPoint ?? undefined}
+              aspectRatio="4 / 1"
             />
           </div>
-        )}
-
-        {post.summary && (
-          <p className="text-lg leading-relaxed text-text-secondary">{post.summary}</p>
         )}
 
         <TextGlitch>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -698,6 +698,32 @@ a.card-scanline:active {
 }
 
 /* ──────────────────────────────────────────────
+   HERO FILTER
+   Theme-tinted scanline overlay for the hero image.
+   Inherits --accent so the wash flips from purple
+   (#7c3aed) to lavender (#b49cff) on theme toggle.
+   ────────────────────────────────────────────── */
+
+.hero-filter {
+  position: relative;
+}
+
+.hero-filter::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    0deg,
+    transparent 0px,
+    transparent 3px,
+    color-mix(in srgb, var(--accent) 12%, transparent) 3px,
+    color-mix(in srgb, var(--accent) 12%, transparent) 5px
+  );
+  z-index: 2;
+}
+
+/* ──────────────────────────────────────────────
    REDUCED MOTION
    Disable all animations and transitions when
    the user has reduced motion preference enabled.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -720,7 +720,9 @@ a.card-scanline:active {
     color-mix(in srgb, var(--accent) 12%, transparent) 3px,
     color-mix(in srgb, var(--accent) 12%, transparent) 5px
   );
-  z-index: 2;
+  /* Above .ascii-preview-img (z:2) so scanlines paint on top of the
+     loaded image, not behind a same-z DOM-order tiebreak. */
+  z-index: 3;
 }
 
 /* ──────────────────────────────────────────────

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -42,6 +42,7 @@ export function PostCard({
             className="transition-transform group-hover:scale-105"
             sizes="(max-width: 768px) 100vw, 720px"
             focalPoint={focalPoint}
+            aspectRatio="4 / 1"
           />
         </div>
       )}

--- a/src/components/ThemeAwareHero.tsx
+++ b/src/components/ThemeAwareHero.tsx
@@ -11,6 +11,7 @@ interface ThemeAwareHeroProps {
   className?: string;
   sizes?: string;
   focalPoint?: { x?: number | null; y?: number | null } | null;
+  aspectRatio?: string;
 }
 
 /**
@@ -83,6 +84,7 @@ export function ThemeAwareHero({
   className = "",
   sizes,
   focalPoint,
+  aspectRatio,
 }: ThemeAwareHeroProps) {
   if (!isMediaObject(light) || !light.url || !isMediaObject(dark) || !dark.url) {
     return null;
@@ -90,7 +92,7 @@ export function ThemeAwareHero({
 
   const width = light.width || 1200;
   const height = light.height || 630;
-  const aspectStyle = { aspectRatio: `${width} / ${height}` };
+  const aspectStyle = { aspectRatio: aspectRatio ?? `${width} / ${height}` };
   const imgStyle = focalPointStyle(focalPoint);
 
   const lightUsesPreview = hasUsablePreview(light);

--- a/tests/unit/components/ThemeAwareHero.test.tsx
+++ b/tests/unit/components/ThemeAwareHero.test.tsx
@@ -171,6 +171,20 @@ describe("ThemeAwareHero", () => {
     expect(wrapper.style.aspectRatio).toBe("1200 / 630");
   });
 
+  it("honors an explicit aspectRatio prop over the natural ratio", () => {
+    const { container } = render(
+      <ThemeAwareHero
+        light={lightMedia}
+        dark={darkMedia}
+        alt="Hero"
+        aspectRatio="4 / 1"
+      />
+    );
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.style.aspectRatio).toBe("4 / 1");
+  });
+
   it("falls back to the provided alt when a variant lacks alt text", () => {
     const lightNoAlt = makeMedia({ ...lightMedia, alt: "" });
     render(


### PR DESCRIPTION
## Diagrams

```mermaid
graph TB
  subgraph Detail["Post detail page"]
    H[header: title + date]
    S["summary p<br/>(reordered above hero)"]
    W["div.hero-filter<br/>position: relative"]
    B[body RichText]
  end
  subgraph Wrapper[".hero-filter"]
    TAH["ThemeAwareHero<br/>aspectRatio='4 / 1'"]
    AFT["::after pseudo<br/>repeating-linear-gradient<br/>color-mix(--accent 12%, transparent)"]
  end
  subgraph Listing["PostCard listing"]
    LH["ThemeAwareHero<br/>aspectRatio='4 / 1'"]
  end

  H --> S --> W --> B
  W --> TAH
  W --> AFT
```

## Summary

- Reorder summary above hero on post detail — image becomes supporting evidence rather than a header bar; `PageLayout`'s flex gap absorbs spacing so `my-8` on the hero wrapper is dropped.
- Lock hero to 4:1 in both detail and listing via a new optional `aspectRatio` prop on `ThemeAwareHero` (falls back to natural-image ratio for any non-opting caller).
- Add `.hero-filter` — theme-tinted scanline overlay using `color-mix(in srgb, var(--accent) 12%, transparent)` so the line color flips with `--accent` between modes (purple in light, lavender in dark) without any JS.

## Screenshots

N/A

## Test plan

- [x] `pnpm vitest run` — 28/28 pass (new test asserts the `aspectRatio` prop overrides the natural ratio)
- [x] `pnpm tsc --noEmit` — clean
- [x] Browser-driven smoke check via chrome-devtools-mcp at 1280×900 in both themes
- [x] Confirmed hero scanline `::after` paints in both modes; pointer-events: none
- [ ] (Follow-up) Audit existing posts whose featured images were authored for ~1.9:1 — some will need focal-point adjustment to keep subjects in the 4:1 window

## Plan reference

Out of plan — ad-hoc editorial redesign requested directly during a working session. The 4:1-on-listing risk (existing images not framed for it) was surfaced by pre-PR review and explicitly accepted by the author with audit-and-recrop tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)