### PR TITLE
chore(config): drop experimental.viewTransition (defer staleTimes) (#378)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,7 +9,12 @@ const nextConfig: NextConfig = {
   experimental: {
     // Optimize package imports to reduce bundle size
     optimizePackageImports: ['@payloadcms/richtext-lexical'],
-    viewTransition: true,
+    // Client-side App Router cache freshness windows (seconds).
+    // Docs: https://nextjs.org/docs/app/api-reference/config/next-config-js/staleTimes
+    staleTimes: {
+      dynamic: 30, // opts back into Next 14-era 30s caching (current default is 0)
+      static: 300, // current Next 16.2 default; explicit for clarity
+    },
   },
 
   // Image optimization configuration

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,12 +9,6 @@ const nextConfig: NextConfig = {
   experimental: {
     // Optimize package imports to reduce bundle size
     optimizePackageImports: ['@payloadcms/richtext-lexical'],
-    // Client-side App Router cache freshness windows (seconds).
-    // Docs: https://nextjs.org/docs/app/api-reference/config/next-config-js/staleTimes
-    staleTimes: {
-      dynamic: 30, // opts back into Next 14-era 30s caching (current default is 0)
-      static: 300, // current Next 16.2 default; explicit for clarity
-    },
   },
 
   // Image optimization configuration


### PR DESCRIPTION
## Diagrams

N/A — one-line config edit; removes `experimental.viewTransition: true` from `next.config.ts`.

## Summary

- **Removes `experimental.viewTransition: true`:** that flag enables React's `<ViewTransition>` component integration. Nothing in `src/` imports `ViewTransition` from `react` (verified by grep) — the codebase uses the third-party `next-view-transitions` library exclusively. The experimental flag was dead weight at best and a conflicting wrapper layer at worst.
- **`staleTimes` deferred to a follow-up.** First commit on this branch added `experimental.staleTimes: { dynamic: 30, static: 300 }`. CI then deterministically failed `tests/e2e/admin/auth/login.spec.ts:100 — "should persist session across page refreshes"` (twice, across rerun). The 30s dynamic client-cache window appears to interact with Payload admin's session refresh flow. The session-persistence test passes on plain `main`; revert restored green. Tracking the staleTimes investigation as a follow-up issue.

## Screenshots

N/A — config-only change, no UI affected.

## Plan reference

Closes #378 (partial — staleTimes deferred per above)

## Verification

- `pnpm lint` — 0 errors (18 pre-existing warnings, unchanged)
- `pnpm typecheck` — clean
- `pnpm test:unit` — 525/525 pass
- `pnpm build` — succeeds, no warnings about the removed experimental flag
- E2E shards 1–4 — covered by CI on this PR

## Five-Level Explanation

- **One word:** Cleanup.
- **One sentence:** Remove an experimental Next.js flag the codebase doesn't use.
- **One paragraph:** `experimental.viewTransition: true` in `next.config.ts` enables Next.js 16's experimental integration with React's `<ViewTransition>` component (`import { ViewTransition } from 'react'`). Nothing in `src/` imports that React component — the codebase wraps navigations with the third-party `next-view-transitions` library, unrelated to this flag. Removing it eliminates a conflicting/redundant wrapper layer.
- **One page:** This is the "config cleanup" slice of the four-ticket back-button-freeze fix. The original ticket also asked for `experimental.staleTimes: { dynamic: 30 }` to keep dynamic-route RSC payloads in the client router cache for 30s on back-navigation. That change deterministically failed an admin-auth E2E test (`should persist session across page refreshes`), so it was reverted and is deferred to a separate investigation. The net change here is a one-line deletion that removes the `viewTransition: true` key.
- **Deep dive:** `experimental.viewTransition` per the Next.js docs explicitly enables the React `<ViewTransition>` component shipped in React 19. The flag does not intercept Next.js navigations on its own — it surfaces the React primitive for opt-in use in your component tree. `grep -rn 'from "react"' src/ | grep ViewTransition` returns nothing. Removal is safe. The third-party `next-view-transitions` library is independent of this flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
