### PR TITLE
feat(analytics): wire up Microsoft Clarity tracking

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Link, ViewTransitions } from "next-view-transitions";
 import { Crimson_Pro, JetBrains_Mono } from "next/font/google";
+import Script from "next/script";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { MobileNav } from "@/components/MobileNav";
@@ -145,6 +146,15 @@ export default function FrontendLayout({
 
           </ViewTransitions>
         </ThemeProvider>
+        <Script id="microsoft-clarity" strategy="afterInteractive">
+          {`
+            (function(c,l,a,r,i,t,y){
+              c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+              t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+              y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "wsu7mgk54v");
+          `}
+        </Script>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

Adds the Microsoft Clarity tracking script (project ID `wsu7mgk54v`) to the frontend layout. Clarity will start receiving page views as soon as this deploys; the dashboard at https://clarity.microsoft.com/projects/view/wsu7mgk54v/dashboard should populate within ~15 min of the first real visitor (or Julian loading the site in incognito post-deploy).

## Changes

- `src/app/(frontend)/layout.tsx` — imported `Script` from `next/script`, added `<Script id="microsoft-clarity" strategy="afterInteractive">` as the last child of `<body>` (after `</ThemeProvider>`, outside the React provider tree) with the canonical Clarity install snippet.

## Manual verification by Julian after merge + deploy

1. Wait ~5 min for Cloud Run redeploy to finish (`gh run watch` if needed).
2. Visit `https://detached-node.dev` in incognito (or any visitor would do — incognito is just to control the event).
3. DevTools → Network → filter "clarity" → expect `/tag/wsu7mgk54v` (script) and `/collect` (event ingest) requests.
4. Wait ~10-15 min, then open https://clarity.microsoft.com/projects/view/wsu7mgk54v/dashboard — should leave the gettingstarted redirect and show the real dashboard.

## Test plan

- [x] `pnpm lint`, `pnpm test:unit`, `pnpm typecheck` pass
- [ ] CI (ESLint, TypeScript, Vitest, Next.js Build, Bundle, CodeQL, E2E x4)

Closes #405