### PR TITLE
fix(seo): immediate EEAT and crawl-surface fixes

### DIFF
--- a/src/app/(frontend)/agentic-design-patterns/[slug]/opengraph-image.tsx
+++ b/src/app/(frontend)/agentic-design-patterns/[slug]/opengraph-image.tsx
@@ -24,6 +24,10 @@ export const alt = "Agentic design pattern reference card";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
+const SITE_DOMAIN = process.env.NEXT_PUBLIC_SERVER_URL
+  ? new URL(process.env.NEXT_PUBLIC_SERVER_URL).hostname
+  : "detached-node.dev";
+
 // Pre-bake one OG image per non-archived pattern at build time.
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
   return getPatternSlugs().map((slug) => ({ slug }));
@@ -128,7 +132,7 @@ export default async function OgImage({ params }: OgImageProps) {
           }}
         >
           <span>Agentic Design Patterns</span>
-          <span>detached-node.com</span>
+          <span>{SITE_DOMAIN}</span>
         </div>
       </div>
     ),

--- a/src/app/(frontend)/agentic-design-patterns/[slug]/page.tsx
+++ b/src/app/(frontend)/agentic-design-patterns/[slug]/page.tsx
@@ -116,15 +116,9 @@ export default async function PatternSatellitePage({
             />
             <ReferencesSection pattern={pattern} />
             {overviewLead && (
-              <DisclosureSection
-                id="overview-discussion"
-                label="Overview · 1-paragraph mechanism"
-                defaultOpen
-              >
-                <p className="text-base leading-7 text-text-secondary [text-wrap:pretty]">
-                  {overviewLead}
-                </p>
-              </DisclosureSection>
+              <p className="text-base leading-7 text-text-secondary [text-wrap:pretty]">
+                {overviewLead}
+              </p>
             )}
             {backgroundParagraphs.length > 0 && (
               <DisclosureSection

--- a/src/app/(frontend)/agentic-design-patterns/opengraph-image.tsx
+++ b/src/app/(frontend)/agentic-design-patterns/opengraph-image.tsx
@@ -22,6 +22,10 @@ export const alt = "Agentic Design Patterns reference catalog";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
+const SITE_DOMAIN = process.env.NEXT_PUBLIC_SERVER_URL
+  ? new URL(process.env.NEXT_PUBLIC_SERVER_URL).hostname
+  : "detached-node.dev";
+
 export default async function OgImage() {
   const subtitle = "A reference catalog of agentic AI design patterns.";
   const footerStat = "5 layers · reference catalog";
@@ -106,7 +110,7 @@ export default async function OgImage() {
           }}
         >
           <span>{footerStat}</span>
-          <span>detached-node.com</span>
+          <span>{SITE_DOMAIN}</span>
         </div>
       </div>
     ),

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -10,19 +10,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: siteUrl,
       lastModified: new Date(),
       changeFrequency: "weekly",
-      priority: 1,
     },
     {
       url: `${siteUrl}/posts`,
       lastModified: new Date(),
       changeFrequency: "daily",
-      priority: 0.9,
     },
     {
       url: `${siteUrl}/about`,
       lastModified: new Date(),
       changeFrequency: "monthly",
-      priority: 0.8,
     },
   ];
 
@@ -32,13 +29,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: `${siteUrl}/agentic-design-patterns`,
       lastModified: new Date(),
       changeFrequency: "weekly",
-      priority: 0.95,
     },
     {
       url: `${siteUrl}/agentic-design-patterns/changelog`,
       lastModified: new Date(),
       changeFrequency: "weekly",
-      priority: 0.7,
     },
   ];
   const adpSatelliteRoutes: MetadataRoute.Sitemap = PATTERNS.filter(
@@ -47,7 +42,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     url: `${siteUrl}/agentic-design-patterns/${p.slug}`,
     lastModified: new Date(p.dateModified),
     changeFrequency: "monthly" as const,
-    priority: 0.85,
   }));
 
   // Fetch published posts
@@ -56,7 +50,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     url: `${siteUrl}/posts/${post.slug}`,
     lastModified: new Date(post.updatedAt),
     changeFrequency: "weekly" as const,
-    priority: 0.7,
   }));
 
   // Fetch published pages
@@ -67,7 +60,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: `${siteUrl}/${page.slug}`,
       lastModified: new Date(page.updatedAt),
       changeFrequency: "monthly" as const,
-      priority: 0.6,
     }));
 
   return [

--- a/src/components/agentic-patterns/PatternHeader.tsx
+++ b/src/components/agentic-patterns/PatternHeader.tsx
@@ -12,6 +12,7 @@
 
 import type { LayerId, Pattern } from "@/data/agentic-design-patterns/types";
 import { LAYERS } from "@/data/agentic-design-patterns/layers";
+import { formatDate } from "@/lib/formatting";
 
 interface PatternHeaderProps {
   pattern: Pattern;
@@ -49,6 +50,12 @@ export function PatternHeader({ pattern }: PatternHeaderProps) {
           {pattern.oneLineSummary}
         </p>
       )}
+      <time
+        dateTime={pattern.dateModified}
+        className="text-sm tracking-[0.03em] text-text-tertiary"
+      >
+        Last edited {formatDate(pattern.dateModified)}
+      </time>
     </header>
   );
 }

--- a/src/lib/schema/config.ts
+++ b/src/lib/schema/config.ts
@@ -41,6 +41,6 @@ export const AUTHOR_CONFIG = {
   // sameAs: external verifiable profiles for entity disambiguation.
   // GitHub org is the one confirmed external reference at launch.
   // Add LinkedIn/Twitter/etc. when/if disclosed.
-  sameAs: ["https://github.com/detached-node"] as string[],
+  sameAs: ["https://github.com/julianken"] as string[],
   description: "Writing on agentic AI in software engineering.",
 } as const;

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -15,6 +15,8 @@ export const siteDescription =
 
 export const siteAuthor = "detached-node";
 
+export const CONTACT_EMAIL = "julian.kennon.d@gmail.com";
+
 export const siteKeywords = [
   "agentic AI",
   "autonomous systems",


### PR DESCRIPTION
## Summary

Six small independent fixes that stop active EEAT damage and remove crawl-surface bugs. Identity-neutral (no Tier C dependencies).

## Changes

1. **Fixed broken `sameAs` URL** — `src/lib/schema/config.ts:44`: `github.com/detached-node` (HTTP 404) -> `github.com/julianken` (HTTP 200). A broken external link in schema is worse than no link — it signals an unverifiable entity to Google's entity graph and LLM citation pipelines.
2. **Removed hardcoded `detached-node.com`** in two OG image footers (`opengraph-image.tsx` line 109 and `[slug]/opengraph-image.tsx` line 131). Now derives from `process.env.NEXT_PUBLIC_SERVER_URL` with `.dev` fallback.
3. **Lifted `overviewLead` out of `<DisclosureSection>`** in pattern pages. The first paragraph of pattern body content was inside an expanded `<details>` element; `<details>` is in the DOM and Googlebot indexes it, but non-Google AI crawlers (GPTBot, ClaudeBot, PerplexityBot) have inconsistent rendering of collapsed content. Plain `<p>` eliminates the ambiguity.
4. **Removed `priority` from sitemap** (Google ignores since 2017 per John Mueller, Search Central). Keeps `lastModified` and `changeFrequency`.
5. **Added `CONTACT_EMAIL`** to `src/lib/site-config.ts` — used by Category E's RSS feed upgrade and future schema work.
6. **Surfaced visible `dateModified`** on pattern pages — already in JSON-LD, now rendered as `<time>` for human freshness signal.

## Test plan

- [x] `pnpm lint` (including `lint:adp`)
- [x] `pnpm test:unit`
- [x] `pnpm typecheck`
- [ ] CI E2E (will run on PR)
- [ ] Visual check via `pnpm dev` of a representative pattern page (confirmed overviewLead renders as plain `<p>` outside details)

## Coordination

- The `sameAs` fix in this PR is a strict subset of issue #388 (Tier C migration), which replaces the entire `AUTHOR_CONFIG`. If both merge, #388 wins via three-way merge of the array (1-item -> 2-item). If #388 merges first, this PR's `sameAs` change becomes a no-op on rebase.

Closes #387