### PR TITLE
chore(analytics): env-gate Clarity to production only

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -146,15 +146,17 @@ export default function FrontendLayout({
 
           </ViewTransitions>
         </ThemeProvider>
-        <Script id="microsoft-clarity" strategy="afterInteractive">
-          {`
-            (function(c,l,a,r,i,t,y){
-              c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-              t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-              y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-            })(window, document, "clarity", "script", "wsu7mgk54v");
-          `}
-        </Script>
+        {process.env.NODE_ENV === 'production' && (
+          <Script id="microsoft-clarity" strategy="afterInteractive">
+            {`
+              (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+              })(window, document, "clarity", "script", "wsu7mgk54v");
+            `}
+          </Script>
+        )}
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

Wraps the Clarity `<Script>` block (added by #406) in a `process.env.NODE_ENV === 'production'` conditional. Server-side check — no `use client` directive, no `NEXT_PUBLIC_*` indirection needed.

## Effect

- `pnpm dev` (NODE_ENV=development): Script does NOT render → no Clarity collection during local dev
- Production builds (`next build` + Cloud Run): Script renders as before → Clarity collection unchanged in production

## Manual verification by Julian after merge + deploy

- `https://detached-node.dev` (prod): Script still loads (DevTools Network → `/tag/wsu7mgk54v`)
- Local `pnpm dev`: Script absent from page source

## Test plan

- [x] `pnpm lint`, `pnpm test:unit`, `pnpm typecheck` pass
- [x] Local smoke: confirmed Script absent in dev mode
- [ ] CI

Closes #407