### PR TITLE
fix(next-image): allow ?prefix=media on local media URLs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,6 +18,12 @@ const nextConfig: NextConfig = {
     deviceSizes: [640, 750, 828, 1080, 1200, 1920],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
     minimumCacheTTL: 31536000, // 1 year for immutable images
+    localPatterns: [
+      {
+        pathname: '/api/media/file/**',
+        search: '?prefix=media',
+      },
+    ],
     remotePatterns: process.env.GCS_BUCKET
       ? [
           {

--- a/next.config.ts
+++ b/next.config.ts
@@ -19,10 +19,10 @@ const nextConfig: NextConfig = {
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
     minimumCacheTTL: 31536000, // 1 year for immutable images
     localPatterns: [
-      {
-        pathname: '/api/media/file/**',
-        search: '?prefix=media',
-      },
+      // Pre-cloud-storage media docs (local-disk fallback, test seed): no query string.
+      { pathname: '/api/media/file/**', search: '' },
+      // Cloud-storage adapter (S3-compatible) appends ?prefix=media to media URLs.
+      { pathname: '/api/media/file/**', search: '?prefix=media' },
     ],
     remotePatterns: process.env.GCS_BUCKET
       ? [


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph media["Payload Media"]
        m1["S3-adapter URL: ?prefix=media"]
        m2["Legacy/local-disk URL: no query"]
    end
    subgraph next["next.config images.localPatterns (strict-allowlist)"]
        n1["{pathname: /api/media/file/**, search: ''}"]
        n2["{pathname: /api/media/file/**, search: '?prefix=media'}"]
    end

    m1 --> n2
    m2 --> n1
    n1 --> ok["200 — image served"]
    n2 --> ok
```

## Summary

- New uploads via Payload's S3-compatible cloud-storage plugin produce `url`s with a `?prefix=media` query string. Next.js refuses to serve `<Image>` from a local src whose query string is not whitelisted in `images.localPatterns`.
- Once `localPatterns` is defined, the allowlist is strict — there is **no implicit empty-search match**. Need both entries: one for legacy/local-disk media (no query string, including the seed-test-db fixtures and pre-S3-adapter prod docs) and one for S3-adapter media (`?prefix=media`).
- Triggered by attaching newly-uploaded heroes to the three published posts and observing every `/posts/*` page (and `/posts`) flip to 500. Heroes were rolled back to previous IDs to restore prod; this PR unblocks reattaching them.

## Screenshots

N/A — not UI. Config-only change to `next.config.ts`; no rendered output changes.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — Next image-config schema validation accepts both entries
- [x] CI E2E shard 4 (which seeds local-disk media without `GCS_BUCKET`) — must pass with the empty-search entry
- [ ] Post-deploy: re-attach the new hero pair (Media IDs 12/13, 14/15, 16/21) on the 3 published posts and confirm `/posts/*` returns 200 with the new heroes in the rendered srcSet

## Plan reference

Out of plan — incident response. Surfaced while attaching new hero images to the three published posts; the `?prefix=media` query string on Payload's S3-adapter URLs is now the standard URL shape for any future media upload, so this gate must be opened before more heroes (or any media) can be linked from posts.