### PR TITLE
fix(nav): remove @view-transition navigation:auto duplicating popstate freeze

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -398,10 +398,6 @@ body {
    get instant navigation with no degradation.
    ────────────────────────────────────────────── */
 
-@view-transition {
-  navigation: auto;
-}
-
 main {
   view-transition-name: main-content;
 }


### PR DESCRIPTION
## Diagrams

N/A — three-line CSS at-rule deletion; the mechanism (two stacked view-transition pathways on popstate, only one removed by this PR) is fully explained in the issue body. See #376.

## Summary

- One slice of the four-ticket back-button-freeze fix. Removes the `@view-transition { navigation: auto; }` at-rule from `src/app/globals.css`, eliminating Next.js 16's browser-native MPA-style same-document view-transition pathway.
- That pathway was redundant with — and on popstate, stacking against — the JS `next-view-transitions` provider's `document.startViewTransition()` call, producing a duplicate freeze layer on back navigation.
- The `::view-transition-old(main-content)` and `::view-transition-new(main-content)` keyframe rules immediately following the deletion are preserved; they remain in use by the JS library's transitions on forward `Link` clicks. The primary popstate-handler fix lands in #377.

## Screenshots

N/A — CSS rule removal with no observable forward-nav UX change. Forward nav still triggers the glitch animation via the JS provider; the only behavioral delta is on back-button popstate, where one redundant transition layer is gone. Verified by E2E and manual back-button drive.

## Test plan

- [x] `pnpm lint && pnpm test` — green (0 errors, 18 pre-existing warnings; 525/525 unit tests pass)
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm test:e2e` — 64/65 pass; the 1 failure (`posts-listing.spec.ts › Multiple Posts Display › formatted date and summary`) is a pre-existing timezone-dependent flake (seed uses `new Date('2026-01-25').toISOString()`, which renders "Jan 24, 2026" in PST). Reproduced on `main` without this PR's diff — unrelated to a CSS at-rule deletion.
- [x] Manual back-button check on dev: clicking back from a post page does not introduce any new visible freeze. Forward nav glitch animation still fires.
- [ ] New unit / integration tests added — N/A, deletion only
- [ ] New Playwright e2e spec added — N/A, no new user-visible behavior

## Plan reference

Closes #376 · part of the four-ticket back-button-freeze series (#377 root-cause popstate handler, #378 router cache + config cleanup, #379 perf narrow — blocked on this ticket)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)