### PR TITLE
fix(seo): use real LinkedIn URL in AUTHOR_CONFIG.sameAs

### DIFF
--- a/docs/seo-strategy/drafts/julianken-profile-readme.md
+++ b/docs/seo-strategy/drafts/julianken-profile-readme.md
@@ -18,4 +18,4 @@ Software engineer (10+ years, full-stack) writing about agentic AI design patter
 - Site: [detached-node.dev](https://detached-node.dev)
 - Email: julian.kennon.d@gmail.com
 - GitHub: [@julianken](https://github.com/julianken)
-- LinkedIn: _to be added_
+- LinkedIn: [julian-k-ba6b5897](https://www.linkedin.com/in/julian-k-ba6b5897)

--- a/src/lib/schema/config.ts
+++ b/src/lib/schema/config.ts
@@ -35,7 +35,7 @@ export const AUTHOR_CONFIG = {
   id: `${siteUrl}/#author`,
   sameAs: [
     "https://github.com/julianken",
-    "https://www.linkedin.com/in/julian-kennon",
+    "https://www.linkedin.com/in/julian-k-ba6b5897",
   ] as string[],
   description:
     "Software engineer with a decade-plus of full-stack experience, focused on agentic AI workflows and autonomous system design. Author of the agentic design patterns reference catalog at detached-node.dev.",

--- a/tests/unit/lib/schema/profile-page.test.ts
+++ b/tests/unit/lib/schema/profile-page.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/lib/schema/config", () => ({
     id: "https://detached-node.com/#author",
     sameAs: [
       "https://github.com/julianken",
-      "https://www.linkedin.com/in/julian-kennon",
+      "https://www.linkedin.com/in/julian-k-ba6b5897",
     ],
     description: "Software engineer focused on agentic AI workflows.",
     jobTitle: "Software Engineer",


### PR DESCRIPTION
## Summary

Replace the LinkedIn placeholder `/in/julian-kennon` in two places with Julian's real URL `/in/julian-k-ba6b5897`.

## Changes

- `src/lib/schema/config.ts` — `AUTHOR_CONFIG.sameAs` second entry.
- `docs/seo-strategy/drafts/julianken-profile-readme.md` — LinkedIn link in the contact section.
- `tests/unit/lib/schema/profile-page.test.ts` — mock `AUTHOR_CONFIG.sameAs` updated to match (test fixture follow-on from config change).

URL verified HTTP 200 at time of writing.

## Test plan

- [x] `pnpm lint`, `pnpm test:unit` (584 passing), `pnpm typecheck` all pass
- [ ] CI

Closes #403