### PR TITLE
fix(nav): mobile menu links — elevate site-frame above backdrop

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -95,8 +95,8 @@ export default function FrontendLayout({
           <ScrollToTop />
           <TextureOverlay />
           <ScrollPillNav />
-          <div className="site-frame mx-auto my-4 flex min-h-[calc(100vh-2rem)] max-w-frame flex-col rounded-sm border border-border sm:my-6 sm:min-h-[calc(100vh-3rem)]">
-            <header className="relative flex items-center justify-between border-b border-border px-4 py-3 sm:px-6">
+          <div className="site-frame relative z-40 mx-auto my-4 flex min-h-[calc(100vh-2rem)] max-w-frame flex-col rounded-sm border border-border sm:my-6 sm:min-h-[calc(100vh-3rem)]">
+            <header className="relative z-40 flex items-center justify-between border-b border-border px-4 py-3 sm:px-6">
               <Link href="/" className="font-mono text-brand font-semibold tracking-tight text-accent lowercase focus-ring">
                 d-n
               </Link>


### PR DESCRIPTION
## Diagrams

N/A — single-CSS-class fix.

## Summary

- The mobile menu's portal'd backdrop (z-30 at \`<body>\`) was intercepting link clicks inside the in-frame hamburger panel.
- Root cause is the existing \`filter: brightness(1)\` on \`.site-frame\` (theming) — non-\`none\` filter creates a CSS stacking context, which caps all descendants at the parent's stacking level. With \`site-frame\` at z-auto, the panel's z-40 was being clamped to body-level z-auto, below the portal'd backdrop's z-30.
- Fix: \`relative z-40\` on \`.site-frame\` (and belt-and-suspenders \`z-40\` on \`<header>\`) so the in-frame content's stacking layer in body sits above the backdrop.

## Screenshots

N/A — not UI, single utility class addition (no visual change at rest).

## Test plan

- [x] Browser-driven verify at 375px: tap hamburger in in-frame header → panel opens → tap "About" → navigates to /about (was: tap was intercepted by backdrop)
- [x] Browser-driven verify at 375px: scroll to reveal pill → tap pill hamburger → tap "About" → navigates (no regression)
- [x] \`document.elementFromPoint\` audit on link center returns the \`<a>\`, not the backdrop
- [x] \`npx tsc --noEmit\` clean

## Plan reference

Out of plan — bug surfaced immediately after PR #374 merged. The backdrop portal was added in #374 to escape the pill's backdrop-filter containing block; this PR addresses the secondary stacking interaction that the portal exposed for the in-frame variant.

Closes the regression reported by Julian after the #374 merge.