### PR TITLE
fix(cms): revalidate /about on Pages edits; swap force-static for ISR

### DIFF
--- a/src/app/(frontend)/about/page.tsx
+++ b/src/app/(frontend)/about/page.tsx
@@ -7,8 +7,7 @@ import { generatePersonSchema, generatePageBreadcrumbSchema } from "@/lib/schema
 import { getPageBySlug } from "@/lib/queries/pages";
 import { siteUrl } from "@/lib/site-config";
 
-// Static generation - about page changes very rarely
-export const dynamic = "force-static";
+export const revalidate = 3600;
 
 export async function generateMetadata(): Promise<Metadata> {
   const page = await getPageBySlug('about');

--- a/src/collections/Pages.ts
+++ b/src/collections/Pages.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig } from 'payload'
 import { createSlugHook } from '@/lib/slug'
 import { publishedOrAuthenticated } from '@/lib/access-control'
+import { revalidateAfterChange, revalidateAfterDelete } from '@/lib/revalidate-page'
 
 export const Pages: CollectionConfig = {
   slug: 'pages',
@@ -14,6 +15,10 @@ export const Pages: CollectionConfig = {
     create: ({ req: { user } }) => !!user,
     update: ({ req: { user } }) => !!user,
     delete: ({ req: { user } }) => !!user,
+  },
+  hooks: {
+    afterChange: [revalidateAfterChange],
+    afterDelete: [revalidateAfterDelete],
   },
   fields: [
     {

--- a/src/lib/revalidate-page.ts
+++ b/src/lib/revalidate-page.ts
@@ -1,0 +1,35 @@
+import { revalidatePath } from 'next/cache'
+import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'payload'
+
+const paths = (slug?: string | null) => {
+  const out = ['/sitemap.xml']
+  if (slug) out.push(`/${slug}`)
+  return out
+}
+
+// Safe revalidate: no-op when invoked outside a Next.js request context
+// (e.g. seed scripts, `payload migrate`, Local API CLI). In those contexts
+// `revalidatePath` throws "Invariant: static generation store missing" — we
+// have no ISR cache to invalidate there, so silently skipping is correct.
+const safeRevalidate = (path: string) => {
+  try {
+    revalidatePath(path)
+  } catch {
+    // outside request scope; nothing to invalidate
+  }
+}
+
+export const revalidateAfterChange: CollectionAfterChangeHook = ({ doc, previousDoc }) => {
+  const targets = new Set<string>()
+  for (const p of paths(doc?.slug)) targets.add(p)
+  if (previousDoc?.slug && previousDoc.slug !== doc?.slug) {
+    targets.add(`/${previousDoc.slug}`)
+  }
+  for (const p of targets) safeRevalidate(p)
+  return doc
+}
+
+export const revalidateAfterDelete: CollectionAfterDeleteHook = ({ doc }) => {
+  for (const p of paths(doc?.slug)) safeRevalidate(p)
+  return doc
+}


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    autonumber
    actor Editor
    participant Admin as Payload /admin
    participant DB as Postgres
    participant Hook as Pages.hooks.afterChange<br/>(NEW)
    participant Next as Next.js ISR cache
    actor Visitor

    Editor->>Admin: Save About edit
    Admin->>DB: UPDATE pages SET ...
    rect rgb(220, 240, 220)
      note over Hook: NEW path — revalidate-page.ts
      Admin->>Hook: doc.slug = "about"
      Hook->>Next: revalidatePath("/about")
      Hook->>Next: revalidatePath("/sitemap.xml")
      Hook-->>Hook: if rename: revalidatePath("/<oldSlug>")
    end
    Visitor->>Next: GET /about
    Note right of Next: cache MISS → regenerate<br/>cache-control: s-maxage=3600
    Next-->>Visitor: Fresh HTML
```

**Before this PR:** the green block did not exist; `/about` was \`force-static\` with no on-demand or time-based invalidation. The first deploy froze the page; admin saves had no effect on the public site.

## Summary

- **Wire the missing hook.** \`Pages.ts\` had no \`afterChange\` / \`afterDelete\` hooks — the equivalent of the \`Posts.ts\` wiring added in [a959c54](https://github.com/julianken/detached-node/commit/a959c54). New \`src/lib/revalidate-page.ts\` mirrors \`revalidate-post.ts\`: invalidates \`/<slug>\`, \`/sitemap.xml\`, and the old slug on rename.
- **Drop \`force-static\` on /about.** Swapped for \`revalidate = 3600\`, matching \`/\`, \`/posts\`, \`/posts/[slug]\`, and \`/agentic-design-patterns\`. Removes the year-long \`s-maxage=31536000\` response header (a CDN-cache landmine) and provides a time-based safety net if the hook ever silently fails.
- **Why both.** The hook alone fixes the immediate symptom; the directive swap shortens the public \`Cache-Control\` window so a future CDN can't reintroduce the bug.

## Screenshots

N/A — server-side caching/CMS-hook change with no rendered-DOM diff.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test:unit\` — 525/525 passing
- [x] \`pnpm lint\` — 0 errors (18 pre-existing warnings unchanged)
- [x] \`pnpm lint:adp\` — sketches/refs/affiliate-links/changelog OK
- [ ] **Post-deploy production verify** (Issue #398 reproduction):
  - \`curl -sI https://detached-node.dev/about | grep -E 'cache-control|x-nextjs'\` → expect \`cache-control: s-maxage=3600, stale-while-revalidate=...\` (was \`s-maxage=31536000\`)
  - Edit /about in admin → save (status: published) → within ~60s, \`curl -s https://detached-node.dev/about | grep -oE '<h1[^>]*>[^<]*</h1>'\` reflects the edit without a redeploy
- [ ] CI: ESLint, TypeScript, Vitest, Next.js Build, Analyze Bundle, CodeQL, E2E Shards 1–4

## Plan reference

Out of plan — user-reported bug, filed mid-session as [#398](https://github.com/julianken/detached-node/issues/398). Closes #398.