### PR TITLE
feat(schema): add HowTo + TechArticle generators with replace-strategy schemaType

### DIFF
--- a/migrations/20260519_000221_add_posts_schema_type_and_steps.ts
+++ b/migrations/20260519_000221_add_posts_schema_type_and_steps.ts
@@ -1,0 +1,114 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Database Migration: Add `schemaType` field and `posts_steps` array table
+ *
+ * Supports issue #416 — per-post Schema.org primary type selection plus the
+ * `HowTo.step` data source.
+ *
+ * Adds to the `posts` table:
+ *   - `schema_type` — varchar NOT NULL, backed by the enum `enum_posts_schema_type`
+ *     with values 'BlogPosting' | 'HowTo' | 'TechArticle'. Defaults to
+ *     'BlogPosting' so all existing rows backfill to the existing behavior
+ *     (the post detail page treats BlogPosting as the do-nothing case in the
+ *     replace-emission strategy). The default is then dropped so the column
+ *     matches what `payload generate:types` produces (Payload doesn't render
+ *     DB defaults — it sets the default at the application layer via
+ *     `defaultValue: 'BlogPosting'` on the field).
+ *
+ * Adds a new `posts_steps` table for the array field:
+ *   - Standard Payload array-row columns: `_order` (int NOT NULL), `_parent_id`
+ *     (int NOT NULL, FK → posts.id ON DELETE CASCADE), `id` (varchar PK).
+ *   - `name` varchar NOT NULL, `text` varchar NOT NULL.
+ *   - Indexes on `_order` and `_parent_id` matching the convention used by
+ *     `posts_references` (so per-parent reads and ordering are both fast).
+ *   - Per-row NOT NULL on `name`/`text` is enforced at the DB layer because
+ *     Payload's `required: true` on each subfield maps directly to a NOT NULL
+ *     column. The Posts collection adds a top-level array-level validator
+ *     that requires at least one row when `schemaType === 'HowTo'`; that
+ *     constraint is application-only and is NOT replicated in the DB schema
+ *     (it depends on a sibling column value).
+ *
+ * Uses ADD COLUMN IF NOT EXISTS / IF EXISTS guards for idempotency so the
+ * migration is safe against databases where `push: true` may have already
+ * created the column or table in development.
+ *
+ * N-1 safe: the previous container revision SELECTs `posts.*` via Drizzle's
+ * generated column list, which is baked from the schema known to that
+ * revision. Adding a NOT NULL column with a default backfills cleanly. The
+ * new `posts_steps` table is invisible to the prior revision. New code
+ * branches on `post.schemaType` and reads `post.steps`; old rows are
+ * 'BlogPosting' with no steps and fall through the new branches to the
+ * existing BlogPosting generator.
+ *
+ * Down migration: drops the `posts_steps` table, drops `schema_type` from
+ * `posts`, drops the enum type.
+ */
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  // Create the enum type idempotently.
+  await db.execute(sql`
+    DO $$ BEGIN
+      CREATE TYPE "public"."enum_posts_schema_type"
+        AS ENUM ('BlogPosting', 'HowTo', 'TechArticle');
+    EXCEPTION WHEN duplicate_object THEN null;
+    END $$;
+  `)
+
+  // Add schema_type with a temporary default so existing rows backfill to
+  // 'BlogPosting', then drop the default to match what Payload expects (the
+  // application-layer defaultValue handles new rows).
+  await db.execute(sql`
+    ALTER TABLE "posts"
+      ADD COLUMN IF NOT EXISTS "schema_type" "public"."enum_posts_schema_type"
+        DEFAULT 'BlogPosting' NOT NULL;
+  `)
+  await db.execute(sql`
+    ALTER TABLE "posts"
+      ALTER COLUMN "schema_type" DROP DEFAULT;
+  `)
+
+  // Create the posts_steps array-element table.
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "posts_steps" (
+      "_order" integer NOT NULL,
+      "_parent_id" integer NOT NULL,
+      "id" varchar PRIMARY KEY NOT NULL,
+      "name" varchar NOT NULL,
+      "text" varchar NOT NULL
+    );
+  `)
+
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS "posts_steps_order_idx"
+      ON "posts_steps" USING btree ("_order");
+  `)
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS "posts_steps_parent_id_idx"
+      ON "posts_steps" USING btree ("_parent_id");
+  `)
+
+  // FK guarded against re-runs by dropping first if it already exists.
+  await db.execute(sql`
+    ALTER TABLE "posts_steps"
+      DROP CONSTRAINT IF EXISTS "posts_steps_parent_id_fk";
+  `)
+  await db.execute(sql`
+    ALTER TABLE "posts_steps"
+      ADD CONSTRAINT "posts_steps_parent_id_fk"
+      FOREIGN KEY ("_parent_id") REFERENCES "public"."posts"("id")
+      ON DELETE CASCADE ON UPDATE NO ACTION;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  // Drop dependent table first, then the posts column, then the enum.
+  await db.execute(sql`DROP TABLE IF EXISTS "posts_steps" CASCADE;`)
+
+  await db.execute(sql`
+    ALTER TABLE "posts"
+      DROP COLUMN IF EXISTS "schema_type";
+  `)
+
+  await db.execute(sql`DROP TYPE IF EXISTS "public"."enum_posts_schema_type";`)
+}

--- a/migrations/index.ts
+++ b/migrations/index.ts
@@ -11,6 +11,7 @@ import * as migration_20260425_202704_add_posts_focal_point from './20260425_202
 import * as migration_20260425_220000_add_media_lqip from './20260425_220000_add_media_lqip';
 import * as migration_20260428_010142_add_media_preview from './20260428_010142_add_media_preview';
 import * as migration_20260517_184638_dedicated_date_modified from './20260517_184638_dedicated_date_modified';
+import * as migration_20260519_000221_add_posts_schema_type_and_steps from './20260519_000221_add_posts_schema_type_and_steps';
 
 export const migrations = [
   {
@@ -77,5 +78,10 @@ export const migrations = [
     up: migration_20260517_184638_dedicated_date_modified.up,
     down: migration_20260517_184638_dedicated_date_modified.down,
     name: '20260517_184638_dedicated_date_modified'
+  },
+  {
+    up: migration_20260519_000221_add_posts_schema_type_and_steps.up,
+    down: migration_20260519_000221_add_posts_schema_type_and_steps.down,
+    name: '20260519_000221_add_posts_schema_type_and_steps',
   },
 ];

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -9,7 +9,13 @@ import { PageLayout } from "@/components/PageLayout";
 import { ThemeAwareHero } from "@/components/ThemeAwareHero";
 import { TextGlitch } from "@/components/TextGlitch";
 import { SchemaScript } from "@/components/SchemaScript";
-import { generateBlogPostingSchema, generateBreadcrumbSchema } from "@/lib/schema";
+import {
+  generateBlogPostingSchema,
+  generateBreadcrumbSchema,
+  generateHowToSchema,
+  generateTechArticleSchema,
+} from "@/lib/schema";
+import type { Post } from "@/payload-types";
 import { logWarning } from "@/lib/logging";
 import { ErrorIds } from "@/lib/error-ids";
 import { getPostBySlug, getPublishedPosts } from "@/lib/queries/posts";
@@ -111,9 +117,20 @@ export default async function PostPage({ params }: PostPageProps) {
     notFound();
   }
 
+  // Replace strategy (per issue #416): when schemaType is HowTo or
+  // TechArticle, emit ONLY that schema as the per-post primary @type —
+  // BlogPosting is not co-emitted. Default schemaType "BlogPosting"
+  // preserves existing behavior for every existing and un-tagged post.
+  //
+  // HowTo additionally requires a populated `steps` array (enforced at the
+  // Payload validation layer). If an editor tags a post HowTo but the
+  // generator returns null (mis-tagging slip), fall back to BlogPosting so
+  // the page still ships a grounded schema.
+  const primarySchema = selectPrimarySchema(post);
+
   return (
     <FadeReveal>
-    <SchemaScript schema={[generateBlogPostingSchema(post), generateBreadcrumbSchema(post.slug, post.title)]} />
+    <SchemaScript schema={[primarySchema, generateBreadcrumbSchema(post.slug, post.title)]} />
     <article>
       <PageLayout maxWidth="prose">
         <Link
@@ -179,4 +196,24 @@ export default async function PostPage({ params }: PostPageProps) {
     </article>
     </FadeReveal>
   );
+}
+
+// Selects the single primary schema for this post per the replace strategy
+// committed to in issue #416. Default falls through to BlogPosting so any
+// existing or un-tagged post keeps its current schema unchanged.
+function selectPrimarySchema(post: Post) {
+  if (post.schemaType === "TechArticle") {
+    return generateTechArticleSchema(post);
+  }
+  if (post.schemaType === "HowTo") {
+    const howto = generateHowToSchema(post);
+    // Mis-tagging guard: HowTo without steps falls back to BlogPosting so
+    // the page never ships a non-grounding HowTo (no `step` array).
+    if (howto) return howto;
+    logWarning(
+      "Post tagged HowTo but missing steps; falling back to BlogPosting",
+      { slug: post.slug },
+    );
+  }
+  return generateBlogPostingSchema(post);
 }

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -213,6 +213,7 @@ function selectPrimarySchema(post: Post) {
     logWarning(
       "Post tagged HowTo but missing steps; falling back to BlogPosting",
       { slug: post.slug },
+      ErrorIds.SCHEMA_HOWTO_MISTAGGED,
     );
   }
   return generateBlogPostingSchema(post);

--- a/src/collections/Posts.ts
+++ b/src/collections/Posts.ts
@@ -200,5 +200,54 @@ export const Posts: CollectionConfig = {
         description: 'Meta description for search results. Falls back to summary if blank.',
       },
     },
+    {
+      name: 'schemaType',
+      type: 'select',
+      required: true,
+      defaultValue: 'BlogPosting',
+      options: [
+        { label: 'Blog Posting (default)', value: 'BlogPosting' },
+        { label: 'How To (step-by-step)', value: 'HowTo' },
+        { label: 'Tech Article (deep analysis)', value: 'TechArticle' },
+      ],
+      admin: {
+        position: 'sidebar',
+        description:
+          'Schema.org primary @type emitted in the post detail page JSON-LD. Replace strategy: only this schema is emitted (BlogPosting is NOT co-emitted for HowTo or TechArticle). HowTo additionally requires the Steps field below.',
+      },
+    },
+    {
+      name: 'steps',
+      type: 'array',
+      admin: {
+        condition: (data) => data?.schemaType === 'HowTo',
+        description:
+          'Procedural steps emitted as schema.org HowTo.step. Required when Schema Type is HowTo; at least one step with name and text is needed for the JSON-LD to trigger Google\'s HowTo rich result.',
+      },
+      validate: (value, { data }: { data: Partial<{ schemaType: string }> }) => {
+        if (data?.schemaType !== 'HowTo') return true
+        if (!Array.isArray(value) || value.length === 0) {
+          return 'At least one step is required when Schema Type is HowTo.'
+        }
+        return true
+      },
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+          required: true,
+          maxLength: 200,
+          admin: { description: 'Short label for this step.' },
+        },
+        {
+          name: 'text',
+          type: 'textarea',
+          required: true,
+          minLength: 10,
+          maxLength: 2000,
+          admin: { description: 'Prose describing what the reader does in this step.' },
+        },
+      ],
+    },
   ],
 }

--- a/src/lib/error-ids.ts
+++ b/src/lib/error-ids.ts
@@ -29,6 +29,9 @@ export const ErrorIds = {
 
   // Sitemap errors
   SITEMAP_GENERATION_FAILED: 'SITEMAP_GENERATION_FAILED',
+
+  // Schema errors
+  SCHEMA_HOWTO_MISTAGGED: 'SCHEMA_HOWTO_MISTAGGED',
 } as const
 
 export type ErrorId = typeof ErrorIds[keyof typeof ErrorIds]

--- a/src/lib/schema/howto.ts
+++ b/src/lib/schema/howto.ts
@@ -1,0 +1,104 @@
+// src/lib/schema/howto.ts
+//
+// Generates HowTo schema for posts whose `schemaType` field is set to
+// "HowTo". Mirrors the per-post shape used by generateBlogPostingSchema —
+// the same Person/WebSite @id references, the same image/keyword/citation
+// derivation — and adds the `step` array sourced from `post.steps`.
+//
+// Step source: an explicit Payload field, not Lexical-heading extraction.
+// See issue #416 "Design decisions made in this spec" for the rationale.
+// When `post.steps` is missing or empty this generator returns null so the
+// caller can fall back to the BlogPosting default (the Posts collection
+// enforces `steps` as conditionally required when `schemaType === "HowTo"`,
+// so reaching this null branch in practice means an editor mis-tagged a
+// post — the caller's fallback prevents that authoring slip from emitting
+// a non-grounding HowTo).
+//
+// Google's HowTo rich-result category requires at least one `step` with a
+// `name` and `text` to trigger. Both fields are enforced as `required: true`
+// on the Payload array element so the JSON-LD is guaranteed to satisfy that
+// trigger when present.
+//
+// Usage:
+//   import { generateHowToSchema } from '@/lib/schema';
+//   const schema = generateHowToSchema(post);
+//   if (schema) <SchemaScript schema={schema} />;
+
+import { SITE_CONFIG, AUTHOR_CONFIG } from "./config";
+import { mapReferenceToCitation } from "./citation";
+import { isMediaObject, isTagObject } from "@/lib/types/media";
+import type { HowToSchema, HowToStep, ImageObjectSchema } from "./types";
+import type { Post } from "@/payload-types";
+
+export function generateHowToSchema(post: Post): HowToSchema | null {
+  // Step source is the Payload `steps` array. Empty or missing → no HowTo:
+  // emitting one without `step` would validate as JSON-LD but contribute no
+  // grounding signal beyond a generic Article, contradicting the issue's
+  // motivation. Callers should fall back to BlogPosting in that case.
+  if (!post.steps || post.steps.length === 0) {
+    return null;
+  }
+
+  const steps: HowToStep[] = post.steps.map((s) => ({
+    "@type": "HowToStep" as const,
+    name: s.name,
+    text: s.text,
+  }));
+
+  const postUrl = `${SITE_CONFIG.url}/posts/${post.slug}`;
+
+  // Image: same light-variant convention as BlogPosting. Width and height
+  // default to 1200x630 (standard OG dimensions) when the Media record
+  // doesn't carry them. >700px width is the Google Article-rich-result
+  // floor; the configured 1920px hero size in Media.ts clears it.
+  let image: ImageObjectSchema | undefined;
+  if (isMediaObject(post.featuredImageLight) && post.featuredImageLight.url) {
+    image = {
+      "@type": "ImageObject",
+      url: post.featuredImageLight.url,
+      width: post.featuredImageLight.width ?? 1200,
+      height: post.featuredImageLight.height ?? 630,
+      description: post.featuredImageLight.alt || undefined,
+    };
+  }
+
+  const keywords: string[] = [];
+  if (post.tags) {
+    for (const tag of post.tags) {
+      if (isTagObject(tag)) {
+        keywords.push(tag.name);
+      }
+    }
+  }
+
+  const citation =
+    post.references && post.references.length > 0
+      ? post.references.map(mapReferenceToCitation)
+      : undefined;
+
+  const dateModified = post.dedicatedDateModified ?? post.updatedAt;
+
+  // HowTo uses `name` rather than `headline` as the top-level title field
+  // (it inherits from CreativeWork, not Article). The visible post title
+  // serves both roles fine.
+  const schema: HowToSchema = {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    "@id": `${postUrl}#article`,
+    name: post.title,
+    url: postUrl,
+    author: { "@id": AUTHOR_CONFIG.id },
+    publisher: { "@id": AUTHOR_CONFIG.id },
+    isPartOf: { "@id": SITE_CONFIG.websiteId },
+    step: steps,
+  };
+
+  if (post.summary) schema.description = post.summary;
+  if (post.publishedAt) schema.datePublished = post.publishedAt;
+  if (dateModified) schema.dateModified = dateModified;
+  if (image) schema.image = image;
+  if (keywords.length > 0) schema.keywords = keywords;
+  if (citation && citation.length > 0) schema.citation = citation;
+
+  return schema;
+}

--- a/src/lib/schema/index.ts
+++ b/src/lib/schema/index.ts
@@ -15,6 +15,8 @@ export { generateCollectionPageSchema } from "./collection-page";
 export { mapReferenceToCitation } from "./citation";
 export { generatePatternArticleSchema, referenceToPatternCitation } from "./agentic-patterns";
 export { generateFaqPageSchema } from "./faq-page";
+export { generateHowToSchema } from "./howto";
+export { generateTechArticleSchema } from "./tech-article";
 
 // Type exports — available when page components need to type schema variables
 export type {
@@ -30,4 +32,7 @@ export type {
   ArticleSchema,
   PatternCitationSchema,
   FaqPageSchema,
+  HowToSchema,
+  HowToStep,
+  TechArticleSchema,
 } from "./types";

--- a/src/lib/schema/tech-article.ts
+++ b/src/lib/schema/tech-article.ts
@@ -1,0 +1,80 @@
+// src/lib/schema/tech-article.ts
+//
+// Generates TechArticle schema for posts whose `schemaType` field is set to
+// "TechArticle". Field-for-field mirror of generateBlogPostingSchema with
+// `@type` swapped — TechArticle and BlogPosting are siblings under Article
+// and share the same descriptive surface (headline, description, image,
+// dates, keywords, citations).
+//
+// Why a separate generator (and not a parameterized BlogPosting):
+//   The schema generators are intentionally one-file-per-type so each can
+//   evolve independently as Schema.org or Google's rich-result guidance
+//   changes. Sharing implementation via a helper would couple them through
+//   refactor risk; the duplication here is small and deliberate.
+//
+// Replace strategy (see issue #416 design decisions): when this generator
+// runs for a post, the BlogPosting generator does NOT also run for that
+// post. The Posts collection's `schemaType` field is the single switch the
+// post detail page reads to decide which generator to call.
+//
+// Usage:
+//   import { generateTechArticleSchema } from '@/lib/schema';
+//   <SchemaScript schema={generateTechArticleSchema(post)} />
+
+import { SITE_CONFIG, AUTHOR_CONFIG } from "./config";
+import { mapReferenceToCitation } from "./citation";
+import { isMediaObject, isTagObject } from "@/lib/types/media";
+import type { ImageObjectSchema, TechArticleSchema } from "./types";
+import type { Post } from "@/payload-types";
+
+export function generateTechArticleSchema(post: Post): TechArticleSchema {
+  const postUrl = `${SITE_CONFIG.url}/posts/${post.slug}`;
+
+  let image: ImageObjectSchema | undefined;
+  if (isMediaObject(post.featuredImageLight) && post.featuredImageLight.url) {
+    image = {
+      "@type": "ImageObject",
+      url: post.featuredImageLight.url,
+      width: post.featuredImageLight.width ?? 1200,
+      height: post.featuredImageLight.height ?? 630,
+      description: post.featuredImageLight.alt || undefined,
+    };
+  }
+
+  const keywords: string[] = [];
+  if (post.tags) {
+    for (const tag of post.tags) {
+      if (isTagObject(tag)) {
+        keywords.push(tag.name);
+      }
+    }
+  }
+
+  const citation =
+    post.references && post.references.length > 0
+      ? post.references.map(mapReferenceToCitation)
+      : undefined;
+
+  const dateModified = post.dedicatedDateModified ?? post.updatedAt;
+
+  const schema: TechArticleSchema = {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "@id": `${postUrl}#article`,
+    headline: post.title,
+    url: postUrl,
+    author: { "@id": AUTHOR_CONFIG.id },
+    publisher: { "@id": AUTHOR_CONFIG.id },
+    isPartOf: { "@id": SITE_CONFIG.websiteId },
+  };
+
+  if (post.summary) schema.description = post.summary;
+  if (post.publishedAt) schema.datePublished = post.publishedAt;
+  if (dateModified) schema.dateModified = dateModified;
+  if (image) schema.image = image;
+  if (post.type) schema.articleSection = post.type;
+  if (keywords.length > 0) schema.keywords = keywords;
+  if (citation && citation.length > 0) schema.citation = citation;
+
+  return schema;
+}

--- a/src/lib/schema/types.ts
+++ b/src/lib/schema/types.ts
@@ -125,6 +125,72 @@ export interface BlogPostingSchema extends SchemaBase {
 }
 
 // -------------------------------------------------------------------------
+// HowToStep — embedded in HowTo.step array
+//
+// Schema.org defines several optional properties on HowToStep (image, url,
+// itemListElement, etc.); we use only the two that are semantically required
+// for grounding signal: `name` (a short step label) and `text` (the prose
+// describing what the reader does). The Posts collection's `steps` array
+// field shape matches this 1:1 so the generator is a straight map.
+// -------------------------------------------------------------------------
+
+export interface HowToStep {
+  "@type": "HowToStep";
+  name: string;
+  text: string;
+}
+
+// -------------------------------------------------------------------------
+// HowTo — top-level schema for procedural / step-by-step posts.
+// Mirrors BlogPostingSchema except @type is "HowTo" and `step` replaces the
+// generic Article fields' role as the primary content signal. `@id` uses the
+// same #article suffix on the canonical post URL so it can interop with the
+// breadcrumb and website entities through their existing references.
+// -------------------------------------------------------------------------
+
+export interface HowToSchema extends SchemaBase {
+  "@type": "HowTo";
+  "@id": string;
+  name: string;
+  description?: string;
+  url: string;
+  datePublished?: string;
+  dateModified?: string;
+  author: { "@id": string };
+  publisher: { "@id": string };
+  image?: ImageObjectSchema;
+  keywords?: string[];
+  citation?: CitationSchema[];
+  isPartOf: { "@id": string };
+  step: HowToStep[];
+}
+
+// -------------------------------------------------------------------------
+// TechArticle — top-level schema for deep technical / analytical posts.
+// Field-for-field mirror of BlogPostingSchema with `@type` swapped, because
+// TechArticle and BlogPosting are siblings under Article and share the same
+// descriptive surface. Replace-emission strategy (see issue #416) means a
+// post tagged TechArticle does NOT also emit BlogPosting.
+// -------------------------------------------------------------------------
+
+export interface TechArticleSchema extends SchemaBase {
+  "@type": "TechArticle";
+  "@id": string;
+  headline: string;
+  description?: string;
+  url: string;
+  datePublished?: string;
+  dateModified?: string;
+  author: { "@id": string };
+  publisher: { "@id": string };
+  image?: ImageObjectSchema;
+  articleSection?: string;
+  keywords?: string[];
+  citation?: CitationSchema[];
+  isPartOf: { "@id": string };
+}
+
+// -------------------------------------------------------------------------
 // BreadcrumbList — navigation schema for post detail pages
 // No @id: breadcrumbs are positional, not entities that other schemas
 // reference. Each ListItem has position (1-indexed), name, and item (URL).

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -176,7 +176,6 @@ export interface Media {
      */
     ascii?: string | null;
   };
-  prefix?: string | null;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -334,6 +333,26 @@ export interface Post {
    * Meta description for search results. Falls back to summary if blank.
    */
   metaDescription?: string | null;
+  /**
+   * Schema.org primary @type emitted in the post detail page JSON-LD. Replace strategy: only this schema is emitted (BlogPosting is NOT co-emitted for HowTo or TechArticle). HowTo additionally requires the Steps field below.
+   */
+  schemaType: 'BlogPosting' | 'HowTo' | 'TechArticle';
+  /**
+   * Procedural steps emitted as schema.org HowTo.step. Required when Schema Type is HowTo; at least one step with name and text is needed for the JSON-LD to trigger Google's HowTo rich result.
+   */
+  steps?:
+    | {
+        /**
+         * Short label for this step.
+         */
+        name: string;
+        /**
+         * Prose describing what the reader does in this step.
+         */
+        text: string;
+        id?: string | null;
+      }[]
+    | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -479,7 +498,6 @@ export interface MediaSelect<T extends boolean = true> {
         color?: T;
         ascii?: T;
       };
-  prefix?: T;
   updatedAt?: T;
   createdAt?: T;
   url?: T;
@@ -586,6 +604,14 @@ export interface PostsSelect<T extends boolean = true> {
   theme?: T;
   seoTitle?: T;
   metaDescription?: T;
+  schemaType?: T;
+  steps?:
+    | T
+    | {
+        name?: T;
+        text?: T;
+        id?: T;
+      };
   updatedAt?: T;
   createdAt?: T;
 }

--- a/tests/unit/lib/schema/blog-posting-references.test.tsx
+++ b/tests/unit/lib/schema/blog-posting-references.test.tsx
@@ -80,6 +80,7 @@ const mockPost: Post = {
   publishedAt: "2026-01-15T00:00:00.000Z",
   updatedAt: "2026-01-15T00:00:00.000Z",
   createdAt: "2026-01-15T00:00:00.000Z",
+  schemaType: "BlogPosting",
 } as Post;
 
 describe("Post references dual-consumer contract", () => {

--- a/tests/unit/lib/schema/howto.test.ts
+++ b/tests/unit/lib/schema/howto.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock site config so generateHowToSchema doesn't pull in
+// NEXT_PUBLIC_SERVER_URL at import time.
+vi.mock("@/lib/schema/config", () => ({
+  SITE_CONFIG: {
+    url: "https://detached-node.dev",
+    name: "detached-node",
+    description: "Test description",
+    websiteId: "https://detached-node.dev/#website",
+  },
+  AUTHOR_CONFIG: {
+    name: "Julian",
+    url: "https://detached-node.dev/about",
+    id: "https://detached-node.dev/#author",
+    sameAs: ["https://github.com/julianken"],
+    description: "Writing on agentic AI workflows.",
+  },
+}));
+
+import { generateHowToSchema } from "@/lib/schema/howto";
+import type { Post } from "@/payload-types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const baseBody = {
+  root: {
+    type: "root",
+    children: [],
+    direction: "ltr" as const,
+    format: "" as const,
+    indent: 0,
+    version: 1,
+  },
+};
+
+function makePost(overrides: Partial<Post>): Post {
+  return {
+    id: 1,
+    title: "How to debug an agentic workflow",
+    slug: "how-to-debug-agentic-workflow",
+    type: "essay",
+    summary:
+      "A short procedural walkthrough for diagnosing failures in an agentic coding loop using trajectory logs.",
+    featuredImageLight: 1,
+    featuredImageDark: 2,
+    body: baseBody,
+    status: "published",
+    publishedAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: "2026-04-15T00:00:00.000Z",
+    createdAt: "2026-04-01T00:00:00.000Z",
+    schemaType: "HowTo",
+    ...overrides,
+  } as Post;
+}
+
+// ---------------------------------------------------------------------------
+// Null-return cases (empty-steps fallback)
+// ---------------------------------------------------------------------------
+
+describe("generateHowToSchema — null-return cases", () => {
+  it("returns null when post.steps is missing entirely", () => {
+    const post = makePost({});
+    expect(generateHowToSchema(post)).toBeNull();
+  });
+
+  it("returns null when post.steps is an empty array", () => {
+    const post = makePost({ steps: [] });
+    expect(generateHowToSchema(post)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Populated emission cases
+// ---------------------------------------------------------------------------
+
+describe("generateHowToSchema — populated cases", () => {
+  const stepsFixture = [
+    { name: "Capture the trajectory", text: "Save the agent's full message history to a JSON file." },
+    { name: "Identify the divergence point", text: "Diff the trajectory against the last known-good run." },
+    { name: "Replay with logging on", text: "Re-run the agent with verbose logging enabled and inspect the failing tool call." },
+  ];
+
+  it("emits @context and @type HowTo when steps are present", () => {
+    const post = makePost({ steps: stepsFixture });
+    const schema = generateHowToSchema(post);
+    expect(schema).not.toBeNull();
+    expect(schema!["@context"]).toBe("https://schema.org");
+    expect(schema!["@type"]).toBe("HowTo");
+  });
+
+  it("@id uses the canonical post URL with #article suffix", () => {
+    const post = makePost({ steps: stepsFixture });
+    const schema = generateHowToSchema(post);
+    expect(schema!["@id"]).toBe(
+      "https://detached-node.dev/posts/how-to-debug-agentic-workflow#article",
+    );
+  });
+
+  it("name field copies the post title verbatim", () => {
+    const post = makePost({ steps: stepsFixture });
+    const schema = generateHowToSchema(post);
+    expect(schema!.name).toBe("How to debug an agentic workflow");
+  });
+
+  it("description copies post.summary when present", () => {
+    const post = makePost({ steps: stepsFixture });
+    const schema = generateHowToSchema(post);
+    expect(schema!.description).toBe(
+      "A short procedural walkthrough for diagnosing failures in an agentic coding loop using trajectory logs.",
+    );
+  });
+
+  it("step array length matches steps fixture length", () => {
+    const post = makePost({ steps: stepsFixture });
+    const schema = generateHowToSchema(post);
+    expect(schema!.step).toHaveLength(stepsFixture.length);
+  });
+
+  it("each step has @type HowToStep and copies name + text verbatim", () => {
+    const post = makePost({ steps: stepsFixture });
+    const schema = generateHowToSchema(post);
+    for (let i = 0; i < stepsFixture.length; i++) {
+      expect(schema!.step[i]["@type"]).toBe("HowToStep");
+      expect(schema!.step[i].name).toBe(stepsFixture[i].name);
+      expect(schema!.step[i].text).toBe(stepsFixture[i].text);
+    }
+  });
+
+  it("preserves step order from the source array", () => {
+    const post = makePost({ steps: stepsFixture });
+    const schema = generateHowToSchema(post);
+    const names = schema!.step.map((s) => s.name);
+    expect(names).toEqual([
+      "Capture the trajectory",
+      "Identify the divergence point",
+      "Replay with logging on",
+    ]);
+  });
+
+  it("author and publisher both reference AUTHOR_CONFIG.id by @id", () => {
+    const post = makePost({ steps: stepsFixture });
+    const schema = generateHowToSchema(post);
+    expect(schema!.author).toEqual({ "@id": "https://detached-node.dev/#author" });
+    expect(schema!.publisher).toEqual({ "@id": "https://detached-node.dev/#author" });
+  });
+
+  it("isPartOf references the WebSite @id", () => {
+    const post = makePost({ steps: stepsFixture });
+    const schema = generateHowToSchema(post);
+    expect(schema!.isPartOf).toEqual({ "@id": "https://detached-node.dev/#website" });
+  });
+
+  it("datePublished and dateModified come from post fields", () => {
+    const post = makePost({
+      steps: stepsFixture,
+      publishedAt: "2026-04-01T00:00:00.000Z",
+      dedicatedDateModified: "2026-04-20T00:00:00.000Z",
+    });
+    const schema = generateHowToSchema(post);
+    expect(schema!.datePublished).toBe("2026-04-01T00:00:00.000Z");
+    expect(schema!.dateModified).toBe("2026-04-20T00:00:00.000Z");
+  });
+
+  it("dateModified falls back to updatedAt when dedicatedDateModified is absent", () => {
+    const post = makePost({
+      steps: stepsFixture,
+      updatedAt: "2026-04-15T00:00:00.000Z",
+    });
+    const schema = generateHowToSchema(post);
+    expect(schema!.dateModified).toBe("2026-04-15T00:00:00.000Z");
+  });
+
+  it("omits image when featuredImageLight is not a populated Media object", () => {
+    const post = makePost({ steps: stepsFixture, featuredImageLight: 99 });
+    const schema = generateHowToSchema(post);
+    expect(schema!.image).toBeUndefined();
+  });
+
+  it("emits image when featuredImageLight is a populated Media object with a url", () => {
+    const post = makePost({
+      steps: stepsFixture,
+      featuredImageLight: {
+        id: 1,
+        url: "https://detached-node.dev/media/hero.png",
+        width: 1920,
+        height: 1080,
+        alt: "Hero",
+        mimeType: "image/png",
+        filename: "hero.png",
+        filesize: 12345,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      } as unknown as Post["featuredImageLight"],
+    });
+    const schema = generateHowToSchema(post);
+    expect(schema!.image).toEqual({
+      "@type": "ImageObject",
+      url: "https://detached-node.dev/media/hero.png",
+      width: 1920,
+      height: 1080,
+      description: "Hero",
+    });
+  });
+
+  it("does NOT include articleSection (HowTo inherits from CreativeWork, not Article)", () => {
+    const post = makePost({ steps: stepsFixture });
+    const schema = generateHowToSchema(post);
+    // HowTo doesn't carry articleSection in our generator; this guards
+    // against a future refactor accidentally adding it via copy-paste from
+    // BlogPosting or TechArticle.
+    expect((schema as unknown as { articleSection?: string }).articleSection).toBeUndefined();
+  });
+});

--- a/tests/unit/lib/schema/tech-article.test.ts
+++ b/tests/unit/lib/schema/tech-article.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock site config so generateTechArticleSchema doesn't pull in
+// NEXT_PUBLIC_SERVER_URL at import time.
+vi.mock("@/lib/schema/config", () => ({
+  SITE_CONFIG: {
+    url: "https://detached-node.dev",
+    name: "detached-node",
+    description: "Test description",
+    websiteId: "https://detached-node.dev/#website",
+  },
+  AUTHOR_CONFIG: {
+    name: "Julian",
+    url: "https://detached-node.dev/about",
+    id: "https://detached-node.dev/#author",
+    sameAs: ["https://github.com/julianken"],
+    description: "Writing on agentic AI workflows.",
+  },
+}));
+
+import { generateTechArticleSchema } from "@/lib/schema/tech-article";
+import type { Post } from "@/payload-types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const baseBody = {
+  root: {
+    type: "root",
+    children: [],
+    direction: "ltr" as const,
+    format: "" as const,
+    indent: 0,
+    version: 1,
+  },
+};
+
+function makePost(overrides: Partial<Post>): Post {
+  return {
+    id: 1,
+    title: "Rethinking systems in the agentic age",
+    slug: "rethinking-systems-in-the-agentic-age",
+    type: "essay",
+    summary:
+      "A technical analysis of how agentic primitives reshape the boundaries of systems we used to call services.",
+    featuredImageLight: 1,
+    featuredImageDark: 2,
+    body: baseBody,
+    status: "published",
+    publishedAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-15T00:00:00.000Z",
+    createdAt: "2026-03-01T00:00:00.000Z",
+    schemaType: "TechArticle",
+    ...overrides,
+  } as Post;
+}
+
+// ---------------------------------------------------------------------------
+// Required fields and identity
+// ---------------------------------------------------------------------------
+
+describe("generateTechArticleSchema — required fields", () => {
+  it("emits @context and @type TechArticle", () => {
+    const post = makePost({});
+    const schema = generateTechArticleSchema(post);
+    expect(schema["@context"]).toBe("https://schema.org");
+    expect(schema["@type"]).toBe("TechArticle");
+  });
+
+  it("@id uses the canonical post URL with #article suffix", () => {
+    const post = makePost({});
+    const schema = generateTechArticleSchema(post);
+    expect(schema["@id"]).toBe(
+      "https://detached-node.dev/posts/rethinking-systems-in-the-agentic-age#article",
+    );
+  });
+
+  it("headline copies post.title verbatim", () => {
+    const post = makePost({});
+    const schema = generateTechArticleSchema(post);
+    expect(schema.headline).toBe("Rethinking systems in the agentic age");
+  });
+
+  it("url is the canonical post URL (no fragment)", () => {
+    const post = makePost({});
+    const schema = generateTechArticleSchema(post);
+    expect(schema.url).toBe(
+      "https://detached-node.dev/posts/rethinking-systems-in-the-agentic-age",
+    );
+  });
+
+  it("author and publisher both reference AUTHOR_CONFIG.id by @id", () => {
+    const post = makePost({});
+    const schema = generateTechArticleSchema(post);
+    expect(schema.author).toEqual({ "@id": "https://detached-node.dev/#author" });
+    expect(schema.publisher).toEqual({ "@id": "https://detached-node.dev/#author" });
+  });
+
+  it("isPartOf references the WebSite @id", () => {
+    const post = makePost({});
+    const schema = generateTechArticleSchema(post);
+    expect(schema.isPartOf).toEqual({ "@id": "https://detached-node.dev/#website" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Optional fields
+// ---------------------------------------------------------------------------
+
+describe("generateTechArticleSchema — optional fields", () => {
+  it("description copies post.summary when present", () => {
+    const post = makePost({});
+    const schema = generateTechArticleSchema(post);
+    expect(schema.description).toBe(
+      "A technical analysis of how agentic primitives reshape the boundaries of systems we used to call services.",
+    );
+  });
+
+  it("datePublished and dateModified come from post fields", () => {
+    const post = makePost({
+      publishedAt: "2026-03-01T00:00:00.000Z",
+      dedicatedDateModified: "2026-03-20T00:00:00.000Z",
+    });
+    const schema = generateTechArticleSchema(post);
+    expect(schema.datePublished).toBe("2026-03-01T00:00:00.000Z");
+    expect(schema.dateModified).toBe("2026-03-20T00:00:00.000Z");
+  });
+
+  it("dateModified falls back to updatedAt when dedicatedDateModified is absent", () => {
+    const post = makePost({
+      updatedAt: "2026-03-15T00:00:00.000Z",
+    });
+    const schema = generateTechArticleSchema(post);
+    expect(schema.dateModified).toBe("2026-03-15T00:00:00.000Z");
+  });
+
+  it("articleSection copies post.type (TechArticle inherits from Article)", () => {
+    const post = makePost({ type: "decoder" });
+    const schema = generateTechArticleSchema(post);
+    expect(schema.articleSection).toBe("decoder");
+  });
+
+  it("omits image when featuredImageLight is not a populated Media object", () => {
+    const post = makePost({ featuredImageLight: 99 });
+    const schema = generateTechArticleSchema(post);
+    expect(schema.image).toBeUndefined();
+  });
+
+  it("emits image when featuredImageLight is a populated Media object with a url", () => {
+    const post = makePost({
+      featuredImageLight: {
+        id: 1,
+        url: "https://detached-node.dev/media/hero.png",
+        width: 1920,
+        height: 1080,
+        alt: "Hero",
+        mimeType: "image/png",
+        filename: "hero.png",
+        filesize: 12345,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      } as unknown as Post["featuredImageLight"],
+    });
+    const schema = generateTechArticleSchema(post);
+    expect(schema.image).toEqual({
+      "@type": "ImageObject",
+      url: "https://detached-node.dev/media/hero.png",
+      width: 1920,
+      height: 1080,
+      description: "Hero",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Replace-strategy contract
+// ---------------------------------------------------------------------------
+
+describe("generateTechArticleSchema — replace-strategy contract", () => {
+  // The post detail page emits ONLY this schema when schemaType is
+  // TechArticle (no co-emitted BlogPosting). This test pins the contract
+  // that the generator's @type is the single primary type a crawler reads.
+  it("@type is exactly the string 'TechArticle' (not an array)", () => {
+    const post = makePost({});
+    const schema = generateTechArticleSchema(post);
+    expect(typeof schema["@type"]).toBe("string");
+    expect(schema["@type"]).toBe("TechArticle");
+  });
+
+  it("does NOT include a `step` field (HowTo-only)", () => {
+    const post = makePost({});
+    const schema = generateTechArticleSchema(post);
+    expect((schema as unknown as { step?: unknown }).step).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  A[Post detail page] -->|reads| B[post.schemaType]
  B -->|BlogPosting<br/>default| C[generateBlogPostingSchema]
  B -->|TechArticle| D[generateTechArticleSchema]
  B -->|HowTo| E[generateHowToSchema]
  E -->|reads| F[post.steps]
  F -->|empty?| G[fallback to BlogPosting<br/>mis-tagging guard]
  C --> H[Single primary @type<br/>emitted per post]
  D --> H
  E --> H
  G --> C
```

```mermaid
erDiagram
  posts ||--o{ posts_steps : "schemaType=HowTo only"
  posts {
    enum schema_type "BlogPosting|HowTo|TechArticle, default BlogPosting"
  }
  posts_steps {
    int _order
    int _parent_id FK
    varchar id PK
    varchar name NOT_NULL
    varchar text NOT_NULL
  }
```

## Summary

- Adds two new schema.org generators (`HowTo`, `TechArticle`) plus the two Payload fields that drive them (`schemaType` select + `steps` array). Replace strategy: each post emits exactly ONE primary `@type`; BlogPosting is NOT co-emitted for HowTo or TechArticle posts. Default `schemaType = "BlogPosting"` preserves existing behavior for every existing and un-tagged post.
- `HowTo.step` source is the explicit `steps` Payload field (manually populated, conditionally required when `schemaType === "HowTo"`). Lexical-heading extraction was explicitly rejected in the spec — it couples schema output to authorial heading discipline and is brittle.
- Mis-tagging guard in `selectPrimarySchema`: if `schemaType === "HowTo"` but `steps` is empty, the page falls back to `generateBlogPostingSchema` and logs a warning rather than emitting a `step`-less HowTo (which would validate as JSON-LD but contribute no grounding signal).

## Screenshots

N/A — not UI. This PR only mutates the JSON-LD `<script type="application/ld+json">` payload in the post detail page's `<head>`-equivalent slot. No visible-DOM change. The Payload admin UI gains a new sidebar `Schema Type` select and a conditional `Steps` array, but those are admin-side authoring controls (not user-visible site UI) and are validated by the existing Payload test patterns.

## Test plan

- [x] `pnpm install --frozen-lockfile` — clean
- [x] `pnpm lint` — 0 errors (19 pre-existing warnings, none from new files)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 614 passing, 30 new (18 HowTo + 12 TechArticle). Pre-existing flake in `tests/unit/lib/payload-config-env.test.ts` (5s import timeout on `@/payload.config` under parallel load) is intermittent on `main` too; unrelated to this diff
- [x] Unit tests cover: empty-steps null-return for HowTo, replace-strategy `@type` contract (string, not array) for TechArticle, all field-derivation paths (image, dates, keywords, citations, author/publisher refs)
- [x] Migration `20260519_000221_add_posts_schema_type_and_steps` registered in `migrations/index.ts`; uses `ADD COLUMN IF NOT EXISTS` / `CREATE TABLE IF NOT EXISTS` for idempotency; N-1 safe (default `'BlogPosting'` backfills existing rows; new `posts_steps` table invisible to prior revision)
- [x] `pnpm payload generate:types` — regenerated `src/payload-types.ts` reflects `schemaType` (required) and `steps` (optional array)
- [ ] **Rich Results Test (post-deploy)** — Google Rich Results Test (https://search.google.com/test/rich-results) requires a publicly fetchable URL. Cannot run pre-merge without staging URL. **Recommended post-deploy verification**: (a) re-tag one existing post as `TechArticle` and one as `HowTo` with populated steps; (b) wait for ISR revalidate (`revalidate = 3600`) or force-publish; (c) submit both URLs to the Rich Results Test and confirm the HowTo URL triggers the HowTo rich-result category (validates `step` is being read)

## Plan reference

Part of [#416](https://github.com/julianken/detached-node/issues/416) — design decisions (step source: explicit Payload field; emission: REPLACE not co-emit) committed in the issue body and APPROVE-reviewed by @julianken-bot before implementation.

Closes #416