### PR TITLE
refactor(posts): drop hero scanline overlay and saturation filter

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -699,9 +699,9 @@ a.card-scanline:active {
 
 /* ──────────────────────────────────────────────
    HERO FILTER
-   Theme-tinted scanline overlay for the hero image.
-   Inherits --accent so the wash flips from purple
-   (#7c3aed) to lavender (#b49cff) on theme toggle.
+   CRT-glass treatment for the hero image: convex
+   sheen + vignette on ::before, accent-tinted glow
+   halo via box-shadow.
    ────────────────────────────────────────────── */
 
 .hero-filter {
@@ -780,11 +780,6 @@ a.card-scanline:active {
     );
 }
 
-/* Counteract the scanline wash desaturating the underlying image. */
-.hero-filter img {
-  filter: saturate(1.7) contrast(1.08);
-}
-
 /* Layered overlay above the image:
    - Soft edge feather (inset shadow in page bg) dissolves the hero into
      the surrounding page instead of cutting out abruptly.
@@ -794,7 +789,7 @@ a.card-scanline:active {
      screens fall off in brightness at the corners as the glass curves
      away from the viewer.
    Painted on ::before so it composites above the absolutely-positioned
-   image but below the scanline ::after at z:3. */
+   image. */
 .hero-filter::before {
   content: "";
   position: absolute;
@@ -834,23 +829,6 @@ a.card-scanline:active {
       rgba(0, 0, 0, 0.65) 100%
     );
   z-index: 2;
-}
-
-.hero-filter::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background-image: repeating-linear-gradient(
-    0deg,
-    transparent 0px,
-    transparent 3px,
-    color-mix(in srgb, var(--accent) 12%, transparent) 3px,
-    color-mix(in srgb, var(--accent) 12%, transparent) 5px
-  );
-  /* Above .ascii-preview-img (z:2) so scanlines paint on top of the
-     loaded image, not behind a same-z DOM-order tiebreak. */
-  z-index: 3;
 }
 
 /* ──────────────────────────────────────────────


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  subgraph Before["Before (PR #367)"]
    A1[".hero-filter::before<br/>convex sheen + glow"] --> A2["img<br/>saturate(1.7) contrast(1.08)"]
    A2 --> A3[".hero-filter::after<br/>scanline overlay z:3"]
    A3 --> A4[Final hero]
  end
  subgraph After["After (this PR)"]
    B1[".hero-filter::before<br/>convex sheen + glow"] --> B2["img<br/>natural color"]
    B2 --> B4[Final hero]
  end
```

## Summary

- Partial revert of #367: the scanline `::after` overlay and the compensating `saturate(1.7)/contrast(1.08)` image filter were a coupled pair — scanlines added chroma wash, the filter fought back. Removing both restores natural image color.
- Kept: 21:9 lock, `rounded-2xl`, page-bg inset feather, four-stop convex sheen on `::before`, dark-mode convexity correction, three-ring accent glow halo, per-post `--hero-glow-light/--hero-glow-dark` tinting.
- Stale comments referencing the removed pieces tidied; section header now reads "CRT-glass treatment".

## Screenshots

Not captured in this dispatch — the change is purely subtractive on a visual treatment introduced in #367, so the visible effect is "image now renders without scanlines and without the saturation boost." Reviewer can drive the post-detail hero locally to confirm; happy to attach captures if requested.

## Test plan

- [x] `pnpm lint` — clean (no JS/TS touched; CSS-only diff)
- [ ] `pnpm build` — relies on CI
- [ ] Browser-driven smoke at mobile + desktop viewports — deferred (see Screenshots)

## Plan reference

Out of plan — visual dial-back on #367; user requested removal of scanlines + saturation filter while keeping the rest of the CRT-glass treatment.