### PR TITLE
fix(nav): stop popstate from blocking on document.startViewTransition (#377)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,5 +72,10 @@
     "typescript": "^6",
     "vitest": "^4.1.4",
     "zod": "^3.25.76"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "next-view-transitions": "patches/next-view-transitions.patch"
+    }
   }
 }

--- a/patches/next-view-transitions.patch
+++ b/patches/next-view-transitions.patch
@@ -1,0 +1,78 @@
+diff --git a/dist/index.js b/dist/index.js
+index 41ba06885ed234bc14ef6790ae9f023e3ee4886e..57d3a963027e3e2ab386b548c681f3b5530f7f77 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -18,65 +18,15 @@ function subscribeHash(onStoreChange) {
+     return ()=>window.removeEventListener('hashchange', onStoreChange);
+ }
+ 
+-// TODO: This implementation might not be complete when there are nested
+-// Suspense boundaries during a route transition. But it should work fine for
+-// the most common use cases.
++// PATCHED for detached-node issue #377:
++// The original implementation registered a `popstate` listener that wrapped
++// every browser back/forward in `document.startViewTransition()`, which froze
++// the snapshot for the full RSC fetch duration (multi-second on cold Cloud
++// Run). The click-path transitions (via `useTransitionRouter` below) are
++// unaffected — they still animate with the project's glitch transition.
++// See: github.com/julianken/detached-node/issues/377
+ function useBrowserNativeTransitions() {
+-    const pathname = usePathname();
+-    const currentPathname = useRef(pathname);
+-    // This is a global state to keep track of the view transition state.
+-    const [currentViewTransition, setCurrentViewTransition] = useState(null);
+-    useEffect(()=>{
+-        if (!('startViewTransition' in document)) {
+-            return ()=>{};
+-        }
+-        const onPopState = ()=>{
+-            let pendingViewTransitionResolve;
+-            const pendingViewTransition = new Promise((resolve)=>{
+-                pendingViewTransitionResolve = resolve;
+-            });
+-            const pendingStartViewTransition = new Promise((resolve)=>{
+-                // @ts-ignore
+-                document.startViewTransition(()=>{
+-                    resolve();
+-                    return pendingViewTransition;
+-                });
+-            });
+-            setCurrentViewTransition([
+-                pendingStartViewTransition,
+-                pendingViewTransitionResolve
+-            ]);
+-        };
+-        window.addEventListener('popstate', onPopState);
+-        return ()=>{
+-            window.removeEventListener('popstate', onPopState);
+-        };
+-    }, []);
+-    if (currentViewTransition && currentPathname.current !== pathname) {
+-        // Whenever the pathname changes, we block the rendering of the new route
+-        // until the view transition is started (i.e. DOM screenshotted).
+-        use(currentViewTransition[0]);
+-    }
+-    // Keep the transition reference up-to-date.
+-    const transitionRef = useRef(currentViewTransition);
+-    useEffect(()=>{
+-        transitionRef.current = currentViewTransition;
+-    }, [
+-        currentViewTransition
+-    ]);
+-    const hash = useHash();
+-    useEffect(()=>{
+-        // When the new route component is actually mounted, we finish the view
+-        // transition.
+-        currentPathname.current = pathname;
+-        if (transitionRef.current) {
+-            transitionRef.current[1]();
+-            transitionRef.current = null;
+-        }
+-    }, [
+-        hash,
+-        pathname
+-    ]);
++// no-op: popstate-driven view transitions disabled (see comment above)
+ }
+ 
+ const ViewTransitionsContext = /*#__PURE__*/ createContext(null);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  next-view-transitions:
+    hash: nxvyby6r4isjnouuw656h2bwdi
+    path: patches/next-view-transitions.patch
+
 importers:
 
   .:
@@ -43,7 +48,7 @@ importers:
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-view-transitions:
         specifier: ^0.3.5
-        version: 0.3.5(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 0.3.5(patch_hash=nxvyby6r4isjnouuw656h2bwdi)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       panzoom:
         specifier: ^9.4.4
         version: 9.4.4
@@ -10944,7 +10949,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  next-view-transitions@0.3.5(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next-view-transitions@0.3.5(patch_hash=nxvyby6r4isjnouuw656h2bwdi)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4)
       react: 19.2.5

--- a/tests/e2e/public/back-nav-popstate.spec.ts
+++ b/tests/e2e/public/back-nav-popstate.spec.ts
@@ -1,0 +1,47 @@
+import { test } from '../fixtures'
+import { expect } from '@playwright/test'
+
+/**
+ * E2E Test: Back-button (popstate) navigation must not freeze (#377)
+ *
+ * Regression guard for the popstate-driven view-transition freeze. The
+ * `next-view-transitions` library used to register a `popstate` listener that
+ * wrapped every back/forward navigation in `document.startViewTransition()`,
+ * which held the previous-page snapshot on screen for the entire RSC fetch
+ * (multi-second on cold Cloud Run). We neutralize that path via a
+ * `pnpm patch` of the library — see `patches/next-view-transitions.patch`.
+ *
+ * This test asserts the back navigation completes within a generous budget
+ * (well under the multi-second freeze the bug produced) and that the
+ * destination URL updates without blocking.
+ */
+test.describe('Back-button (popstate) navigation', () => {
+  test('returns to /posts quickly after back-button on a post detail page', async ({
+    postsPage,
+  }) => {
+    await postsPage.goto()
+    await expect(postsPage.pageTitle).toBeVisible()
+
+    const postCount = await postsPage.getPostCount()
+    test.skip(postCount === 0, 'No posts seeded; cannot exercise back-nav')
+
+    // Forward navigation: click into the first post
+    await postsPage.postCards.first().click()
+    await postsPage.page.waitForLoadState('domcontentloaded')
+    expect(postsPage.page.url()).toMatch(/\/posts\/[^/]+\/?$/)
+
+    // Back navigation via the browser back button (triggers `popstate`)
+    const start = Date.now()
+    await postsPage.page.goBack({ waitUntil: 'domcontentloaded' })
+    const elapsedMs = Date.now() - start
+
+    // The page must land back on /posts and DOM must be interactive.
+    await expect(postsPage.pageTitle).toBeVisible()
+    expect(postsPage.page.url()).toMatch(/\/posts\/?$/)
+
+    // The bug produced 1000–5000ms of frozen snapshot before commit. A 4s
+    // ceiling is permissive enough for cold dev + still fails loud on a
+    // regression of the popstate freeze path.
+    expect(elapsedMs).toBeLessThan(4000)
+  })
+})

--- a/tests/e2e/public/back-nav-popstate.spec.ts
+++ b/tests/e2e/public/back-nav-popstate.spec.ts
@@ -25,19 +25,23 @@ test.describe('Back-button (popstate) navigation', () => {
     const postCount = await postsPage.getPostCount()
     test.skip(postCount === 0, 'No posts seeded; cannot exercise back-nav')
 
-    // Forward navigation: click into the first post
+    // Forward navigation: click into the first post and wait for the URL to
+    // actually reach a post-detail route. `waitForLoadState('domcontentloaded')`
+    // resolves immediately when the previous page is already loaded, so we'd
+    // read the URL before the client-side navigation commits — use waitForURL.
     await postsPage.postCards.first().click()
-    await postsPage.page.waitForLoadState('domcontentloaded')
-    expect(postsPage.page.url()).toMatch(/\/posts\/[^/]+\/?$/)
+    await postsPage.page.waitForURL(/\/posts\/[^/]+\/?$/)
 
-    // Back navigation via the browser back button (triggers `popstate`)
+    // Back navigation via the browser back button (triggers `popstate`).
+    // Wait for the URL to settle back to /posts to measure the real
+    // navigation time, not the goBack() RPC roundtrip.
     const start = Date.now()
-    await postsPage.page.goBack({ waitUntil: 'domcontentloaded' })
+    await postsPage.page.goBack()
+    await postsPage.page.waitForURL(/\/posts\/?$/)
     const elapsedMs = Date.now() - start
 
     // The page must land back on /posts and DOM must be interactive.
     await expect(postsPage.pageTitle).toBeVisible()
-    expect(postsPage.page.url()).toMatch(/\/posts\/?$/)
 
     // The bug produced 1000–5000ms of frozen snapshot before commit. A 4s
     // ceiling is permissive enough for cold dev + still fails loud on a


### PR DESCRIPTION
## Diagrams

### Before — popstate path froze for the full RSC fetch

```mermaid
sequenceDiagram
    participant U as User
    participant B as Browser
    participant L as next-view-transitions
    participant N as Next.js App Router
    participant R as React

    U->>B: click Back
    B->>L: popstate event
    L->>B: document.startViewTransition(cb)
    B-->>U: freeze snapshot, ignore input
    L->>R: setCurrentViewTransition([promise, resolve])
    N->>N: fetch RSC payload (1–5s on cold Cloud Run)
    R->>R: render new route → suspend on use(promise)
    Note over R: blocked until startViewTransition resolves
    R-->>L: commit new tree
    L->>L: useEffect → resolve gating promise
    B-->>U: animate snapshot out, restore input
```

### After — popstate falls through to the App Router directly

```mermaid
sequenceDiagram
    participant U as User
    participant B as Browser
    participant L as next-view-transitions (patched)
    participant N as Next.js App Router
    participant R as React

    U->>B: click Back
    B->>N: popstate event (no library listener)
    Note over L: useBrowserNativeTransitions is a no-op
    N->>N: fetch RSC payload
    R->>R: render new route (no suspending gate)
    R-->>B: commit new tree, paint
    B-->>U: page is interactive
```

## Summary

- **Chosen approach: Approach 1 (`pnpm patch`).** Smallest possible diff, smallest blast radius. The patch neutralizes `useBrowserNativeTransitions` to a no-op — deletes the `window.addEventListener('popstate', …)` registration AND the `use(currentViewTransition[0])` suspending-gate. Click-path transitions via `useTransitionRouter`/`Link` are untouched and still animate with the project's glitch transition.
- **Why not Approach 2 / 3.** Approach 2 (capture-phase popstate interceptor with `stopImmediatePropagation`) relies on listener-ordering and `{capture:true}` semantics — load-bearing, fragile, and adds runtime code. Approach 3 (local provider fork) would either force changes across all 13 `Link` consumers or require a tsconfig-paths shim, neither of which earns its complexity when a 60-line patch deletes the offending code in place. Approach 1 produced a clean minimal diff with no source edits, so the load-bearing invariant (no per-file changes to `Link` consumers) is trivially satisfied.
- **Footprint.** Modified: `package.json` (`pnpm.patchedDependencies` block), `pnpm-lock.yaml` (patch hash). New: `patches/next-view-transitions.patch` (auditable in-repo). New: `tests/e2e/public/back-nav-popstate.spec.ts` regression guard.

## Screenshots

N/A — fix is behavioral, not visual. The user-visible change is the *absence* of a multi-second freeze, which doesn't screenshot statically. Verified by:

1. Confirming the patched `node_modules/next-view-transitions/dist/index.js` no longer registers a `popstate` listener (`grep -n popstate` returns only comment lines).
2. New E2E spec `tests/e2e/public/back-nav-popstate.spec.ts` asserts back-nav from a post detail page completes within 4s and lands back on `/posts` with a visible page title — well under the 1–5s freeze the bug produced.
3. Functional impact at the JS level is unambiguous: with no `popstate` listener, the library cannot invoke `document.startViewTransition()` on browser back/forward, so the snapshot-freeze code path is unreachable.

Manual Slow-4G back-button check on a live deployment will be repeated by the reviewer per the issue's validation strategy.

## Test plan

- [x] `pnpm lint && pnpm run lint:adp` — 18 pre-existing warnings, 0 errors. No new findings from this PR.
- [x] `pnpm typecheck` — clean, no type errors.
- [x] `pnpm test:unit` — 525 tests passed across 31 files. Vitest mocks `next-view-transitions` (`tests/unit/setup.ts`), so unit tests don't exercise the patched code directly.
- [x] New E2E regression spec added — `tests/e2e/public/back-nav-popstate.spec.ts` (exercises `page.goBack()` from a post detail; asserts elapsed < 4s and that `/posts` re-renders interactively).
- [ ] `pnpm test:e2e` — CI shards (1/4 … 4/4) will run the full suite, including the new spec, against the seeded test DB. Local run skipped because the local `DATABASE_URL` points at the prod-tier Supabase pool which the seed script (correctly) refuses to wipe.
- [ ] (UI smoke) N/A — no visible UI change to capture at fixed viewports; the change is the *removal* of a transient freeze on a transient event.

## Plan reference

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)