### PR TITLE
fix(seo): return HTTP 404 for missing post slugs + redirect trailing punctuation

### DIFF
--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -23,7 +23,22 @@ import { PostReferencesSection } from "@/components/PostReferencesSection";
 // ISR: Revalidate every hour - post content changes infrequently
 export const revalidate = 3600;
 
-// Allow dynamic rendering of posts not pre-rendered at build time
+// Allow dynamic rendering of posts not pre-rendered at build time.
+//
+// Soft-404 trap (issue #414): with ISR (`revalidate`) + `dynamicParams=true`,
+// Next.js prerenders and caches the `notFound()` render as a 200 with
+// the page-level `s-maxage=3600` (known framework limitation —
+// vercel/next.js#43831, #79497). The result was every missing-slug URL
+// being indexable as a valid page. The fix lives in `src/proxy.ts`:
+// for `/posts/<slug>` requests, the proxy does a fast existence check
+// against the posts table BEFORE the ISR-cached page route is entered.
+// Missing slugs short-circuit at the proxy layer with a proper 404 +
+// `Cache-Control: no-cache, no-store, max-age=0, must-revalidate`;
+// valid slugs pass through to this page, which keeps its
+// `revalidate = 3600` ISR cache headers. The
+// `agentic-design-patterns/[slug]` route avoids the same trap via
+// `dynamicParams=false` (its slug list is statically known); that's not
+// viable here because Payload CMS adds posts at runtime.
 export const dynamicParams = true;
 
 type PostPageProps = {

--- a/src/lib/queries/posts.ts
+++ b/src/lib/queries/posts.ts
@@ -68,6 +68,55 @@ export const getPublishedPosts = cache(async (): Promise<Post[]> => {
 });
 
 /**
+ * Existence check for a published post by slug.
+ *
+ * Field-projected (select: { slug: true }), depth: 0, limit: 1 — used by
+ * `src/proxy.ts` to short-circuit missing slugs without paying the cost
+ * of pulling the full Post document (Lexical body, references, joined
+ * media). The proxy runs on every uncached `/posts/<slug>` request, so
+ * dropping the full-document load here is a meaningful saving.
+ *
+ * Not wrapped in `cache()` — the proxy's React-`cache()` scope is not
+ * shared with the page handler in Next.js 16 (proxy.ts and the page
+ * render are separate execution contexts), so caching here would only
+ * deduplicate within a single proxy invocation, where the same slug is
+ * never queried twice.
+ *
+ * @param slug - Raw slug string from URL params (validated internally)
+ * @returns true if a published post with this slug exists, false otherwise
+ */
+export const postSlugExists = async (slug: string): Promise<boolean> => {
+  if (!isValidSlug(slug)) {
+    return false;
+  }
+
+  const validatedSlug: Slug = slug;
+
+  try {
+    const payload = await getPayload({ config });
+    const { docs } = await payload.find({
+      collection: 'posts',
+      where: {
+        slug: { equals: validatedSlug },
+        status: { equals: 'published' },
+      },
+      select: { slug: true },
+      depth: 0,
+      limit: 1,
+    });
+    return docs.length > 0;
+  } catch (error) {
+    logError(
+      'Failed to check post slug existence',
+      error,
+      { collection: 'posts', slug: validatedSlug },
+      ErrorIds.PAYLOAD_FIND_FAILED
+    );
+    throw error;
+  }
+};
+
+/**
  * Get post by slug with branded type validation
  * Cached to prevent duplicate queries in generateMetadata + page component
  *

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -21,10 +21,14 @@ import type { NextRequest } from "next/server";
  *   - Slugs follow `isValidSlug` (lowercase alphanumeric + hyphens).
  *     Format-invalid slugs are short-circuited synchronously — no DB
  *     hop needed.
- *   - The existence check delegates to `getPostBySlug` (the same
- *     React-`cache()`-wrapped query the page uses). The downstream
- *     page render therefore hits a primed Payload connection rather
- *     than a cold-start one.
+ *   - The existence check delegates to `postSlugExists`, a
+ *     field-projected query (`select: { slug: true }`, depth 0, no
+ *     joins) — it answers existence without pulling the post's Lexical
+ *     body, references, or joined media. The proxy lookup is separate
+ *     from the page handler's `getPostBySlug` — React `cache()` is
+ *     per-request and is NOT shared between `proxy.ts` and the page
+ *     render in Next.js 16 (they are distinct execution contexts). The
+ *     cost is one extra projected query in the proxy.
  *   - Errors during the existence check fail OPEN (pass through to the
  *     page). A transient DB outage shouldn't paint the entire site 404.
  *
@@ -38,7 +42,12 @@ import type { NextRequest } from "next/server";
  * cannot import Payload's transitive deps (`url`, `fs`, `sharp`).
  */
 
-const TRAILING_PUNCT_PATTERN = /^(\/posts\/[a-z0-9-]+?)['")\].,;:!?]+$/i;
+// Trailing-punctuation characters are case-invariant, and the downstream
+// slug pattern + `isFormatValidSlug` are case-sensitive (lowercase only).
+// Using `/i` here would 301 `/posts/Foo'` to `/posts/Foo` which would
+// then 404 — an extra hop. Drop the `/i` and let mixed-case slugs fall
+// through; they'd 404 anyway since they don't match the slug format.
+const TRAILING_PUNCT_PATTERN = /^(\/posts\/[a-z0-9-]+?)['")\].,;:!?]+$/;
 const POSTS_SLUG_PATTERN = /^\/posts\/([a-z0-9-]+)$/;
 
 // Synchronous slug-format check — mirrors `isValidSlug` from
@@ -62,9 +71,8 @@ function isFormatValidSlug(slug: string): boolean {
  */
 async function defaultPostSlugExists(slug: string): Promise<boolean | null> {
   try {
-    const { getPostBySlug } = await import("@/lib/queries/posts");
-    const post = await getPostBySlug(slug);
-    return post !== null;
+    const { postSlugExists } = await import("@/lib/queries/posts");
+    return await postSlugExists(slug);
   } catch {
     // Fail open — let the page handle it.
     return null;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,171 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+/**
+ * Proxy handler for `/posts/<slug>` routes (issue #414).
+ *
+ * Two concerns:
+ *   1. Trailing-punctuation redirect — AI-generated markdown links and
+ *      search-index crawlers produce URLs with stray trailing punctuation
+ *      (e.g. `/posts/some-slug'`, `/posts/some-slug)`). Strip the
+ *      punctuation and 301 to the canonical URL.
+ *   2. Soft-404 short-circuit — Next.js ISR caches the `notFound()`
+ *      render as a successful 200 with the page's normal `s-maxage`
+ *      headers (vercel/next.js#43831, #79497). To keep `revalidate = 3600`
+ *      on valid posts but avoid soft-404s on missing ones, we do a
+ *      fast slug-existence check here (BEFORE the page enters the ISR
+ *      cache envelope) and emit a proper 404 with no-cache headers when
+ *      the slug doesn't resolve to a published post.
+ *
+ * Implementation notes:
+ *   - Slugs follow `isValidSlug` (lowercase alphanumeric + hyphens).
+ *     Format-invalid slugs are short-circuited synchronously — no DB
+ *     hop needed.
+ *   - The existence check delegates to `getPostBySlug` (the same
+ *     React-`cache()`-wrapped query the page uses). The downstream
+ *     page render therefore hits a primed Payload connection rather
+ *     than a cold-start one.
+ *   - Errors during the existence check fail OPEN (pass through to the
+ *     page). A transient DB outage shouldn't paint the entire site 404.
+ *
+ * Next 16 naming: this file is `proxy.ts` rather than `middleware.ts`
+ * because `proxy.ts` runs on the Node.js runtime (per the Next 16
+ * upgrade guide), and the existence check imports Payload which is
+ * Node-only. The issue spec uses the `middleware` term but the
+ * mechanism it specifies — a per-request handler that runs before the
+ * route — is exactly what `proxy.ts` provides in Next 16. The legacy
+ * `middleware.ts` file convention defaults to the Edge runtime, which
+ * cannot import Payload's transitive deps (`url`, `fs`, `sharp`).
+ */
+
+const TRAILING_PUNCT_PATTERN = /^(\/posts\/[a-z0-9-]+?)['")\].,;:!?]+$/i;
+const POSTS_SLUG_PATTERN = /^\/posts\/([a-z0-9-]+)$/;
+
+// Synchronous slug-format check — mirrors `isValidSlug` from
+// `src/lib/types/branded.ts`. Inlined here so the proxy bundle doesn't
+// need to pull the branded-types module's transitive imports.
+const SLUG_FORMAT = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const SLUG_MAX_LENGTH = 200;
+
+function isFormatValidSlug(slug: string): boolean {
+  return (
+    slug.length > 0 && slug.length <= SLUG_MAX_LENGTH && SLUG_FORMAT.test(slug)
+  );
+}
+
+/**
+ * Existence-check delegate, broken out so unit tests can swap it via
+ * `__testing__.setPostSlugExists` without booting Payload. The
+ * production binding (below) defers the Payload import so proxy module
+ * load doesn't pull the CMS into the cold-start path; the cost is only
+ * paid on actual `/posts/<slug>` requests.
+ */
+async function defaultPostSlugExists(slug: string): Promise<boolean | null> {
+  try {
+    const { getPostBySlug } = await import("@/lib/queries/posts");
+    const post = await getPostBySlug(slug);
+    return post !== null;
+  } catch {
+    // Fail open — let the page handle it.
+    return null;
+  }
+}
+
+// Mutable binding so tests can override. Production code never
+// reassigns this.
+// eslint-disable-next-line prefer-const
+let postSlugExistsImpl: (slug: string) => Promise<boolean | null> =
+  defaultPostSlugExists;
+
+// Minimal not-found HTML body. The browser shows a stripped-down 404
+// page; this path is exercised primarily by crawlers and typo'd URLs,
+// not human navigation, so we trade full-layout fidelity for the
+// out-of-ISR-cache 404 status that fixes the soft-404 bug.
+const NOT_FOUND_BODY = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Post not found · detached-node</title>
+    <style>
+      body { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: #fafafa; color: #18181b; margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center; }
+      main { text-align: center; padding: 2rem; }
+      h1 { font-size: 1.5rem; margin: 0 0 0.5rem; }
+      p { color: #71717a; margin: 0 0 1.5rem; }
+      a { color: #18181b; text-decoration: underline; text-underline-offset: 4px; }
+      @media (prefers-color-scheme: dark) { body { background: #18181b; color: #fafafa; } p { color: #a1a1aa; } a { color: #fafafa; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p style="font-size: 0.875rem; margin-bottom: 0.5rem;">404</p>
+      <h1>Post not found</h1>
+      <p>This post does not exist, or may have been removed.</p>
+      <a href="/posts">Browse all posts</a>
+    </main>
+  </body>
+</html>`;
+
+function notFoundResponse(): NextResponse {
+  return new NextResponse(NOT_FOUND_BODY, {
+    status: 404,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+    },
+  });
+}
+
+export async function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // 1. Trailing-punctuation redirect — runs first so the canonical URL
+  // is what the existence check below evaluates on the next hop.
+  const puncMatch = pathname.match(TRAILING_PUNCT_PATTERN);
+  if (puncMatch) {
+    const canonicalPath = puncMatch[1];
+    const redirectUrl = new URL(canonicalPath, request.url);
+    redirectUrl.search = request.nextUrl.search;
+    return NextResponse.redirect(redirectUrl, 301);
+  }
+
+  // 2. Soft-404 short-circuit — only fires on canonical `/posts/<slug>`
+  // shapes (after the redirect above has cleaned trailing chars).
+  const slugMatch = pathname.match(POSTS_SLUG_PATTERN);
+  if (slugMatch) {
+    const slug = slugMatch[1];
+    if (!isFormatValidSlug(slug)) {
+      return notFoundResponse();
+    }
+    const exists = await postSlugExistsImpl(slug);
+    if (exists === false) {
+      return notFoundResponse();
+    }
+    // `null` (DB unavailable) → fall through to page, fail-open.
+  }
+
+  return NextResponse.next();
+}
+
+/**
+ * Test-only: swap the existence-check delegate so unit tests don't
+ * boot Payload. Reset via `resetPostSlugExists` in `afterEach`.
+ */
+export const __testing__ = {
+  setPostSlugExists: (fn: (slug: string) => Promise<boolean | null>): void => {
+    postSlugExistsImpl = fn;
+  },
+  resetPostSlugExists: (): void => {
+    postSlugExistsImpl = defaultPostSlugExists;
+  },
+};
+
+/**
+ * Narrow the matcher to `/posts/<slug>` paths only — never the `/posts`
+ * listing, never any other route. The handler regexes still gate the
+ * actual behavior at runtime.
+ */
+export const config = {
+  matcher: ["/posts/:slug+"],
+};

--- a/tests/e2e/public/posts-soft-404.spec.ts
+++ b/tests/e2e/public/posts-soft-404.spec.ts
@@ -25,13 +25,23 @@ test.describe('posts/[slug] — HTTP contract', () => {
     // Use the slug from the issue — the apostrophe is the AI-generated
     // typo we're protecting against. We follow the redirect chain via
     // page.goto and assert (a) the final URL is canonical, and (b) the
-    // first response in the chain is a 301.
+    // first server-emitted response in the chain is a 301.
     //
     // page.goto returns the LAST response. To prove the redirect was 301,
     // we listen to the response event for the leading hop.
+    //
+    // Filter: Chromium emits its own internal 307 "Internal Redirect" to
+    // URL-encode the apostrophe before the request leaves the browser.
+    // That hop is a client-side artefact, not the contract under test —
+    // skip it and assert against the first redirect that actually
+    // originates from the server.
     const redirectResponses: { url: string; status: number }[] = []
     page.on('response', (resp) => {
-      if (resp.status() >= 300 && resp.status() < 400) {
+      if (
+        resp.status() >= 300 &&
+        resp.status() < 400 &&
+        resp.statusText() !== 'Internal Redirect'
+      ) {
         redirectResponses.push({ url: resp.url(), status: resp.status() })
       }
     })
@@ -41,7 +51,7 @@ test.describe('posts/[slug] — HTTP contract', () => {
     )
     expect(finalResponse, 'page.goto should return a response').not.toBeNull()
 
-    // The first redirect we captured must be a 301 on the punctuated URL.
+    // The first server redirect we captured must be a 301 on the punctuated URL.
     const firstRedirect = redirectResponses[0]
     expect(firstRedirect, 'a 3xx hop was expected').toBeDefined()
     expect(firstRedirect!.status, 'redirect must be 301 (permanent)').toBe(301)
@@ -62,9 +72,15 @@ test.describe('posts/[slug] — HTTP contract', () => {
   test('trailing parenthesis on a slug also 301-redirects', async ({ page }) => {
     // Defensive coverage for the second punctuation class — apostrophe
     // is the wild-traffic case, but the spec requires the full set.
+    // Filter out Chromium's internal URL-canonicalization 307 (see the
+    // apostrophe test above) so we assert against the server-emitted hop.
     const redirectResponses: { url: string; status: number }[] = []
     page.on('response', (resp) => {
-      if (resp.status() >= 300 && resp.status() < 400) {
+      if (
+        resp.status() >= 300 &&
+        resp.status() < 400 &&
+        resp.statusText() !== 'Internal Redirect'
+      ) {
         redirectResponses.push({ url: resp.url(), status: resp.status() })
       }
     })

--- a/tests/e2e/public/posts-soft-404.spec.ts
+++ b/tests/e2e/public/posts-soft-404.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * E2E coverage for issue #414 — soft-404 fix + trailing-punctuation
+ * redirect on the /posts/<slug> route.
+ *
+ * These specs intentionally use raw `@playwright/test` (not the fixtures
+ * base) because they only need raw HTTP-status assertions on the dev
+ * server — no Page Object indirection.
+ */
+
+test.describe('posts/[slug] — HTTP contract', () => {
+  test('unknown slug returns HTTP 404 (not a cacheable 200)', async ({ page }) => {
+    const response = await page.goto('/posts/does-not-exist-12345')
+    expect(response, 'page.goto should return a response').not.toBeNull()
+    expect(response!.status()).toBe(404)
+    // Defensive: the not-found.tsx body must be what rendered, not the
+    // listing page or a real post.
+    await expect(page.getByRole('heading', { name: /post not found/i })).toBeVisible()
+  })
+
+  test('trailing apostrophe on a known slug 301-redirects to the canonical URL', async ({
+    page,
+  }) => {
+    // Use the slug from the issue — the apostrophe is the AI-generated
+    // typo we're protecting against. We follow the redirect chain via
+    // page.goto and assert (a) the final URL is canonical, and (b) the
+    // first response in the chain is a 301.
+    //
+    // page.goto returns the LAST response. To prove the redirect was 301,
+    // we listen to the response event for the leading hop.
+    const redirectResponses: { url: string; status: number }[] = []
+    page.on('response', (resp) => {
+      if (resp.status() >= 300 && resp.status() < 400) {
+        redirectResponses.push({ url: resp.url(), status: resp.status() })
+      }
+    })
+
+    const finalResponse = await page.goto(
+      "/posts/agentic-patterns-in-your-coding-workflow'",
+    )
+    expect(finalResponse, 'page.goto should return a response').not.toBeNull()
+
+    // The first redirect we captured must be a 301 on the punctuated URL.
+    const firstRedirect = redirectResponses[0]
+    expect(firstRedirect, 'a 3xx hop was expected').toBeDefined()
+    expect(firstRedirect!.status, 'redirect must be 301 (permanent)').toBe(301)
+    expect(firstRedirect!.url).toMatch(
+      /\/posts\/agentic-patterns-in-your-coding-workflow'$/,
+    )
+
+    // Final URL is the canonical slug (no apostrophe). The page may
+    // resolve to a 200 (post exists) or a 404 (post not seeded in test
+    // DB) — both are acceptable for proving the redirect happened.
+    // The contract under test is the 301; the destination's own status
+    // is not in scope of issue #414.
+    expect(page.url()).toMatch(
+      /\/posts\/agentic-patterns-in-your-coding-workflow$/,
+    )
+  })
+
+  test('trailing parenthesis on a slug also 301-redirects', async ({ page }) => {
+    // Defensive coverage for the second punctuation class — apostrophe
+    // is the wild-traffic case, but the spec requires the full set.
+    const redirectResponses: { url: string; status: number }[] = []
+    page.on('response', (resp) => {
+      if (resp.status() >= 300 && resp.status() < 400) {
+        redirectResponses.push({ url: resp.url(), status: resp.status() })
+      }
+    })
+
+    await page.goto('/posts/some-test-slug)')
+    const firstRedirect = redirectResponses[0]
+    expect(firstRedirect).toBeDefined()
+    expect(firstRedirect!.status).toBe(301)
+    expect(page.url()).toMatch(/\/posts\/some-test-slug$/)
+  })
+})

--- a/tests/unit/app/posts-slug-page.test.ts
+++ b/tests/unit/app/posts-slug-page.test.ts
@@ -52,6 +52,24 @@ vi.mock("@/lib/queries/posts", () => ({
   getPublishedPosts: vi.fn(() => Promise.resolve([])),
 }));
 
+// Stub the Payload config + client so the page's transitive deps (e.g.
+// `@/components/RelatedPosts` → `@/lib/queries/related-posts`) don't pull
+// `@payload-config` at module load — that file calls `assertRequiredEnv`
+// for `PAYLOAD_SECRET` + `DATABASE_URL` at import time and would throw
+// under the CI unit-test job (which doesn't provision those env vars).
+// Matches the pattern in `tests/unit/lib/queries/posts.test.ts`.
+vi.mock("@payload-config", () => ({
+  default: {},
+}));
+vi.mock("payload", () => ({
+  getPayload: vi.fn(async () => ({
+    find: vi.fn(async () => ({ docs: [] })),
+  })),
+}));
+vi.mock("@/lib/queries/related-posts", () => ({
+  getRelatedPosts: vi.fn(() => Promise.resolve([])),
+}));
+
 // Mock logging to avoid noisy stderr during tests.
 vi.mock("@/lib/logging", () => ({
   logWarning: vi.fn(),

--- a/tests/unit/app/posts-slug-page.test.ts
+++ b/tests/unit/app/posts-slug-page.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The page module transitively reads `NEXT_PUBLIC_SERVER_URL` via
+// `siteUrl` (which calls `assertRequiredEnv` at module load). Stub it
+// before the dynamic import so the page module loads cleanly under
+// jsdom without requiring a real env file.
+process.env.NEXT_PUBLIC_SERVER_URL ||= "http://localhost:3000";
+
+/**
+ * Issue #414 regression test: the post page route must call `notFound()`
+ * for any slug that doesn't resolve to a published post.
+ *
+ * Status-code assertion is intentionally NOT done here — `notFound()`
+ * throws `NEXT_NOT_FOUND` (a framework-internal sentinel), and the HTTP
+ * 404 emission is the framework's job once that throw is caught.
+ * Importantly, ISR + `dynamicParams=true` causes Next.js to cache the
+ * `notFound()` render as a successful 200 with the page's `s-maxage`
+ * headers — the soft-404 trap fixed by this issue (vercel/next.js#43831).
+ * That status-code path is short-circuited *before* this page handler
+ * runs by `src/proxy.ts`, which does the existence check at the proxy
+ * layer (outside the ISR cache envelope) and emits the real 404 with
+ * `no-cache` headers.
+ *
+ * This unit test covers the page's contract on the slow-path (proxy
+ * fail-open: DB unavailable). The HTTP-status verification on the
+ * fast-path lives in the Playwright E2E `unknown post slug returns 404`
+ * spec and in the post-deploy curl verification documented in the issue
+ * body.
+ */
+
+// Capture the notFound() invocation
+const notFoundSpy = vi.fn(() => {
+  // Real notFound() throws NEXT_NOT_FOUND. Mirror the throw so callers
+  // short-circuit and downstream code that assumes "control does not
+  // return from notFound()" still holds.
+  const err = new Error("NEXT_NOT_FOUND");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (err as any).digest = "NEXT_NOT_FOUND";
+  throw err;
+});
+
+// Override the global setup mock for next/navigation
+vi.mock("next/navigation", () => ({
+  notFound: notFoundSpy,
+}));
+
+// Mock the data layer — the page's only external dependency for the
+// pre-render check we care about. Default: slug not found.
+const getPostBySlugMock = vi.fn();
+vi.mock("@/lib/queries/posts", () => ({
+  getPostBySlug: getPostBySlugMock,
+  getPublishedPosts: vi.fn(() => Promise.resolve([])),
+}));
+
+// Mock logging to avoid noisy stderr during tests.
+vi.mock("@/lib/logging", () => ({
+  logWarning: vi.fn(),
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+// Pull the page module AFTER mocks are installed.
+async function loadPage() {
+  return await import("@/app/(frontend)/posts/[slug]/page");
+}
+
+describe("posts/[slug]/page: soft-404 fix (issue #414)", () => {
+  beforeEach(() => {
+    notFoundSpy.mockClear();
+    getPostBySlugMock.mockReset();
+  });
+
+  it("calls notFound() when the slug is not a valid format", async () => {
+    const { default: PostPage } = await loadPage();
+    await expect(
+      // Uppercase + spaces => isValidSlug() returns false
+      PostPage({ params: Promise.resolve({ slug: "Not A Valid Slug" }) }),
+    ).rejects.toThrow(/NEXT_NOT_FOUND/);
+    expect(notFoundSpy).toHaveBeenCalledTimes(1);
+    // getPostBySlug should NOT be hit when format validation fails first.
+    expect(getPostBySlugMock).not.toHaveBeenCalled();
+  });
+
+  it("calls notFound() when getPostBySlug returns null (slug not in DB)", async () => {
+    getPostBySlugMock.mockResolvedValue(null);
+    const { default: PostPage } = await loadPage();
+    await expect(
+      PostPage({
+        params: Promise.resolve({ slug: "does-not-exist-12345" }),
+      }),
+    ).rejects.toThrow(/NEXT_NOT_FOUND/);
+    expect(notFoundSpy).toHaveBeenCalledTimes(1);
+    expect(getPostBySlugMock).toHaveBeenCalledWith("does-not-exist-12345");
+  });
+
+  it("does NOT call notFound() when the post resolves successfully", async () => {
+    // Minimal Post shape the page renders without throwing. The point
+    // of this test is to confirm that the early-return short-circuits
+    // notFound() — full render fidelity isn't required.
+    const fakePost = {
+      id: "00000000-0000-4000-8000-000000000000",
+      slug: "real-post",
+      title: "Real Post",
+      summary: "summary",
+      publishedAt: "2026-01-01T00:00:00.000Z",
+      body: { root: { children: [], direction: null, format: "", indent: 0, type: "root", version: 1 } },
+      references: [],
+      featuredImageLight: null,
+      featuredImageDark: null,
+      focalPoint: null,
+      status: "published",
+    };
+    getPostBySlugMock.mockResolvedValue(fakePost);
+    const { default: PostPage } = await loadPage();
+    // The component returns JSX; we only care that notFound was NOT called.
+    // We swallow downstream rendering errors that come from the JSX
+    // referencing components/styles we haven't mocked — those don't bear
+    // on the soft-404 contract.
+    try {
+      await PostPage({
+        params: Promise.resolve({ slug: "real-post" }),
+      });
+    } catch (err) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if ((err as any)?.message === "NEXT_NOT_FOUND") {
+        throw err; // Genuine failure mode for this test
+      }
+      // Any other render-time error is acceptable here.
+    }
+    expect(notFoundSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/queries/posts.test.ts
+++ b/tests/unit/lib/queries/posts.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Unit tests for `postSlugExists` (issue #414 follow-up).
+ *
+ * The proxy at `src/proxy.ts` calls this query on every uncached
+ * `/posts/<slug>` request — the whole point of swapping it in for
+ * `getPostBySlug` is to avoid pulling the full Post document (Lexical
+ * body, references, joined media) just to answer existence. These tests
+ * pin the contract that makes that saving real:
+ *
+ *   - select is { slug: true } only (no other field requested)
+ *   - depth is 0 (no relationship joins)
+ *   - limit is 1 (Payload knows existence is the only question)
+ *   - filter is { slug equals, status equals 'published' } (matches the
+ *     published-post contract enforced elsewhere)
+ *
+ * The full-doc loader `getPostBySlug` lives downstream in the page
+ * handler; nothing here should accidentally start pulling that payload.
+ */
+
+const findMock = vi.fn();
+
+vi.mock("payload", () => ({
+  getPayload: vi.fn(async () => ({
+    find: findMock,
+  })),
+}));
+
+vi.mock("@payload-config", () => ({
+  default: {},
+}));
+
+vi.mock("@/lib/logging", () => ({
+  logError: vi.fn(),
+}));
+
+import { postSlugExists } from "@/lib/queries/posts";
+
+beforeEach(() => {
+  findMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("postSlugExists", () => {
+  it("returns true when a published post with the slug exists", async () => {
+    findMock.mockResolvedValue({ docs: [{ id: "1", slug: "real-slug" }] });
+
+    const result = await postSlugExists("real-slug");
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when no matching published post exists", async () => {
+    findMock.mockResolvedValue({ docs: [] });
+
+    const result = await postSlugExists("does-not-exist");
+
+    expect(result).toBe(false);
+  });
+
+  it("uses field projection (select: { slug: true } only) — no full doc load", async () => {
+    findMock.mockResolvedValue({ docs: [] });
+
+    await postSlugExists("any-slug");
+
+    expect(findMock).toHaveBeenCalledTimes(1);
+    const callArgs = findMock.mock.calls[0][0];
+    // The whole point of this query: select narrows to slug ONLY.
+    // No body, no references, no featured-image relationships.
+    expect(callArgs.select).toEqual({ slug: true });
+  });
+
+  it("passes depth: 0 (no relationship joins) and limit: 1", async () => {
+    findMock.mockResolvedValue({ docs: [] });
+
+    await postSlugExists("any-slug");
+
+    const callArgs = findMock.mock.calls[0][0];
+    expect(callArgs.depth).toBe(0);
+    expect(callArgs.limit).toBe(1);
+  });
+
+  it("queries the posts collection filtered by slug + published status", async () => {
+    findMock.mockResolvedValue({ docs: [] });
+
+    await postSlugExists("agentic-patterns");
+
+    const callArgs = findMock.mock.calls[0][0];
+    expect(callArgs.collection).toBe("posts");
+    expect(callArgs.where).toEqual({
+      slug: { equals: "agentic-patterns" },
+      status: { equals: "published" },
+    });
+  });
+
+  it("returns false for format-invalid slugs without hitting the DB", async () => {
+    // Mixed-case fails `isValidSlug` (lowercase + hyphens only).
+    const result = await postSlugExists("Mixed-Case");
+
+    expect(result).toBe(false);
+    expect(findMock).not.toHaveBeenCalled();
+  });
+
+  it("returns false for empty-string slugs without hitting the DB", async () => {
+    const result = await postSlugExists("");
+
+    expect(result).toBe(false);
+    expect(findMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates DB errors so the proxy fail-open wrapper can translate them", async () => {
+    findMock.mockRejectedValue(new Error("connection refused"));
+
+    await expect(postSlugExists("any-slug")).rejects.toThrow(
+      "connection refused",
+    );
+  });
+});

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// NextResponse mock: capture redirect target + status for assertions,
+// emit sentinels for `.next()` and bare 404 responses so we can assert
+// each branch.
+const REDIRECT = Symbol("redirect");
+const NEXT = Symbol("next");
+const RESPONSE = Symbol("response");
+
+type RedirectResult = {
+  kind: typeof REDIRECT;
+  url: string;
+  status: number;
+};
+
+type NextResult = {
+  kind: typeof NEXT;
+};
+
+type ResponseResult = {
+  kind: typeof RESPONSE;
+  status: number;
+  cacheControl: string | undefined;
+  contentType: string | undefined;
+  body: string;
+};
+
+vi.mock("next/server", () => ({
+  NextResponse: class {
+    static redirect(url: URL, status?: number): RedirectResult {
+      return {
+        kind: REDIRECT,
+        url: url.toString(),
+        status: status ?? 307,
+      };
+    }
+    static next(): NextResult {
+      return { kind: NEXT };
+    }
+    constructor(body: BodyInit | null, init?: ResponseInit) {
+      const headers = new Headers(init?.headers);
+      return {
+        kind: RESPONSE,
+        status: init?.status ?? 200,
+        cacheControl: headers.get("cache-control") ?? undefined,
+        contentType: headers.get("content-type") ?? undefined,
+        body: typeof body === "string" ? body : "",
+      } as unknown as ResponseResult;
+    }
+  },
+}));
+
+import { proxy, __testing__ } from "@/proxy";
+
+/**
+ * Construct a minimal NextRequest-shaped object that the proxy
+ * function actually reads from: `nextUrl.pathname`, `nextUrl.search`,
+ * and `url`. Avoids pulling the full NextRequest constructor (which
+ * needs the Web `Request` polyfill and a request-context store).
+ */
+function makeRequest(pathname: string, search = ""): unknown {
+  const base = "http://localhost:3000";
+  const url = base + pathname + search;
+  return {
+    nextUrl: { pathname, search },
+    url,
+  };
+}
+
+const slugExistsMock = vi.fn();
+
+beforeEach(() => {
+  slugExistsMock.mockReset();
+  // Default: slug exists in DB (passes through). Tests that need a
+  // missing or DB-failure path override per-test.
+  slugExistsMock.mockResolvedValue(true);
+  __testing__.setPostSlugExists(slugExistsMock);
+});
+
+afterEach(() => {
+  __testing__.resetPostSlugExists();
+});
+
+describe("proxy: trailing-punctuation redirect for /posts/<slug>", () => {
+  it("strips a trailing apostrophe and 301s to the canonical slug", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await proxy(makeRequest("/posts/agentic-patterns'") as any);
+    expect(result).toMatchObject({
+      kind: REDIRECT,
+      url: "http://localhost:3000/posts/agentic-patterns",
+      status: 301,
+    });
+    // Redirect path must NOT trigger an existence check — the redirect
+    // is the only network hop the proxy should issue here.
+    expect(slugExistsMock).not.toHaveBeenCalled();
+  });
+
+  it("strips multiple trailing punctuation characters in one redirect", async () => {
+    const result = await proxy(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeRequest("/posts/my-post')") as any,
+    );
+    expect(result).toMatchObject({
+      kind: REDIRECT,
+      url: "http://localhost:3000/posts/my-post",
+      status: 301,
+    });
+  });
+
+  it("strips a mix of trailing characters (period, comma, semicolon, etc.)", async () => {
+    const cases: [string, string][] = [
+      ["/posts/foo.", "/posts/foo"],
+      ["/posts/foo,", "/posts/foo"],
+      ['/posts/foo"', "/posts/foo"],
+      ["/posts/foo)", "/posts/foo"],
+      ["/posts/foo]", "/posts/foo"],
+      ["/posts/foo;", "/posts/foo"],
+      ["/posts/foo:", "/posts/foo"],
+      ["/posts/foo!", "/posts/foo"],
+      ["/posts/foo?", "/posts/foo"],
+    ];
+    for (const [input, expectedPath] of cases) {
+      const result = (await proxy(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        makeRequest(input) as any,
+      )) as unknown as RedirectResult;
+      expect(result.kind, `input=${input}`).toBe(REDIRECT);
+      expect(result.url, `input=${input}`).toBe(
+        "http://localhost:3000" + expectedPath,
+      );
+      expect(result.status, `input=${input}`).toBe(301);
+    }
+  });
+
+  it("preserves the query string on redirect", async () => {
+    const result = await proxy(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeRequest("/posts/foo'", "?ref=bing") as any,
+    );
+    expect(result).toMatchObject({
+      kind: REDIRECT,
+      url: "http://localhost:3000/posts/foo?ref=bing",
+      status: 301,
+    });
+  });
+});
+
+describe("proxy: soft-404 short-circuit", () => {
+  it("passes a clean /posts/<slug> path through when the post exists", async () => {
+    slugExistsMock.mockResolvedValue(true);
+    const result = await proxy(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeRequest("/posts/agentic-patterns") as any,
+    );
+    expect(result).toMatchObject({ kind: NEXT });
+    expect(slugExistsMock).toHaveBeenCalledTimes(1);
+    expect(slugExistsMock).toHaveBeenCalledWith("agentic-patterns");
+  });
+
+  it("returns 404 with no-cache headers when the post does NOT exist", async () => {
+    slugExistsMock.mockResolvedValue(false);
+    const result = (await proxy(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeRequest("/posts/does-not-exist-12345") as any,
+    )) as unknown as ResponseResult;
+    expect(result.kind).toBe(RESPONSE);
+    expect(result.status).toBe(404);
+    expect(result.cacheControl).toMatch(/no-store/);
+    expect(result.cacheControl).toMatch(/must-revalidate/);
+    // Sanity: the body includes the not-found UI text we serve.
+    expect(result.body).toMatch(/Post not found/i);
+  });
+
+  it("returns 404 synchronously for format-invalid slugs (no DB hop)", async () => {
+    // Slugs longer than SLUG_MAX_LENGTH (200) fail format validation
+    // before the existence check.
+    const longSlug = "a".repeat(201);
+    const result = (await proxy(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeRequest("/posts/" + longSlug) as any,
+    )) as unknown as ResponseResult;
+    expect(result.kind).toBe(RESPONSE);
+    expect(result.status).toBe(404);
+    expect(slugExistsMock).not.toHaveBeenCalled();
+  });
+
+  it("falls open (passes through) when the existence check returns null", async () => {
+    // null = DB unavailable / fail-open path. The page handler will
+    // still try and call notFound() — we don't want a transient DB
+    // outage to paint the entire post route 404.
+    slugExistsMock.mockResolvedValue(null);
+    const result = await proxy(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeRequest("/posts/some-slug") as any,
+    );
+    expect(result).toMatchObject({ kind: NEXT });
+  });
+});
+
+describe("proxy: scope discipline", () => {
+  it("passes through the /posts listing (no slug) unchanged", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await proxy(makeRequest("/posts") as any);
+    expect(result).toMatchObject({ kind: NEXT });
+    expect(slugExistsMock).not.toHaveBeenCalled();
+  });
+
+  it("passes through /posts/ (trailing slash, no slug) unchanged", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await proxy(makeRequest("/posts/") as any);
+    expect(result).toMatchObject({ kind: NEXT });
+    expect(slugExistsMock).not.toHaveBeenCalled();
+  });
+
+  it("does not touch non-/posts/ paths even if they end in punctuation", async () => {
+    const cases = [
+      "/about'",
+      "/agentic-design-patterns/reflexion'",
+      "/posts-nested/foo'",
+      "/api/health.",
+    ];
+    for (const path of cases) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await proxy(makeRequest(path) as any);
+      expect(result, `input=${path}`).toMatchObject({ kind: NEXT });
+    }
+    expect(slugExistsMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -143,6 +143,26 @@ describe("proxy: trailing-punctuation redirect for /posts/<slug>", () => {
       status: 301,
     });
   });
+
+  it("does NOT redirect mixed-case slugs (case-sensitive — avoids 301→404 hop)", async () => {
+    // The trailing-punctuation regex was previously `/i`, which would
+    // match `/posts/Foo'` and 301 to `/posts/Foo` — only to 404 at the
+    // next hop because the downstream slug pattern + `isFormatValidSlug`
+    // are case-sensitive (lowercase only). Dropping `/i` lets mixed-case
+    // paths fall through unchanged (the format-invalid slug check then
+    // 404s them directly, no extra hop).
+    slugExistsMock.mockResolvedValue(false);
+    const result = (await proxy(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeRequest("/posts/Foo'") as any,
+    )) as unknown as ResponseResult | NextResult;
+    // Either a 404 (matcher hit + format check fails) or a pass-through
+    // (`NextResponse.next()`) — what must NOT happen is a 301 to
+    // `/posts/Foo`.
+    expect(result.kind).not.toBe(REDIRECT);
+    // Existence check never runs for format-invalid slugs.
+    expect(slugExistsMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("proxy: soft-404 short-circuit", () => {


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Crawler as Bing/Copilot (or human)
    participant Proxy as src/proxy.ts<br/>(Node runtime)
    participant Page as /posts/[slug]/page.tsx<br/>(ISR, revalidate=3600)
    participant DB as Postgres (posts)

    rect rgb(245, 230, 230)
    Note over Crawler,DB: Path A: trailing-punctuation typo URL
    Crawler->>Proxy: GET /posts/some-slug'
    Proxy->>Proxy: TRAILING_PUNCT_PATTERN match
    Proxy-->>Crawler: 301 Moved Permanently<br/>location: /posts/some-slug
    end

    rect rgb(255, 240, 215)
    Note over Crawler,DB: Path B: missing slug (the soft-404 bug)
    Crawler->>Proxy: GET /posts/does-not-exist-12345
    Proxy->>DB: SELECT 1 ... slug='does-not-exist-12345'
    DB-->>Proxy: rowCount=0
    Proxy-->>Crawler: 404 Not Found<br/>Cache-Control: no-cache, no-store,<br/>max-age=0, must-revalidate
    Note right of Proxy: Page never enters the ISR<br/>cache envelope. The 404 is not<br/>baked as a successful prerender.
    end

    rect rgb(230, 245, 230)
    Note over Crawler,DB: Path C: valid post (unchanged behavior)
    Crawler->>Proxy: GET /posts/real-post-slug
    Proxy->>DB: SELECT 1 ... slug='real-post-slug'
    DB-->>Proxy: rowCount=1
    Proxy-->>Page: NextResponse.next()
    Page->>DB: getPostBySlug() [Payload]
    DB-->>Page: Post
    Page-->>Crawler: 200 OK<br/>Cache-Control: s-maxage=3600,<br/>stale-while-revalidate=...
    end
```

## Summary

- **Why:** Live curl against production confirmed the issue's diagnosis — ISR + `dynamicParams=true` was caching `notFound()` renders as cacheable HTTP 200s with `s-maxage=3600`, indexable by Bing and citable by Copilot (vercel/next.js#43831, #79497).
- **Fix:** A Node-runtime ` src/proxy.ts` (Next 16's middleware successor) does a fast slug-existence check BEFORE the ISR-cached page route is entered. Missing slugs short-circuit at the proxy layer with a real 404 + no-cache headers; valid slugs pass through to the page, which keeps ` revalidate = 3600` untouched.
- **Trailing punctuation:** Same proxy 301-redirects ` /posts/<slug>` URLs that end in `'\"\")].,;:!?` to the canonical slug. Matcher narrowed to ` /posts/:slug+` so the proxy never fires on the listing or other routes.

## Screenshots

N/A — not UI. The diff is a Node-runtime proxy file, three test files, and a comment update on ` page.tsx`. No React component changes.

## Test plan

- [x] ` pnpm lint` — 0 errors (20 pre-existing warnings, none touch the new files)
- [x] ` pnpm typecheck` — clean
- [x] ` pnpm test:unit` — 598 / 598 passing (39 files; ` proxy.test.ts` = 11 new, ` posts-slug-page.test.ts` = 3 new)
- [x] ` pnpm build` — clean production build with stub env (` Proxy (Middleware)` registered in output)
- [x] Local prod ` pnpm start` + curl verification (output below)
- [ ] ` pnpm test:e2e` — not runnable locally without a seeded test DB (` pnpm seed:test` needs real DATABASE_URL); CI will validate against the seeded staging env

### Local verification (` pnpm start` against stub DB)

` ` `
=== Missing slug returns 404 + no-cache ===
$ curl -sI http://localhost:3000/posts/does-not-exist-12345
HTTP/1.1 404 Not Found
cache-control: no-cache, no-store, max-age=0, must-revalidate

=== Trailing apostrophe 301 redirects ===
$ curl -sI \"http://localhost:3000/posts/agentic-patterns-in-your-coding-workflow'\"
HTTP/1.1 301 Moved Permanently
location: /posts/agentic-patterns-in-your-coding-workflow

=== Full chain (--max-redirs follow) ===
$ curl -sIL \"http://localhost:3000/posts/agentic-patterns-in-your-coding-workflow'\"
HTTP/1.1 301 Moved Permanently
location: /posts/agentic-patterns-in-your-coding-workflow
HTTP/1.1 404 Not Found
cache-control: no-cache, no-store, max-age=0, must-revalidate
` ` `

The second 404 in the chain is expected: the local stub DB doesn't contain the canonical post, so the existence check correctly returns false for the redirect target. On production (real DB), the chain terminates in a 200.

## Plan reference

Closes #414.

The issue is part of the SEO + AI-discovery strategy work (` area:seo`) — the soft-404 is the upstream cause of 36% of weekly bot traffic landing on indexable not-found pages.

---

### Non-obvious decisions for the reviewer

1. **File is ` src/proxy.ts`, not ` src/middleware.ts`** as named in the spec. Reason: Next 16 deprecated ` middleware.ts` in favor of ` proxy.ts`. ` middleware.ts` defaults to the Edge runtime, which cannot import Payload's Node-only deps (` url`, ` fs`, ` sharp`). ` proxy.ts` runs on Node, so the existence check can reuse ` getPostBySlug` from ` @/lib/queries/posts`. The issue spec wording predates this Next 16 rename; the mechanism it specifies — a per-request handler that runs before the route — is exactly what ` proxy.ts` provides.

2. **Not-found body is custom HTML** (in ` proxy.ts`), not the React ` not-found.tsx`. The proxy returns a stripped-down 404 page because Next.js doesn't render route-segment ` not-found.tsx` for non-route responses. Trade-off accepted because: (a) the bug's hot traffic is bots, not humans; (b) the layout-matched ` /posts/[slug]/not-found.tsx` still renders when ` notFound()` runs from the page itself (e.g., on a fail-open DB outage); (c) the contract under issue #414 is the HTTP semantics, not the UX of the 404 page itself.

3. **Fail-open on DB error.** If the proxy's existence check throws, it passes through to the page rather than emitting a blanket 404. A transient DB outage shouldn't paint the whole post route 404. The page's own ` notFound()` still fires for genuinely-missing slugs in this case — we accept the soft-404 fallback during a DB outage as a graceful degradation.

4. **Soft-404 unit test asserts ` notFound()` is called**, not the HTTP status. ` notFound()` throws ` NEXT_NOT_FOUND` which the framework intercepts; surfacing the actual 404 status requires a real request through the server. This matches julianken-bot's APPROVE review note that the unit-test status assertion is awkward in Next 16. HTTP-status verification lives in the E2E spec + local curl + the post-deploy ` curl -sI` verification documented in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)