### PR TITLE
chore(readme): update Recent essays link to renamed post slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ SITEMAP.md                          # Public route inventory
 
 ## Recent essays
 
-- **[Where Agentic Patterns Actually Live in Your Coding Workflow](https://detached-node.dev/posts/where-agentic-patterns-actually-live)** (May 15, 2026)
+- **[Agentic Patterns in Your Coding Workflow](https://detached-node.dev/posts/agentic-patterns-in-your-coding-workflow)** (May 15, 2026)
 - **[Subagent Orchestration Workflow](https://detached-node.dev/posts/subagent-orchestration-workflow)** (Apr 24, 2026)
 - **[In Defense of Tickets and Pull Requests](https://detached-node.dev/posts/what-tickets-and-prs-are-actually-for)** (Apr 20, 2026)
 - **[Rethinking Systems in the Agentic Age](https://detached-node.dev/posts/rethinking-systems-in-the-agentic-age)** (Apr 19, 2026)


### PR DESCRIPTION
## Summary
One-line README update — the "Recent essays" link to the May-15 post now points to the renamed URL (`agentic-patterns-in-your-coding-workflow`). The old URL serves a noindex 404 fallback after the Payload slug rename.

Follow-up to #409, which intentionally deferred this change until the Payload slug rename was applied.

## Test plan
- [ ] CI green
- [ ] Live URL verified: `curl -s 'https://detached-node.dev/posts/agentic-patterns-in-your-coding-workflow' | grep -oE '<title[^>]*>[^<]+</title>'` returns the post title with `index, follow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)