### PR TITLE
feat(posts): visible references section + inline citation superscripts

### DIFF
--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -17,7 +17,8 @@ import { isValidSlug } from "@/lib/types/branded";
 import { isMediaObject } from "@/lib/types/media";
 import { FadeReveal } from "@/components/FadeReveal";
 import { siteUrl, ogDefaultImage } from "@/lib/site-config";
-import { mermaidConverters } from "@/lib/lexical/mermaid-converter";
+import { postBodyConverters } from "@/lib/lexical/post-body-converters";
+import { PostReferencesSection } from "@/components/PostReferencesSection";
 
 // ISR: Revalidate every hour - post content changes infrequently
 export const revalidate = 3600;
@@ -168,10 +169,12 @@ export default async function PostPage({ params }: PostPageProps) {
           <section className="prose dark:prose-invert max-w-none">
             <RichText
               data={post.body as SerializedEditorState}
-              converters={mermaidConverters}
+              converters={postBodyConverters}
             />
           </section>
         </TextGlitch>
+
+        <PostReferencesSection references={post.references ?? []} />
       </PageLayout>
     </article>
     </FadeReveal>

--- a/src/components/PostReferencesSection.tsx
+++ b/src/components/PostReferencesSection.tsx
@@ -1,0 +1,145 @@
+// ---------------------------------------------------------------------------
+// PostReferencesSection
+// ---------------------------------------------------------------------------
+// Renders the bottom-of-post references list for blog post detail pages.
+// Companion to the inline-citation Lexical converter in
+// `src/lib/lexical/post-body-converters.tsx`: authors insert `#ref-N` links
+// in the body, which render as superscripts and jump down to the matching
+// `<li id="ref-N">` rendered here.
+//
+// Single-source dataflow: the same `ReferenceInput[]` array drives both this
+// visible list and the JSON-LD `BlogPosting.citation` field emitted by
+// `generateBlogPostingSchema`. The shared `ReferenceInput` type (from
+// `@/lib/schema/citation`) is the contract that keeps the two surfaces in
+// sync — covered by the dual-consumer test.
+//
+// Server component. Returns null on empty array so the page does not render
+// an empty <section>.
+//
+// Visual conventions intentionally match
+// `src/components/agentic-patterns/ReferencesSection.tsx`; the Posts shape
+// has no `type` field so there is no type-badge column here.
+
+import type { ReferenceInput } from "@/lib/schema/citation";
+import { formatDate } from "@/lib/formatting";
+
+interface PostReferencesSectionProps {
+  references: ReferenceInput[];
+}
+
+function ReferenceItem({
+  reference,
+  index,
+}: {
+  reference: ReferenceInput;
+  index: number;
+}) {
+  const hasAuthor =
+    typeof reference.author === "string" && reference.author.length > 0;
+  const hasPublication =
+    typeof reference.publication === "string" && reference.publication.length > 0;
+  const hasDate =
+    typeof reference.date === "string" && reference.date.length > 0;
+  const hasUrl = typeof reference.url === "string" && reference.url.length > 0;
+  const hasMeta = hasAuthor || hasPublication || hasDate;
+
+  // Build meta segments so we can drop the `·` separator around any empty
+  // slot without leaving an orphan dot floating in the markup.
+  const metaParts: Array<{ key: string; node: React.ReactNode }> = [];
+  if (hasAuthor) {
+    metaParts.push({ key: "author", node: <span>{reference.author}</span> });
+  }
+  if (hasPublication) {
+    metaParts.push({
+      key: "publication",
+      node: <span className="italic">{reference.publication}</span>,
+    });
+  }
+  if (hasDate) {
+    metaParts.push({
+      key: "date",
+      node: (
+        <time dateTime={reference.date!}>{formatDate(reference.date)}</time>
+      ),
+    });
+  }
+
+  // Reference number — 1-indexed for matching `#ref-N` anchors authored
+  // inline. Drift between array order and inline markers is acceptable at
+  // current scale (3-4 refs/post); see issue #401 risk note.
+  const refNumber = index + 1;
+
+  const titleContent = (
+    <cite className="not-italic">{reference.title}</cite>
+  );
+
+  return (
+    <li
+      id={`ref-${refNumber}`}
+      className="flex flex-col gap-1.5 border-b border-border-subtle py-3 last:border-b-0 scroll-mt-24"
+    >
+      <div className="flex flex-wrap items-baseline gap-2">
+        {hasUrl ? (
+          <a
+            href={reference.url!}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-body font-medium text-accent underline underline-offset-4 hover:text-accent-muted"
+          >
+            {titleContent}
+          </a>
+        ) : (
+          // No URL → render the title as plain text inside <cite>. Mirrors
+          // the schema.org/CreativeWork fallback in mapReferenceToCitation.
+          <span className="text-body font-medium text-text-primary">
+            {titleContent}
+          </span>
+        )}
+      </div>
+      {hasMeta && (
+        <div className="font-mono text-meta text-text-secondary">
+          {metaParts.map((part, i) => (
+            <span key={part.key}>
+              {i > 0 && (
+                <span className="mx-1.5 text-text-tertiary">·</span>
+              )}
+              {part.node}
+            </span>
+          ))}
+        </div>
+      )}
+    </li>
+  );
+}
+
+export function PostReferencesSection({
+  references,
+}: PostReferencesSectionProps) {
+  if (references.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      id="references"
+      aria-labelledby="references-heading"
+      className="scroll-mt-24"
+    >
+      <h2
+        id="references-heading"
+        className="text-2xl font-semibold tracking-tight text-text-primary"
+      >
+        References
+      </h2>
+      <ol className="mt-4 list-none">
+        {references.map((reference, idx) => (
+          <ReferenceItem
+            key={reference.id ?? `${reference.title}-${idx}`}
+            reference={reference}
+            index={idx}
+          />
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/src/lib/lexical/post-body-converters.tsx
+++ b/src/lib/lexical/post-body-converters.tsx
@@ -1,0 +1,94 @@
+// ---------------------------------------------------------------------------
+// postBodyConverters
+// ---------------------------------------------------------------------------
+// JSX converter composition for post body rich-text rendering. Composes:
+//
+//   1. mermaidConverters(args) — brings in defaultConverters + the Mermaid
+//      block override. This is a factory function (`JSXConvertersFunction`),
+//      not an object literal; it MUST be invoked with `args`, not spread.
+//
+//   2. LinkJSXConverter — the canonical default link converter pair
+//      (`link` + `autolink`). We hold a reference to its `link` so the
+//      citation override below can delegate to it explicitly.
+//
+//   3. A citation-aware `link` override that wraps link nodes whose URL
+//      matches `/^#ref-\d+$/` in a <sup>. Authors mark inline citations by
+//      inserting a normal Lexical link pointing at `#ref-1`, `#ref-2`, etc.;
+//      the rendered anchor jumps to the matching <li id="ref-N"> in
+//      PostReferencesSection.
+//
+// Composition order is load-bearing.
+//
+// `mermaidConverters` already re-spreads `defaultConverters`, which includes
+// the framework default `link`. If the citation override were placed BEFORE
+// `...mermaidConverters(args)` it would be silently clobbered. The override
+// MUST come last.
+//
+// The override MUST NOT return `null` for non-citation links. Payload's
+// converter loop runs `.filter(Boolean)` on the produced JSX (see
+// `node_modules/@payloadcms/richtext-lexical/dist/features/converters/lexicalToJSX/converter/index.js:261`),
+// so a `null` return silently deletes the entire link node — every plain
+// hyperlink in post bodies would vanish. We explicitly delegate to
+// `linkPair.link(linkArgs)` for the non-citation branch.
+
+import {
+  LinkJSXConverter,
+  type JSXConvertersFunction,
+} from '@payloadcms/richtext-lexical/react'
+import type { DefaultNodeTypes } from '@payloadcms/richtext-lexical'
+import { mermaidConverters } from './mermaid-converter'
+
+const CITATION_HREF = /^#ref-\d+$/
+
+export const postBodyConverters: JSXConvertersFunction<DefaultNodeTypes> = (
+  args,
+) => {
+  // Citation links are author-maintained `#ref-N` fragments — no Payload
+  // document lookup is involved. internalDocToHref still has to exist for
+  // the converter pair to render any true internal-doc link cleanly; we
+  // route it to `#` as a safe fallback (no Posts collection currently links
+  // to other Posts via the internal-doc picker; if that changes, replace
+  // with a real Payload doc-to-href resolver).
+  const linkPair = LinkJSXConverter({
+    internalDocToHref: () => '#',
+  })
+
+  // `JSXConverter<T>` is `((args) => ReactNode) | ReactNode`. Payload ships
+  // `link` as a function, but the type union forces a narrow before call.
+  // We capture the narrowed function once so both branches below can invoke
+  // it without repeating the guard.
+  const defaultLink = linkPair.link
+  if (typeof defaultLink !== 'function') {
+    // Should never happen — LinkJSXConverter ships a function. We throw
+    // rather than return null so a future Payload upgrade that changes the
+    // converter shape surfaces loudly instead of silently deleting links.
+    throw new Error(
+      'postBodyConverters: LinkJSXConverter returned a non-function link converter',
+    )
+  }
+
+  return {
+    // Mermaid + framework defaults (re-spreads defaultConverters internally).
+    ...mermaidConverters(args),
+    // Canonical link/autolink pair (anchors at known shape).
+    ...linkPair,
+    // Citation-aware link override — MUST come after the spreads above, or
+    // the framework's default `link` clobbers it.
+    link: (linkArgs) => {
+      const href = linkArgs.node.fields.url ?? ''
+      const isCitation =
+        linkArgs.node.fields.linkType === 'custom' && CITATION_HREF.test(href)
+      if (isCitation) {
+        return (
+          <sup className="align-super text-meta">
+            {defaultLink(linkArgs)}
+          </sup>
+        )
+      }
+      // Explicit delegation — never return null. Payload's converter loop
+      // filters null with .filter(Boolean), which would silently delete
+      // every plain hyperlink in post bodies (BLOCKER regression guard).
+      return defaultLink(linkArgs)
+    },
+  }
+}

--- a/tests/unit/components/PostReferencesSection.test.tsx
+++ b/tests/unit/components/PostReferencesSection.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PostReferencesSection } from "@/components/PostReferencesSection";
+import type { ReferenceInput } from "@/lib/schema/citation";
+
+// ---------------------------------------------------------------------------
+// Fixtures — ReferenceInput rows mirror the Post.references field shape.
+// ---------------------------------------------------------------------------
+
+const fullRef: ReferenceInput = {
+  title: "Attention Is All You Need",
+  url: "https://arxiv.org/abs/1706.03762",
+  author: "Vaswani et al.",
+  publication: "NeurIPS",
+  date: "2017-06-12",
+};
+
+const titleAndUrlOnly: ReferenceInput = {
+  title: "A minimal entry",
+  url: "https://example.com/minimal",
+};
+
+const noDate: ReferenceInput = {
+  title: "Reference without a date",
+  url: "https://example.com/no-date",
+  author: "Anon",
+  publication: "Somewhere",
+};
+
+const noUrl: ReferenceInput = {
+  title: "Offline citation",
+  author: "Print Author",
+  publication: "Print Journal",
+  date: "1999-01-01",
+};
+
+// ---------------------------------------------------------------------------
+
+describe("PostReferencesSection", () => {
+  it("returns null when references array is empty", () => {
+    const { container } = render(<PostReferencesSection references={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders one <li> per reference with the correct count", () => {
+    render(
+      <PostReferencesSection
+        references={[fullRef, titleAndUrlOnly, noDate]}
+      />,
+    );
+
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(3);
+  });
+
+  it("numbers <li id='ref-N'> 1-indexed in array order", () => {
+    const { container } = render(
+      <PostReferencesSection
+        references={[fullRef, titleAndUrlOnly, noDate]}
+      />,
+    );
+
+    expect(container.querySelector("#ref-1")).not.toBeNull();
+    expect(container.querySelector("#ref-2")).not.toBeNull();
+    expect(container.querySelector("#ref-3")).not.toBeNull();
+    // 1-indexed: ref-0 must NOT exist
+    expect(container.querySelector("#ref-0")).toBeNull();
+  });
+
+  it("wraps the matching <li id='ref-N'> around the corresponding title", () => {
+    const { container } = render(
+      <PostReferencesSection
+        references={[fullRef, titleAndUrlOnly]}
+      />,
+    );
+
+    const ref1 = container.querySelector("#ref-1");
+    const ref2 = container.querySelector("#ref-2");
+    expect(ref1?.textContent).toContain(fullRef.title);
+    expect(ref2?.textContent).toContain(titleAndUrlOnly.title);
+  });
+
+  it("renders a section labelled by the references heading", () => {
+    render(
+      <PostReferencesSection
+        references={[fullRef]}
+      />,
+    );
+
+    const section = screen.getByRole("region", { name: /references/i });
+    expect(section).toHaveAttribute("id", "references");
+    const heading = screen.getByRole("heading", { name: /references/i });
+    expect(heading).toHaveAttribute("id", "references-heading");
+  });
+
+  it("renders the title as an external link when url is present", () => {
+    render(
+      <PostReferencesSection
+        references={[fullRef]}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: /attention is all you need/i });
+    expect(link).toHaveAttribute("href", fullRef.url);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders the title without a link when url is absent", () => {
+    render(
+      <PostReferencesSection
+        references={[noUrl]}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("link", { name: /offline citation/i }),
+    ).toBeNull();
+    expect(screen.getByText(/offline citation/i)).toBeInTheDocument();
+  });
+
+  it("omits the meta line when author, publication, and date are all empty", () => {
+    const { container } = render(
+      <PostReferencesSection references={[titleAndUrlOnly]} />,
+    );
+
+    // The meta line carries the font-mono class; with no fields it should
+    // not be present.
+    const metaLines = container.querySelectorAll(".font-mono");
+    expect(metaLines.length).toBe(0);
+  });
+
+  it("renders the meta line when only some fields are populated", () => {
+    const { container } = render(
+      <PostReferencesSection references={[noDate]} />,
+    );
+
+    const metaLine = container.querySelector(".font-mono");
+    expect(metaLine).not.toBeNull();
+    expect(metaLine?.textContent).toContain(noDate.author);
+    expect(metaLine?.textContent).toContain(noDate.publication);
+  });
+
+  it("renders the date inside a <time dateTime> element when present", () => {
+    const { container } = render(
+      <PostReferencesSection references={[fullRef]} />,
+    );
+
+    const timeEl = container.querySelector("time");
+    expect(timeEl).not.toBeNull();
+    expect(timeEl).toHaveAttribute("dateTime", fullRef.date);
+  });
+
+  it("wraps the title in <cite> for semantic correctness", () => {
+    const { container } = render(
+      <PostReferencesSection references={[fullRef]} />,
+    );
+
+    const citeEl = container.querySelector("cite");
+    expect(citeEl).not.toBeNull();
+    expect(citeEl?.textContent).toBe(fullRef.title);
+  });
+
+  it("survives null-valued optional fields gracefully", () => {
+    const refWithNulls: ReferenceInput = {
+      title: "Null-field reference",
+      url: null,
+      author: null,
+      publication: null,
+      date: null,
+    };
+
+    const { container } = render(
+      <PostReferencesSection references={[refWithNulls]} />,
+    );
+
+    expect(container.querySelector("#ref-1")).not.toBeNull();
+    expect(container.querySelector(".font-mono")).toBeNull();
+  });
+
+  it("accepts ReferenceInput[] (compile-time contract — also used by mapReferenceToCitation)", () => {
+    // This test exists primarily so a future refactor that drifts the
+    // component's prop type away from ReferenceInput[] fails at type-check.
+    // The dual-consumer test in tests/unit/lib/schema/blog-posting.test.tsx
+    // also asserts this contract at the value level.
+    const refs: ReferenceInput[] = [fullRef, noUrl];
+    render(<PostReferencesSection references={refs} />);
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+  });
+});

--- a/tests/unit/lib/lexical/post-body-converters.test.tsx
+++ b/tests/unit/lib/lexical/post-body-converters.test.tsx
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import type { SerializedEditorState } from "@payloadcms/richtext-lexical/lexical";
+
+// Mock MermaidDiagram so we don't need the real runtime.
+vi.mock("@/components/MermaidDiagram", () => ({
+  MermaidDiagram: ({ source }: { source: string }) => (
+    <div data-testid="mermaid-diagram" data-source={source}>
+      mocked-diagram
+    </div>
+  ),
+}));
+
+// MermaidDiagram transitively pulls in next-themes; stub it.
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+import { RichText } from "@payloadcms/richtext-lexical/react";
+import { postBodyConverters } from "@/lib/lexical/post-body-converters";
+
+// ---------------------------------------------------------------------------
+// Helpers — minimal SerializedEditorState fixtures
+// ---------------------------------------------------------------------------
+
+type AnyNode = SerializedEditorState["root"]["children"][number];
+
+function makeText(text: string): AnyNode {
+  return {
+    type: "text",
+    version: 1,
+    text,
+    format: 0,
+    style: "",
+    mode: "normal",
+    detail: 0,
+  } as unknown as AnyNode;
+}
+
+function makeLink(opts: {
+  url: string;
+  linkType?: "custom" | "internal";
+  newTab?: boolean;
+  childText: string;
+}): AnyNode {
+  return {
+    type: "link",
+    version: 1,
+    format: "",
+    indent: 0,
+    direction: "ltr",
+    fields: {
+      linkType: opts.linkType ?? "custom",
+      newTab: opts.newTab ?? false,
+      url: opts.url,
+    },
+    children: [makeText(opts.childText)],
+  } as unknown as AnyNode;
+}
+
+function makeParagraph(children: AnyNode[]): AnyNode {
+  return {
+    type: "paragraph",
+    format: "",
+    indent: 0,
+    version: 1,
+    direction: "ltr",
+    textStyle: "",
+    textFormat: 0,
+    children,
+  } as unknown as AnyNode;
+}
+
+function makeRoot(children: AnyNode[]): SerializedEditorState {
+  return {
+    root: {
+      type: "root",
+      format: "",
+      indent: 0,
+      version: 1,
+      direction: "ltr",
+      children,
+    },
+  } as unknown as SerializedEditorState;
+}
+
+function renderWithLink(opts: Parameters<typeof makeLink>[0]) {
+  return render(
+    <RichText
+      data={makeRoot([makeParagraph([makeLink(opts)])])}
+      converters={postBodyConverters}
+    />,
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+describe("postBodyConverters", () => {
+  describe("citation links (#ref-N)", () => {
+    it("wraps a #ref-1 link in <sup>", () => {
+      const { container } = renderWithLink({
+        url: "#ref-1",
+        childText: "[1]",
+      });
+
+      const sup = container.querySelector("sup");
+      expect(sup).not.toBeNull();
+      const anchor = sup?.querySelector("a");
+      expect(anchor).not.toBeNull();
+      expect(anchor).toHaveAttribute("href", "#ref-1");
+      expect(anchor?.textContent).toBe("[1]");
+    });
+
+    it("wraps multi-digit #ref-123 in <sup>", () => {
+      const { container } = renderWithLink({
+        url: "#ref-123",
+        childText: "[123]",
+      });
+
+      const sup = container.querySelector("sup");
+      expect(sup).not.toBeNull();
+      expect(sup?.querySelector("a")).toHaveAttribute("href", "#ref-123");
+    });
+
+    it("preserves whatever the author typed inside the link", () => {
+      const { container } = renderWithLink({
+        url: "#ref-2",
+        childText: "see note 2",
+      });
+
+      const sup = container.querySelector("sup");
+      expect(sup?.textContent).toBe("see note 2");
+    });
+  });
+
+  describe("non-citation links (BLOCKER regression check)", () => {
+    it("plain external link renders as a normal <a> — NOT wrapped in <sup>", () => {
+      // This is the BLOCKER from the V1 spec: returning null for
+      // non-citation links would silently delete the node entirely because
+      // Payload's converter loop filters null with .filter(Boolean).
+      const { container } = renderWithLink({
+        url: "https://example.com",
+        childText: "example",
+      });
+
+      const anchor = container.querySelector("a");
+      expect(anchor).not.toBeNull();
+      expect(anchor).toHaveAttribute("href", "https://example.com");
+      expect(anchor?.textContent).toBe("example");
+      // Critical: the anchor must NOT be wrapped in <sup>.
+      expect(container.querySelector("sup")).toBeNull();
+    });
+
+    it("internal-doc link renders as the default internal-anchor render — NOT wrapped in <sup>", () => {
+      const { container } = render(
+        <RichText
+          data={makeRoot([
+            makeParagraph([
+              makeLink({
+                url: "",
+                linkType: "internal",
+                childText: "internal post",
+              }),
+            ]),
+          ])}
+          converters={postBodyConverters}
+        />,
+      );
+
+      // Internal links resolve via internalDocToHref (we route to "#" so
+      // they render as a real anchor element rather than being dropped).
+      const anchor = container.querySelector("a");
+      expect(anchor).not.toBeNull();
+      expect(anchor?.textContent).toBe("internal post");
+      expect(container.querySelector("sup")).toBeNull();
+    });
+
+    it("#ref- with no digit is NOT treated as a citation", () => {
+      const { container } = renderWithLink({
+        url: "#ref-",
+        childText: "not a citation",
+      });
+
+      expect(container.querySelector("sup")).toBeNull();
+      const anchor = container.querySelector("a");
+      expect(anchor).toHaveAttribute("href", "#ref-");
+      expect(anchor?.textContent).toBe("not a citation");
+    });
+
+    it("#ref-abc (non-numeric suffix) is NOT treated as a citation", () => {
+      const { container } = renderWithLink({
+        url: "#ref-abc",
+        childText: "alpha",
+      });
+
+      expect(container.querySelector("sup")).toBeNull();
+      const anchor = container.querySelector("a");
+      expect(anchor).toHaveAttribute("href", "#ref-abc");
+    });
+
+    it("a custom-type link with empty url renders without crashing or null-deleting", () => {
+      const { container } = renderWithLink({
+        url: "",
+        childText: "empty-url link",
+      });
+
+      // The anchor should still exist (the default link converter renders
+      // <a href="">…</a>). What we are guarding against is the node being
+      // silently filtered out.
+      const anchor = container.querySelector("a");
+      expect(anchor).not.toBeNull();
+      expect(anchor?.textContent).toBe("empty-url link");
+      expect(container.querySelector("sup")).toBeNull();
+    });
+  });
+
+  describe("Mermaid composition", () => {
+    it("still renders Mermaid blocks (composition with mermaidConverters preserved)", () => {
+      const source = "graph LR; A-->B";
+      const mermaidNode = {
+        type: "block",
+        format: "",
+        version: 2,
+        fields: {
+          id: "block-1",
+          blockName: "",
+          blockType: "mermaid",
+          code: source,
+        },
+      } as unknown as AnyNode;
+
+      render(
+        <RichText
+          data={makeRoot([mermaidNode])}
+          converters={postBodyConverters}
+        />,
+      );
+
+      const diagram = screen.getByTestId("mermaid-diagram");
+      expect(diagram).toBeInTheDocument();
+      expect(diagram).toHaveAttribute("data-source", source);
+    });
+  });
+
+  describe("passthrough", () => {
+    it("paragraph with plain text still renders as <p>", () => {
+      render(
+        <RichText
+          data={makeRoot([makeParagraph([makeText("hello world")])])}
+          converters={postBodyConverters}
+        />,
+      );
+
+      const p = screen.getByText("hello world");
+      expect(p.tagName).toBe("P");
+    });
+  });
+});

--- a/tests/unit/lib/schema/blog-posting-references.test.tsx
+++ b/tests/unit/lib/schema/blog-posting-references.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Mock site config so generateBlogPostingSchema doesn't pull in
+// NEXT_PUBLIC_SERVER_URL at import time.
+vi.mock("@/lib/schema/config", () => ({
+  SITE_CONFIG: {
+    url: "https://detached-node.dev",
+    name: "detached-node",
+    description: "Test description",
+    websiteId: "https://detached-node.dev/#website",
+  },
+  AUTHOR_CONFIG: {
+    name: "Julian",
+    url: "https://detached-node.dev/about",
+    id: "https://detached-node.dev/#author",
+    sameAs: ["https://github.com/julianken"],
+    description: "Writing on agentic AI workflows.",
+  },
+}));
+
+import { generateBlogPostingSchema } from "@/lib/schema/blog-posting";
+import { PostReferencesSection } from "@/components/PostReferencesSection";
+import type { Post } from "@/payload-types";
+import type { ReferenceInput } from "@/lib/schema/citation";
+
+// ---------------------------------------------------------------------------
+// Dual-consumer test
+// ---------------------------------------------------------------------------
+// The Post.references array drives TWO surfaces from a single source:
+//
+//   1. JSON-LD BlogPosting.citation (generateBlogPostingSchema → mapReferenceToCitation)
+//   2. The visible bottom-of-post references list (PostReferencesSection)
+//
+// This test exists to fail loudly if a future refactor decouples those two
+// surfaces — e.g. by introducing a separate "visible-references" field, or
+// by changing the shape of one consumer but not the other. Asserting only
+// one half (just the JSON-LD snapshot, or just the rendered DOM) would
+// silently let the two diverge.
+// ---------------------------------------------------------------------------
+
+const sharedReferences: ReferenceInput[] = [
+  {
+    title: "Attention Is All You Need",
+    url: "https://arxiv.org/abs/1706.03762",
+    author: "Vaswani et al.",
+    publication: "NeurIPS",
+    date: "2017-06-12",
+  },
+  {
+    title: "ReAct: Synergizing Reasoning and Acting in Language Models",
+    url: "https://arxiv.org/abs/2210.03629",
+    author: "Yao et al.",
+    publication: "ICLR",
+    date: "2023-03-10",
+  },
+];
+
+const mockPost: Post = {
+  id: 1,
+  title: "Test post for dual-consumer reference contract",
+  slug: "dual-consumer-references",
+  type: "essay",
+  summary:
+    "A fixture-shaped post used to verify that references drive both JSON-LD and visible rendering from one source.",
+  featuredImageLight: 1,
+  featuredImageDark: 2,
+  body: {
+    root: {
+      type: "root",
+      children: [],
+      direction: "ltr",
+      format: "",
+      indent: 0,
+      version: 1,
+    },
+  },
+  references: sharedReferences,
+  status: "published",
+  publishedAt: "2026-01-15T00:00:00.000Z",
+  updatedAt: "2026-01-15T00:00:00.000Z",
+  createdAt: "2026-01-15T00:00:00.000Z",
+} as Post;
+
+describe("Post references dual-consumer contract", () => {
+  it("BlogPosting.citation matches the references array length", () => {
+    const schema = generateBlogPostingSchema(mockPost);
+    expect(schema.citation).toBeDefined();
+    expect(schema.citation).toHaveLength(sharedReferences.length);
+  });
+
+  it("BlogPosting.citation snapshot is stable", () => {
+    const schema = generateBlogPostingSchema(mockPost);
+    expect(schema.citation).toMatchInlineSnapshot(`
+      [
+        {
+          "@type": "ScholarlyArticle",
+          "author": {
+            "@type": "Person",
+            "name": "Vaswani et al.",
+          },
+          "datePublished": "2017-06-12",
+          "isPartOf": {
+            "@type": "Website",
+            "name": "NeurIPS",
+          },
+          "name": "Attention Is All You Need",
+          "url": "https://arxiv.org/abs/1706.03762",
+        },
+        {
+          "@type": "ScholarlyArticle",
+          "author": {
+            "@type": "Person",
+            "name": "Yao et al.",
+          },
+          "datePublished": "2023-03-10",
+          "isPartOf": {
+            "@type": "Website",
+            "name": "ICLR",
+          },
+          "name": "ReAct: Synergizing Reasoning and Acting in Language Models",
+          "url": "https://arxiv.org/abs/2210.03629",
+        },
+      ]
+    `);
+  });
+
+  it("PostReferencesSection renders one <li> per reference, matching titles and urls", () => {
+    render(
+      <PostReferencesSection references={mockPost.references ?? []} />,
+    );
+
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(sharedReferences.length);
+
+    for (const ref of sharedReferences) {
+      const link = screen.getByRole("link", { name: new RegExp(ref.title.split(":")[0], "i") });
+      expect(link).toHaveAttribute("href", ref.url);
+    }
+  });
+
+  it("JSON-LD citation names and visible <cite> titles use the same source data", () => {
+    // Single source of truth check: walk both surfaces and assert the same
+    // titles appear in both. A schema-level rename or a component-level
+    // hard-coded list would break this.
+    const schema = generateBlogPostingSchema(mockPost);
+    const jsonLdNames = (schema.citation ?? []).map((c) => c.name);
+
+    const { container } = render(
+      <PostReferencesSection references={mockPost.references ?? []} />,
+    );
+    const visibleTitles = Array.from(container.querySelectorAll("cite")).map(
+      (el) => el.textContent ?? "",
+    );
+
+    expect(jsonLdNames).toEqual(sharedReferences.map((r) => r.title));
+    expect(visibleTitles).toEqual(sharedReferences.map((r) => r.title));
+    expect(jsonLdNames).toEqual(visibleTitles);
+  });
+});


### PR DESCRIPTION
## Summary

Renders the `post.references` array as an auto-numbered `<ol>` at the bottom of post detail pages, plus a Lexical converter that wraps inline `#ref-N` link nodes in `<sup>` for citation-style markers in the body.

## Changes

- `src/components/PostReferencesSection.tsx` (new) — server component, takes `ReferenceInput[]` (reused from `src/lib/schema/citation.ts:18-25`), renders auto-numbered `<ol>` with `<li id="ref-N">` anchors. Visual conventions match `agentic-patterns/ReferencesSection.tsx`. Type-badge column omitted since Posts references have no `type` field.
- `src/lib/lexical/post-body-converters.tsx` (new) — `JSXConvertersFunction<DefaultNodeTypes>` that composes `mermaidConverters(args)` + `LinkJSXConverter` + a citation-aware `link` override. The override wraps `#ref-N` links in `<sup>` and explicitly delegates to the default for all other links (never returns null per the V1 BLOCKER fix). Composition order is load-bearing: the override is placed AFTER both spreads so it isn't clobbered by `defaultConverters`' `link`.
- `src/app/(frontend)/posts/[slug]/page.tsx` — replace `mermaidConverters` with `postBodyConverters` on `<RichText>`; render `<PostReferencesSection references={post.references ?? []} />` after the body.

## Tests

- `tests/unit/components/PostReferencesSection.test.tsx` — 13 cases: empty array, populated array, `id="ref-N"` 1-indexed numbering, partial fields (no date / no url / all-null optionals), section landmark + heading, `<cite>` wrap, `<time dateTime>` rendering, meta-line omission with no fields.
- `tests/unit/lib/lexical/post-body-converters.test.tsx` — 10 cases: `#ref-1` wrap, multi-digit `#ref-123`, author text preserved, **plain external link renders as plain `<a>` not wrapped in `<sup>` (BLOCKER regression check)**, internal-doc link, `#ref-` (no digit), `#ref-abc` (non-numeric suffix), empty-url custom link, Mermaid block composition preserved, paragraph passthrough.
- `tests/unit/lib/schema/blog-posting-references.test.tsx` — dual-consumer contract: single `Post` fixture drives both `generateBlogPostingSchema(post).citation` (inline snapshot of 2 `ScholarlyArticle` entries) AND `<PostReferencesSection references={post.references}>` render, asserting both surfaces use the same source data.

## Test plan

- [x] `pnpm lint` (0 errors)
- [x] `pnpm test:unit` (584/584 passing, 27 new)
- [x] `pnpm typecheck` (clean)
- [x] BLOCKER regression test: plain external link in body renders as `<a href="https://example.com">` — NOT wrapped in `<sup>`, NOT filtered out by `.filter(Boolean)`
- [x] Mermaid composition preserved (existing block-rendering test still green via new converter)
- [ ] CI (10 required checks: ESLint, TypeScript, Vitest, Next.js Build, Analyze Bundle, CodeQL, 4× E2E shards + Mergify queue)
- [ ] Visual smoke on production-shaped data (will attach screenshots after deploy)

## Risk acknowledged

Manual-numbering brittleness: reordering the references array in Payload admin doesn't update inline `#ref-N` markers in the body. Acceptable for current scale (3-4 refs/post); future `validate-post-references.ts` script deferred to a follow-up issue per the spec's "out of scope" list.

Closes #401