### PR TITLE
chore(repo): rewrite README; draft profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,105 @@
-# Detached Node
+# detached-node
 
-A tech blog exploring modern agentic AI workflows, autonomous systems, and the philosophy of machine intelligence.
+A reference catalog of agentic AI design patterns for software engineers building with LLMs. The live site is [detached-node.dev](https://detached-node.dev). This repo is the source.
 
-**Live site:** [detached-node.dev](https://detached-node.dev)
-
-## Architecture
-
-| Layer | Technology |
-|-------|-----------|
-| Framework | Next.js 16 (App Router) |
-| Language | TypeScript (strict mode) |
-| Styling | Tailwind CSS 4 |
-| CMS | Payload CMS 3 |
-| Database | PostgreSQL via Supabase |
-| Media | Google Cloud Storage |
-| Rate Limiting | Upstash Redis (with in-memory fallback) |
-| Deployment | Google Cloud Run |
-| Testing | Vitest (unit) + Playwright (e2e) |
-
-### Project Structure
+## What's in this repo
 
 ```
 src/
 ├── app/
-│   ├── (frontend)/                    # Public-facing routes
-│   │   ├── page.tsx                    # Home
-│   │   ├── posts/                      # Post listing + detail ([slug])
-│   │   ├── about/                      # Static about page
-│   │   └── agentic-design-patterns/    # Hub + [slug] satellites + changelog
-│   └── (payload)/                      # CMS admin routes
-├── components/            # Shared React components
-├── lib/                   # Utilities, config, schema generators
-└── collections/           # Payload CMS collection definitions
+│   ├── (frontend)/                 # Public site
+│   │   ├── agentic-design-patterns/   # 24-pattern catalog (hub + satellites)
+│   │   ├── posts/                  # Essays
+│   │   └── about/
+│   └── (payload)/                  # Payload CMS admin
+├── data/agentic-design-patterns/   # Pattern source-of-truth (one TS file per pattern)
+├── lib/schema/                     # JSON-LD generators (BlogPosting, TechArticle, Person, etc.)
+├── collections/                    # Payload CMS collection definitions
+└── components/                     # Site UI
+
+docs/                               # Project docs (design system, deployment, SEO strategy)
+PROJECT_BRIEF.md                    # Goals, non-goals, phase roadmap
+CONTENT_MODEL.md                    # Payload collection field definitions
+AGENTS.md                           # Conventions for AI-assisted contributors
+SITEMAP.md                          # Public route inventory
 ```
 
-### Key Design Decisions
+## Patterns covered
 
-- **Route groups** separate the public site `(frontend)` from the CMS admin `(payload)`, sharing a Next.js app without coupling concerns.
-- **JSON-LD structured data** is generated per page via schema utilities in `src/lib/schema/`, supporting BlogPosting, BreadcrumbList, WebSite, and Person entities.
-- **Rate limiting** uses a strategy pattern — Upstash Redis in production, an in-memory implementation in development — so the app runs without external dependencies locally.
-- **Payload CMS** runs embedded within the Next.js app (no separate server), using the Local API for content seeding and server-side queries.
+### Layer 1 — Topology / control flow
+
+#### Single-agent
+
+- **[Prompt Chaining](https://detached-node.dev/agentic-design-patterns/prompt-chaining)** — Decomposes a task into a fixed chain of LLM calls, each consuming the previous output.
+- **[Routing](https://detached-node.dev/agentic-design-patterns/routing)** — Classifies the input, then forwards it to the matching prompt, model, or sub-agent.
+- **[Parallelization](https://detached-node.dev/agentic-design-patterns/parallelization)** — Fires N LLM calls in parallel and reduces them with a deterministic aggregator.
+- **[Planning](https://detached-node.dev/agentic-design-patterns/planning)** — Drafts a multi-step plan, executes it, and revises the tail when a step fails.
+- **[Tool Use / ReAct](https://detached-node.dev/agentic-design-patterns/tool-use-react)** — Loops a thought, a tool call, and the result until the agent emits a final answer.
+- **[Code Agent](https://detached-node.dev/agentic-design-patterns/code-agent)** — Wires the tool-use loop to a codebase, an editor, a shell, and a test runner.
+- **[Evaluator-Optimizer](https://detached-node.dev/agentic-design-patterns/evaluator-optimizer)** — Drafts an answer, scores it against a rubric, and regenerates with the critique appended.
+- **[RAG](https://detached-node.dev/agentic-design-patterns/rag)** — Pulls documents from an external store and uses them as context for the model's answer.
+- **[Agentic RAG](https://detached-node.dev/agentic-design-patterns/agentic-rag)** — Lets the model issue retrieval as a tool call and decide when to stop searching.
+- **[Reflexion](https://detached-node.dev/agentic-design-patterns/reflexion)** — Writes a critique after each attempt and retrieves prior critiques on the next attempt.
+
+#### Multi-agent
+
+- **[Orchestrator-Workers](https://detached-node.dev/agentic-design-patterns/orchestrator-workers)** — Has a central orchestrator dispatch sub-tasks to fresh workers and merge their outputs.
+- **[Multi-Agent Debate](https://detached-node.dev/agentic-design-patterns/multi-agent-debate)** — Runs N agents on the same prompt, exposes them to each other's answers, and votes.
+- **[Handoffs / Swarm](https://detached-node.dev/agentic-design-patterns/handoffs-swarm)** — Lets one agent own the dialogue and hand control off via a transfer tool call.
+
+### Layer 2 — Quality and control gates
+
+- **[Guardrails](https://detached-node.dev/agentic-design-patterns/guardrails)** — Wraps the model in input and output checks that block, rewrite, or refuse the response.
+- **[Human in the Loop](https://detached-node.dev/agentic-design-patterns/human-in-the-loop)** — Pauses at designated steps and resumes only after a person approves, edits, or rejects.
+- **[Evaluation (LLM-as-Judge)](https://detached-node.dev/agentic-design-patterns/evaluation-llm-as-judge)** — Scores model outputs with a stronger LLM applying a written rubric.
+
+### Layer 3 — State and context
+
+- **[Memory Management](https://detached-node.dev/agentic-design-patterns/memory-management)** — Splits agent state into a working window plus episodic and semantic durable stores.
+- **[Context Engineering](https://detached-node.dev/agentic-design-patterns/context-engineering)** — Decides which tokens fill the model's window, in what order, at what fraction of budget.
+- **[Checkpointing](https://detached-node.dev/agentic-design-patterns/checkpointing)** — Persists run state at step boundaries so a fresh worker resumes after a crash.
+
+### Layer 4 — Interfaces and transport
+
+- **[MCP](https://detached-node.dev/agentic-design-patterns/mcp)** — Standardises how an agent host discovers and calls tools across vendors over JSON-RPC.
+- **[A2A](https://detached-node.dev/agentic-design-patterns/a2a)** — Lets one agent call another over HTTP by fetching an Agent Card and posting a Task.
+- **[Streaming](https://detached-node.dev/agentic-design-patterns/streaming)** — Sends partial output frame by frame as it is generated, not after the model finishes.
+
+### Layer 5 — Methodology
+
+- **[12-Factor Agent](https://detached-node.dev/agentic-design-patterns/12-factor-agent)** — Catalogues twelve principles a team applies to push an agent from demo to production.
+- **[Identity-Separated Review](https://detached-node.dev/agentic-design-patterns/identity-separated-review)** — Routes PR review through a separate machine-user identity on a different model tier.
+
+## Recent essays
+
+- **[Where Agentic Patterns Actually Live in Your Coding Workflow](https://detached-node.dev/posts/where-agentic-patterns-actually-live)** (May 15, 2026)
+- **[Subagent Orchestration Workflow](https://detached-node.dev/posts/subagent-orchestration-workflow)** (Apr 24, 2026)
+- **[In Defense of Tickets and Pull Requests](https://detached-node.dev/posts/what-tickets-and-prs-are-actually-for)** (Apr 20, 2026)
+- **[Rethinking Systems in the Agentic Age](https://detached-node.dev/posts/rethinking-systems-in-the-agentic-age)** (Apr 19, 2026)
+
+## Architecture
+
+Next.js 16, React 19, TypeScript, Tailwind CSS 4, Payload CMS (Postgres backend), Google Cloud Run.
+
+See:
+- [`PROJECT_BRIEF.md`](./PROJECT_BRIEF.md) — phase roadmap, goals, non-goals
+- [`CONTENT_MODEL.md`](./CONTENT_MODEL.md) — Payload collection field definitions
+- [`AGENTS.md`](./AGENTS.md) — conventions for AI-assisted contributors
+- [`SITEMAP.md`](./SITEMAP.md) — public route inventory
 
 ## Development
 
 ```bash
-pnpm install
-pnpm dev          # Start dev server (localhost:3000)
-pnpm build        # Production build
-pnpm lint         # ESLint
-pnpm test:unit    # Vitest unit tests
-pnpm test:e2e     # Playwright end-to-end tests
+pnpm dev        # localhost:3000
+pnpm build      # production build
+pnpm lint       # eslint + lint:adp
+pnpm test:unit  # vitest
+pnpm test:e2e   # playwright
 ```
 
-### Environment
+## Live site
 
-Copy `.env.example` for the required environment variables. The app requires:
-- `DATABASE_URL` — PostgreSQL connection string
-- `PAYLOAD_SECRET` — Payload CMS encryption key
-
-Optional for full functionality:
-- `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` — production rate limiting
-- `GCS_BUCKET` — Google Cloud Storage bucket name for media
-- `GCS_HMAC_ACCESS_KEY` — GCS HMAC access key for S3-compatible media uploads
-- `GCS_HMAC_SECRET` — GCS HMAC secret for S3-compatible media uploads
-
-### AI-Assisted Development
-
-This project uses [Claude Code](https://claude.ai/code) as a development tool. The `CLAUDE.md` file provides project context and coding conventions to the AI assistant — functioning as executable documentation that keeps AI contributions consistent with the project's architecture and style.
-
-## Content Model
-
-Three content types managed through Payload CMS:
-
-- **Post** — Long-form article with title, slug, summary, body (Lexical rich text), tags, and publication date
-- **Listing** — Curated groupings of posts
-- **Page** — Static content (About, etc.)
-
-See `CONTENT_MODEL.md` for the full schema specification.
+[detached-node.dev](https://detached-node.dev)
 
 ## License
 

--- a/docs/seo-strategy/drafts/README.md
+++ b/docs/seo-strategy/drafts/README.md
@@ -1,0 +1,3 @@
+# Drafts
+
+Content drafts for manual copy to other GitHub repositories or external surfaces. Not deployed by this site.

--- a/docs/seo-strategy/drafts/julianken-profile-readme.md
+++ b/docs/seo-strategy/drafts/julianken-profile-readme.md
@@ -1,0 +1,21 @@
+# Julian Kennon
+
+Software engineer (10+ years, full-stack) writing about agentic AI design patterns at [detached-node.dev](https://detached-node.dev). Current focus: how pattern coupling actually works in production coding workflows — what's load-bearing, what's coupling theater, and what breaks first when the model tier shifts.
+
+## What I'm working on
+
+- **[detached-node.dev](https://detached-node.dev)** — a reference catalog of 24 agentic design patterns across 5 architectural layers (topology, quality gates, state and context, interfaces, methodology). Each entry is ~2,000 words, includes a Mermaid diagram, code, "when to use / when not to use", and cited references.
+- **[Agentic Design Patterns catalog source](https://github.com/julianken/detached-node)** — public, MIT-licensed; the site itself.
+
+## Pinned reading
+
+- [Where agentic patterns actually live](https://detached-node.dev/posts/where-agentic-patterns-actually-live)
+- [Subagent orchestration workflow](https://detached-node.dev/posts/subagent-orchestration-workflow)
+- [What tickets and PRs are actually for](https://detached-node.dev/posts/what-tickets-and-prs-are-actually-for)
+
+## Reach me
+
+- Site: [detached-node.dev](https://detached-node.dev)
+- Email: julian.kennon.d@gmail.com
+- GitHub: [@julianken](https://github.com/julianken)
+- LinkedIn: _to be added_


### PR DESCRIPTION
## Summary

Replaces the existing `README.md` with a structured reference parseable by recruiter-AI tools (Juicebox, hireEZ, Gem, Claude Cowork). Claude Cowork specifically clones repos and reads the README first when sourcing candidates — this is the load-bearing artifact for that signal.

Also produces a draft of the `julianken/julianken` profile README under `docs/seo-strategy/drafts/julianken-profile-readme.md` for Julian to manually copy into the profile repo. **This PR does not push to `julianken/julianken`** — that's Julian's manual step post-merge.

## Changes

- `README.md` — full rewrite, 729 words (slightly above the 400-600 target because every one of the 24 pattern `oneLineSummary` strings is preserved verbatim from the data files; those are load-bearing signal for the recruiter-AI use case). Lists all 24 non-archived patterns by layer, 4 recent essays with dates, architecture pointers (PROJECT_BRIEF, CONTENT_MODEL, AGENTS, SITEMAP), dev commands, license. No emojis, no badge stack.
- `docs/seo-strategy/drafts/julianken-profile-readme.md` — new file, 141-word draft of the profile README for the `julianken/julianken` repo. Not deployed.
- `docs/seo-strategy/drafts/README.md` — one-line directory explanation.

## Manual post-merge steps for Julian

These can't be done by the subagent (require Julian's account or other-repo access):

1. `gh repo edit --description "A reference catalog of agentic AI design patterns for software engineers building with LLMs."`
2. `gh repo edit --add-topic agentic-ai --add-topic ai-engineering --add-topic claude-code`
3. Copy `docs/seo-strategy/drafts/julianken-profile-readme.md` into a new `julianken/julianken/README.md` on github.com

## Test plan

- [x] All 24 non-archived pattern slugs present and linked (verified by slug-loop grep)
- [x] Pattern `oneLineSummary` strings match the source data files verbatim
- [x] No emojis, no badge banners
- [x] Word count: 729 (README), 141 (profile draft)
- [x] `pnpm lint` (no new warnings or errors)
- [x] `pnpm test:unit` (525 tests pass)
- [x] `pnpm typecheck` (clean)
- [ ] CI

Closes #391