### PR TITLE
perf(view-transitions): narrow main-content snapshot to inner wrapper (#379)

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -114,7 +114,9 @@ export default function FrontendLayout({
                 </div>
               </div>
             </header>
-            <main id="main-content" className="flex-1 px-4 py-8 sm:px-6 lg:px-8">{children}</main>
+            <main id="main-content" className="flex-1 px-4 py-8 sm:px-6 lg:px-8">
+              <div className="route-content">{children}</div>
+            </main>
             <StatusBar />
           </div>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -398,7 +398,7 @@ body {
    get instant navigation with no degradation.
    ────────────────────────────────────────────── */
 
-main {
+.route-content {
   view-transition-name: main-content;
 }
 


### PR DESCRIPTION
## Diagrams

Before this PR the view-transition snapshot named `main-content` covered the entire `<main>` padding box. After this PR it covers only an inner `.route-content` wrapper — same content area, no padding, smaller snapshot, no compositor layer for `<main>` itself.

```mermaid
graph TD
    subgraph Before["Before — snapshot scope = main"]
        M1["main#main-content<br/>(view-transition-name)<br/>flex-1 px-4 py-8"]
        M1 --> C1["{children}"]
    end

    subgraph After["After — snapshot scope = route-content"]
        M2["main#main-content<br/>flex-1 px-4 py-8"]
        M2 --> R2[".route-content<br/>(view-transition-name)"]
        R2 --> C2["{children}"]
    end

    style M1 fill:#fbb,stroke:#900
    style R2 fill:#bfb,stroke:#090
```

## Summary

- Snapshot scope was `<main>` including its padding box and full-width flex container; narrowing it to an inner wrapper shrinks the captured raster and avoids a compositor layer for `<main>`'s own background during the glitch transition.
- Mandated approach (b) per the issue: a wrapper `<div className="route-content">` in `(frontend)/layout.tsx` plus a CSS selector swap in `globals.css`. The skip-link target (`id="main-content"`) stays on `<main>` so a11y is unchanged.

## Screenshots

N/A — perf-only; forward-nav glitch transition is visually unchanged. Verified manually by clicking a Link on dev.

## Test plan

- [x] `pnpm lint` — 0 errors (18 pre-existing warnings)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 525/525 passing
- [ ] `pnpm test:e2e` — **could not run locally**: `seed-test-db` refuses to wipe the Supabase production-tier pooler that `.env.local` points at, and there is no local Postgres in this worktree. Relying on CI's seeded E2E matrix (Shards 1–4) which the issue's AC depends on.
- [x] Manual DOM check on `pnpm dev`:
  - `GET /` → `<main id="main-content" ...><div class="route-content"><div class="opacity-0 ">…` (FadeReveal as inner mount-animation wrapper, unchanged nesting)
  - `GET /posts` → `<main id="main-content" ...><div class="route-content"><…><div class="glitch-reveal …">` (posts mount animation, unchanged)
  - Skip-link still anchors to `#main-content` on `<main>`.

## Plan reference

Closes #379

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)