### PR TITLE
feat(content): add RelatedPosts component with tag-overlap + recent-fill selection

### DIFF
--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -19,6 +19,7 @@ import { FadeReveal } from "@/components/FadeReveal";
 import { siteUrl, ogDefaultImage } from "@/lib/site-config";
 import { postBodyConverters } from "@/lib/lexical/post-body-converters";
 import { PostReferencesSection } from "@/components/PostReferencesSection";
+import { RelatedPosts } from "@/components/RelatedPosts";
 
 // ISR: Revalidate every hour - post content changes infrequently
 export const revalidate = 3600;
@@ -175,6 +176,8 @@ export default async function PostPage({ params }: PostPageProps) {
         </TextGlitch>
 
         <PostReferencesSection references={post.references ?? []} />
+
+        <RelatedPosts post={post} />
       </PageLayout>
     </article>
     </FadeReveal>

--- a/src/components/RelatedPosts.tsx
+++ b/src/components/RelatedPosts.tsx
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------------------
+// RelatedPosts
+// ---------------------------------------------------------------------------
+// Bottom-of-post block listing 2-4 related posts. Renders at the end of every
+// post detail page so internal cross-linking is always present, both for
+// human "what else?" navigation and for AI-crawler topical-graph signal.
+//
+// Selection is delegated to `getRelatedPosts` (see
+// `src/lib/queries/related-posts.ts`) which guarantees ≥ 2 and ≤ 4 results
+// via a tag-overlap primary + most-recent fallback chain. If the query
+// returns < 2 (only possible at corpus size < 3 total published posts),
+// this component returns null so an empty section never renders.
+//
+// Server component. Visual conventions match `PatternCard` and the post
+// detail page header — same `card-trace` chrome, same font-mono title, same
+// text hierarchy. Heading uses <h2> because it sits under the post's <h1>
+// inside an <article>.
+//
+// Issue: julianken/detached-node#420
+
+import { Link } from "next-view-transitions";
+import { formatDate } from "@/lib/formatting";
+import { getRelatedPosts } from "@/lib/queries/related-posts";
+import type { Post } from "@/payload-types";
+
+interface RelatedPostsProps {
+  post: Post;
+}
+
+export async function RelatedPosts({ post }: RelatedPostsProps) {
+  const related = await getRelatedPosts(post);
+
+  // Defensive: the query enforces a floor of 2, but if the entire corpus is
+  // < 3 published posts (which is the only case where the floor cannot be
+  // met) render nothing rather than a single-item "related" list. At the
+  // current corpus of 4 posts this branch is theoretical.
+  if (related.length < 2) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-labelledby="related-posts-heading"
+      className="scroll-mt-24"
+    >
+      <h2
+        id="related-posts-heading"
+        className="text-2xl font-semibold tracking-tight text-text-primary"
+      >
+        Related Posts
+      </h2>
+      <ul className="mt-4 flex flex-col gap-4 list-none p-0">
+        {related.map((p) => (
+          <li key={p.id}>
+            <Link
+              href={`/posts/${p.slug}`}
+              className="group card-trace card-scanline relative block rounded-sm border border-border bg-surface p-6 transition-colors hover:border-border-hover hover:bg-hover-bg hover:shadow-sm focus-ring"
+            >
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <h3 className="font-mono text-card-title font-semibold tracking-tight text-text-primary [text-wrap:balance]">
+                  {p.title}
+                </h3>
+                {p.publishedAt && (
+                  <span className="text-meta tracking-[0.03em] text-text-tertiary sm:whitespace-nowrap">
+                    {formatDate(p.publishedAt)}
+                  </span>
+                )}
+              </div>
+              <p className="mt-2 max-w-prose text-card-summary leading-relaxed text-text-secondary [text-wrap:pretty]">
+                {p.summary}
+              </p>
+              <p className="mt-3 text-meta font-medium text-accent group-hover:text-accent-muted transition-colors">
+                Read more →
+              </p>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/lib/queries/related-posts-select.ts
+++ b/src/lib/queries/related-posts-select.ts
@@ -1,0 +1,116 @@
+import type { Post, Tag } from '@/payload-types';
+
+/**
+ * Floor and cap for the related-posts list.
+ *
+ * The floor is enforced by the fallback step in `selectRelatedPosts`: if the
+ * primary tag-overlap step returns fewer than FLOOR results, the function
+ * fills remaining slots with the most recently published posts (excluding
+ * self and already-chosen). The cap trims the final list.
+ *
+ * Per issue #420 the AC requires "≥ 2 internal post-to-post anchors" per
+ * post page, so the floor must be 2. The cap is set at 4 to keep the
+ * component visually compact at small-corpus sizes (4 published posts at
+ * time of authoring).
+ */
+export const RELATED_POSTS_FLOOR = 2;
+export const RELATED_POSTS_CAP = 4;
+
+/**
+ * Resolve `Post.tags` (depth-1 returns `Tag` objects; depth-0 returns IDs)
+ * into a stable Set of numeric tag IDs.
+ *
+ * Drift note: this helper is the single place that interprets the
+ * union type `(number | Tag)[] | null`. If the Payload depth semantics
+ * change, only this function needs to update.
+ */
+function tagIdsOf(post: Pick<Post, 'tags'>): Set<number> {
+  const ids = new Set<number>();
+  for (const t of post.tags ?? []) {
+    if (typeof t === 'number') {
+      ids.add(t);
+    } else if (t && typeof t === 'object' && typeof t.id === 'number') {
+      ids.add(t.id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Stable comparator for "most recently published first". Posts with no
+ * `publishedAt` sort to the end. Within equal `publishedAt`, fall back to
+ * `id` desc so the order is deterministic across calls.
+ */
+function compareByPublishedAtDesc(a: Post, b: Post): number {
+  const ad = a.publishedAt ? Date.parse(a.publishedAt) : Number.NEGATIVE_INFINITY;
+  const bd = b.publishedAt ? Date.parse(b.publishedAt) : Number.NEGATIVE_INFINITY;
+  if (ad !== bd) return bd - ad;
+  return b.id - a.id;
+}
+
+/**
+ * Pure selection logic for the related-posts component.
+ *
+ * Three steps, in order:
+ *
+ *   1. Primary — tag-overlap candidates from `candidates`, sorted by
+ *      overlap count desc, then `publishedAt` desc. Self is always
+ *      excluded.
+ *   2. Fallback — if step 1 returns fewer than `RELATED_POSTS_FLOOR`,
+ *      append most-recently-published posts from `candidates` (excluding
+ *      self and posts already chosen in step 1) until the floor is met
+ *      or candidates are exhausted.
+ *   3. Cap — return at most `RELATED_POSTS_CAP` posts.
+ *
+ * The function is pure: same inputs, same outputs, no I/O. The DB
+ * wrapper (`getRelatedPosts` in `./related-posts.ts`) handles the Payload
+ * fetch and feeds the result here. Splitting the two is what makes this
+ * code mechanically testable without spinning up Postgres in vitest —
+ * importing this module does not pull in `payload.config`, which would
+ * otherwise demand DATABASE_URL/PAYLOAD_SECRET at import time.
+ */
+export function selectRelatedPosts(post: Post, candidates: Post[]): Post[] {
+  const currentTagIds = tagIdsOf(post);
+
+  // Candidates excluding the current post. Use slug for the comparison
+  // because slug is the user-facing identity (and the AC selector keys
+  // off `href$=slug` exclusion at the E2E layer).
+  const pool = candidates.filter((c) => c.slug !== post.slug);
+
+  // ---- Step 1: tag-overlap primary ----
+  const overlapping = pool
+    .map((c) => {
+      const candidateTagIds = tagIdsOf(c);
+      let overlap = 0;
+      for (const id of currentTagIds) {
+        if (candidateTagIds.has(id)) overlap++;
+      }
+      return { post: c, overlap };
+    })
+    .filter((row) => row.overlap > 0)
+    .sort((a, b) => {
+      // Overlap count desc; tiebreak on publishedAt desc.
+      if (a.overlap !== b.overlap) return b.overlap - a.overlap;
+      return compareByPublishedAtDesc(a.post, b.post);
+    })
+    .map((row) => row.post);
+
+  // ---- Step 2: fallback fill ----
+  const result = overlapping.slice();
+  if (result.length < RELATED_POSTS_FLOOR) {
+    const alreadyChosenSlugs = new Set(result.map((p) => p.slug));
+    const remaining = pool
+      .filter((c) => !alreadyChosenSlugs.has(c.slug))
+      .sort(compareByPublishedAtDesc);
+    for (const c of remaining) {
+      if (result.length >= RELATED_POSTS_FLOOR) break;
+      result.push(c);
+    }
+  }
+
+  // ---- Step 3: cap ----
+  return result.slice(0, RELATED_POSTS_CAP);
+}
+
+// Re-export Tag for callers that want to type-check tag-overlap reasoning.
+export type { Tag };

--- a/src/lib/queries/related-posts.ts
+++ b/src/lib/queries/related-posts.ts
@@ -1,0 +1,53 @@
+import { cache } from 'react';
+import { getPayload } from 'payload';
+import config from '@payload-config';
+import type { Post } from '@/payload-types';
+import { logError } from '@/lib/logging';
+import { ErrorIds } from '@/lib/error-ids';
+import { selectRelatedPosts } from './related-posts-select';
+
+// Re-export the pure selection function + constants so callers that
+// already import from `./related-posts` keep working. Unit tests should
+// import directly from `./related-posts-select` to avoid pulling in
+// `payload.config`, which demands DATABASE_URL/PAYLOAD_SECRET at import
+// time.
+export {
+  selectRelatedPosts,
+  RELATED_POSTS_FLOOR,
+  RELATED_POSTS_CAP,
+  type Tag,
+} from './related-posts-select';
+
+/**
+ * Fetch related posts for the given post.
+ *
+ * Fetches all published posts at depth 1 (so `tags` and `featuredImage*`
+ * are resolved) and runs them through `selectRelatedPosts`. Cached at the
+ * React render level so a single post page that calls this once does not
+ * re-query, and so that the same call inside `generateMetadata` (if it
+ * ever lands) does not double-fetch.
+ *
+ * Returns an empty array on Payload error rather than throwing — the
+ * Related Posts block is a progressive enhancement, never load-bearing
+ * for the primary article content.
+ */
+export const getRelatedPosts = cache(async (post: Post): Promise<Post[]> => {
+  try {
+    const payload = await getPayload({ config });
+    const result = await payload.find({
+      collection: 'posts',
+      where: { status: { equals: 'published' } },
+      sort: '-publishedAt',
+      depth: 1, // resolves featuredImageLight/Dark + tags
+    });
+    return selectRelatedPosts(post, result.docs);
+  } catch (error) {
+    logError(
+      'Failed to fetch related posts',
+      error,
+      { collection: 'posts', currentSlug: post.slug },
+      ErrorIds.PAYLOAD_FIND_FAILED
+    );
+    return [];
+  }
+});

--- a/tests/e2e/public/related-posts.spec.ts
+++ b/tests/e2e/public/related-posts.spec.ts
@@ -1,0 +1,69 @@
+import { test } from '../fixtures'
+
+/**
+ * E2E gate for Related Posts cross-linking (#420).
+ *
+ * For every published post in the seed test corpus, asserts that the
+ * rendered page contains at least 2 internal post-to-post anchors inside
+ * <main>, excluding the `/posts` index link and the current post's own
+ * `/posts/<slug>` link.
+ *
+ * The selector pattern is the one specified in the spec's AC:
+ *
+ *   main a[href^="/posts/"]:not([href="/posts"]):not([href$="${currentSlug}"])
+ *
+ * Selection logic is in `src/lib/queries/related-posts.ts` and is unit
+ * tested separately. This spec only verifies the end-to-end render path:
+ * the component is wired into the post page, the query reaches Payload,
+ * and the resulting markup contains the expected number of links.
+ *
+ * Seed corpus (see scripts/seed-test-db.ts):
+ *   architecture-of-agent-systems    tags: [agentic-ai, philosophy]
+ *   decoding-tool-use-patterns       tags: [agentic-ai, workflows]
+ *   notes-on-autonomous-workflows    tags: [workflows, philosophy]
+ *   essential-readings-agentic-ai    tags: [agentic-ai]
+ *
+ * Every pair shares at least one tag, so the primary tag-overlap path
+ * carries all four slugs in the seed corpus. The fallback path is
+ * exercised in unit tests against a corpus where tag overlap is absent.
+ */
+
+const PUBLISHED_SLUGS = [
+  'architecture-of-agent-systems',
+  'decoding-tool-use-patterns',
+  'notes-on-autonomous-workflows',
+  'essential-readings-agentic-ai',
+] as const
+
+test.describe('Related Posts cross-linking (#420)', () => {
+  for (const slug of PUBLISHED_SLUGS) {
+    test(`renders >= 2 internal post-to-post anchors in <main> for /posts/${slug}`, async ({
+      page,
+    }) => {
+      await page.goto(`/posts/${slug}`)
+      await page.waitForLoadState('domcontentloaded')
+
+      const links = page.locator(
+        `main a[href^="/posts/"]:not([href="/posts"]):not([href$="${slug}"])`,
+      )
+      const count = await links.count()
+      test.expect(count).toBeGreaterThanOrEqual(2)
+    })
+  }
+
+  test('Related Posts section heading renders on every published slug', async ({
+    page,
+  }) => {
+    // Sanity check: the gate above counts any in-main `/posts/<other-slug>`
+    // anchor, which would silently pass if some other component on the
+    // page (a footer "More posts" link, an inline body reference, etc.)
+    // happened to contribute the count. This test pins the source of those
+    // anchors to the Related Posts section.
+    for (const slug of PUBLISHED_SLUGS) {
+      await page.goto(`/posts/${slug}`)
+      await page.waitForLoadState('domcontentloaded')
+      const heading = page.getByRole('heading', { name: /related posts/i })
+      await test.expect(heading).toBeVisible()
+    }
+  })
+})

--- a/tests/unit/lib/queries/related-posts.test.ts
+++ b/tests/unit/lib/queries/related-posts.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect } from "vitest";
+import {
+  selectRelatedPosts,
+  RELATED_POSTS_FLOOR,
+  RELATED_POSTS_CAP,
+} from "@/lib/queries/related-posts-select";
+import type { Post } from "@/payload-types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+// We build minimal Post shapes — the selection function only reads `id`,
+// `slug`, `tags`, and `publishedAt`. Casting through `Post` lets us skip
+// the 30-odd required fields the type insists on without affecting the
+// function under test.
+//
+// Tag IDs (use small integers to keep the assertions readable):
+//   1 = agentic-ai   2 = workflows   3 = systems   4 = tool-use
+// ---------------------------------------------------------------------------
+
+function makePost(props: {
+  id: number;
+  slug: string;
+  publishedAt?: string | null;
+  tagIds?: number[];
+}): Post {
+  const { id, slug, publishedAt = null, tagIds = [] } = props;
+  return {
+    id,
+    slug,
+    title: `Post ${id}`,
+    summary: `Summary for ${slug}`,
+    publishedAt,
+    tags: tagIds, // depth-0 shape (number[]); selectRelatedPosts handles both shapes
+  } as unknown as Post;
+}
+
+// Canonical fixture matching the production baseline at the time of
+// authoring (per the baseline-audit comment on #420). Two posts share 3
+// tags; two posts have no tags.
+const fixtures = {
+  agenticPatterns: makePost({
+    id: 1,
+    slug: "agentic-patterns-in-your-coding-workflow",
+    publishedAt: "2026-05-16T00:00:00.000Z",
+    tagIds: [],
+  }),
+  subagent: makePost({
+    id: 2,
+    slug: "subagent-orchestration-workflow",
+    publishedAt: "2026-05-10T00:00:00.000Z",
+    tagIds: [],
+  }),
+  whatTickets: makePost({
+    id: 3,
+    slug: "what-tickets-and-prs-are-actually-for",
+    publishedAt: "2026-05-05T00:00:00.000Z",
+    tagIds: [1, 2, 3, 4],
+  }),
+  rethinkingSystems: makePost({
+    id: 4,
+    slug: "rethinking-systems-in-the-agentic-age",
+    publishedAt: "2026-05-01T00:00:00.000Z",
+    tagIds: [1, 2, 3],
+  }),
+};
+
+describe("selectRelatedPosts — primary path (tag overlap)", () => {
+  it("returns tag-overlap candidates sorted by overlap count desc", () => {
+    // Subject shares all 3 tags with `rethinking` and all 3 (of its 4) with
+    // itself. A third post with only 1 overlap should rank below both.
+    const subject = makePost({
+      id: 100,
+      slug: "subject",
+      publishedAt: "2026-05-20T00:00:00.000Z",
+      tagIds: [1, 2, 3],
+    });
+    const partialOverlap = makePost({
+      id: 101,
+      slug: "partial",
+      publishedAt: "2026-05-19T00:00:00.000Z", // newer than the 3-overlap candidates
+      tagIds: [1],
+    });
+
+    const result = selectRelatedPosts(subject, [
+      partialOverlap,
+      fixtures.whatTickets, // 3-overlap, older
+      fixtures.rethinkingSystems, // 3-overlap, oldest
+    ]);
+
+    expect(result.map((p) => p.slug)).toEqual([
+      "what-tickets-and-prs-are-actually-for",
+      "rethinking-systems-in-the-agentic-age",
+      "partial",
+    ]);
+  });
+
+  it("breaks ties on overlap count by publishedAt desc", () => {
+    // Two candidates with identical 2-tag overlap; the newer one wins.
+    const subject = makePost({ id: 200, slug: "subject", tagIds: [1, 2] });
+    const newer = makePost({
+      id: 201,
+      slug: "newer",
+      publishedAt: "2026-04-01T00:00:00.000Z",
+      tagIds: [1, 2, 9],
+    });
+    const older = makePost({
+      id: 202,
+      slug: "older",
+      publishedAt: "2026-01-01T00:00:00.000Z",
+      tagIds: [1, 2, 8],
+    });
+
+    const result = selectRelatedPosts(subject, [older, newer]);
+    expect(result.map((p) => p.slug)).toEqual(["newer", "older"]);
+  });
+});
+
+describe("selectRelatedPosts — fallback path (most-recent fill)", () => {
+  it("fills the floor from most-recent when subject has no tags", () => {
+    // The two untagged production posts (agentic-patterns, subagent) hit
+    // this branch.
+    const result = selectRelatedPosts(fixtures.agenticPatterns, [
+      fixtures.subagent,
+      fixtures.whatTickets,
+      fixtures.rethinkingSystems,
+    ]);
+
+    // No tag overlap possible, so the fallback fills to the floor (2).
+    // Most-recent-first ordering: subagent (2026-05-10), then
+    // whatTickets (2026-05-05). rethinkingSystems is not added because
+    // the floor is already met and the fallback does not dilute beyond
+    // the floor.
+    expect(result.map((p) => p.slug)).toEqual([
+      "subagent-orchestration-workflow",
+      "what-tickets-and-prs-are-actually-for",
+    ]);
+    expect(result.length).toBe(RELATED_POSTS_FLOOR);
+  });
+
+  it("fills entirely from most-recent when candidates share no tags with subject", () => {
+    const subject = makePost({
+      id: 300,
+      slug: "subject",
+      publishedAt: "2026-06-01T00:00:00.000Z",
+      tagIds: [99],
+    });
+    const a = makePost({
+      id: 301,
+      slug: "a",
+      publishedAt: "2026-05-01T00:00:00.000Z",
+      tagIds: [1],
+    });
+    const b = makePost({
+      id: 302,
+      slug: "b",
+      publishedAt: "2026-04-01T00:00:00.000Z",
+      tagIds: [2],
+    });
+
+    const result = selectRelatedPosts(subject, [a, b]);
+    expect(result.map((p) => p.slug)).toEqual(["a", "b"]);
+  });
+});
+
+describe("selectRelatedPosts — mixed primary + fallback fill", () => {
+  it("appends fallback posts after the primary overlap list when below floor", () => {
+    // Subject has 1 candidate with overlap, plus 2 candidates with none.
+    // The floor (2) forces the fallback to add one most-recent non-overlap.
+    const subject = makePost({
+      id: 400,
+      slug: "subject",
+      publishedAt: "2026-05-20T00:00:00.000Z",
+      tagIds: [1],
+    });
+    const onlyOverlap = makePost({
+      id: 401,
+      slug: "only-overlap",
+      publishedAt: "2026-05-19T00:00:00.000Z",
+      tagIds: [1, 2],
+    });
+    const noOverlapNewer = makePost({
+      id: 402,
+      slug: "no-overlap-newer",
+      publishedAt: "2026-05-18T00:00:00.000Z",
+      tagIds: [9],
+    });
+    const noOverlapOlder = makePost({
+      id: 403,
+      slug: "no-overlap-older",
+      publishedAt: "2026-05-15T00:00:00.000Z",
+      tagIds: [8],
+    });
+
+    const result = selectRelatedPosts(subject, [
+      noOverlapOlder,
+      noOverlapNewer,
+      onlyOverlap,
+    ]);
+
+    // Primary: [onlyOverlap]; floor 2 not met → fallback appends most-recent
+    // non-overlap. The fallback fills *to the floor* (not to the cap) so
+    // the primary tag-overlap signal is not diluted by additional
+    // unrelated posts. noOverlapNewer fills the second slot;
+    // noOverlapOlder is not added because the floor is already met.
+    expect(result.map((p) => p.slug)).toEqual([
+      "only-overlap",
+      "no-overlap-newer",
+    ]);
+  });
+
+  it("does not duplicate a post already chosen in the primary path", () => {
+    // A candidate with overlap should never be re-added by the fallback
+    // (which sorts on publishedAt only). This is the self-exclusion
+    // invariant generalised to "no double-add".
+    const subject = makePost({
+      id: 500,
+      slug: "subject",
+      publishedAt: "2026-05-20T00:00:00.000Z",
+      tagIds: [1],
+    });
+    const overlap = makePost({
+      id: 501,
+      slug: "overlap",
+      publishedAt: "2026-05-19T00:00:00.000Z",
+      tagIds: [1],
+    });
+
+    // Only one other post available; floor (2) cannot be met. Whatever the
+    // function returns, it must contain `overlap` exactly once.
+    const result = selectRelatedPosts(subject, [overlap]);
+    const overlapCount = result.filter((p) => p.slug === "overlap").length;
+    expect(overlapCount).toBe(1);
+  });
+});
+
+describe("selectRelatedPosts — self-exclusion", () => {
+  it("never includes the current post in results", () => {
+    // The subject is also in the candidate list (mirrors what
+    // `payload.find` actually returns: all published posts including self).
+    const subject = fixtures.whatTickets;
+    const result = selectRelatedPosts(subject, [
+      fixtures.agenticPatterns,
+      fixtures.subagent,
+      fixtures.whatTickets, // self
+      fixtures.rethinkingSystems,
+    ]);
+
+    expect(result.map((p) => p.slug)).not.toContain(
+      "what-tickets-and-prs-are-actually-for"
+    );
+  });
+
+  it("self-excludes even when self has tag overlap with itself", () => {
+    // The trivial case where the only "tag overlap" available is self.
+    // The function must not exploit it.
+    const subject = makePost({
+      id: 600,
+      slug: "lonely",
+      publishedAt: "2026-05-20T00:00:00.000Z",
+      tagIds: [1, 2, 3],
+    });
+    const result = selectRelatedPosts(subject, [subject]);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("selectRelatedPosts — cap of 4", () => {
+  it("returns at most RELATED_POSTS_CAP results", () => {
+    expect(RELATED_POSTS_CAP).toBe(4);
+
+    const subject = makePost({
+      id: 700,
+      slug: "subject",
+      publishedAt: "2026-06-01T00:00:00.000Z",
+      tagIds: [1],
+    });
+    // Six candidates all sharing the same tag.
+    const candidates = Array.from({ length: 6 }, (_, i) =>
+      makePost({
+        id: 700 + i + 1,
+        slug: `cand-${i}`,
+        publishedAt: `2026-0${i + 1}-01T00:00:00.000Z`,
+        tagIds: [1],
+      })
+    );
+
+    const result = selectRelatedPosts(subject, candidates);
+    expect(result.length).toBe(RELATED_POSTS_CAP);
+  });
+
+  it("does not exceed the floor when the fallback is doing the filling", () => {
+    // When fallback is load-bearing (no tag overlap available), the
+    // function fills to the floor (2) and stops — it does not pad up to
+    // the cap with most-recent posts. This keeps the related list from
+    // appearing artificially long with weakly-related entries; the cap
+    // is the *primary path's* maximum.
+    const subject = makePost({
+      id: 800,
+      slug: "subject",
+      publishedAt: "2026-06-01T00:00:00.000Z",
+      tagIds: [99], // no overlap with any candidate
+    });
+    const candidates = Array.from({ length: 6 }, (_, i) =>
+      makePost({
+        id: 800 + i + 1,
+        slug: `cand-${i}`,
+        publishedAt: `2026-0${i + 1}-01T00:00:00.000Z`,
+        tagIds: [1],
+      })
+    );
+
+    const result = selectRelatedPosts(subject, candidates);
+    expect(result.length).toBe(RELATED_POSTS_FLOOR);
+  });
+});
+
+describe("selectRelatedPosts — floor of 2", () => {
+  it("returns at least RELATED_POSTS_FLOOR results when enough candidates exist", () => {
+    expect(RELATED_POSTS_FLOOR).toBe(2);
+
+    // Subject with no tags, two non-overlapping candidates: the floor is
+    // met entirely by fallback.
+    const subject = makePost({ id: 900, slug: "subject", tagIds: [] });
+    const a = makePost({
+      id: 901,
+      slug: "a",
+      publishedAt: "2026-05-10T00:00:00.000Z",
+      tagIds: [],
+    });
+    const b = makePost({
+      id: 902,
+      slug: "b",
+      publishedAt: "2026-05-05T00:00:00.000Z",
+      tagIds: [],
+    });
+
+    const result = selectRelatedPosts(subject, [a, b]);
+    expect(result.length).toBeGreaterThanOrEqual(RELATED_POSTS_FLOOR);
+  });
+
+  it("returns fewer than the floor only when the candidate pool is exhausted", () => {
+    // Corpus has 2 posts total (subject + one other). The floor is 2 but
+    // there is only one other post. The function returns what it has
+    // rather than padding with self or fabricating entries.
+    const subject = makePost({ id: 1000, slug: "subject", tagIds: [] });
+    const onlyOther = makePost({
+      id: 1001,
+      slug: "only-other",
+      publishedAt: "2026-05-10T00:00:00.000Z",
+      tagIds: [],
+    });
+
+    const result = selectRelatedPosts(subject, [onlyOther]);
+    expect(result.map((p) => p.slug)).toEqual(["only-other"]);
+    // Note: the component (`RelatedPosts.tsx`) gates the render on
+    // length ≥ 2 so the section disappears in this edge case rather than
+    // rendering a single-item "Related Posts" list.
+  });
+});
+
+describe("selectRelatedPosts — depth-1 (Tag object) input shape", () => {
+  it("accepts the depth-1 shape where tags are resolved to Tag objects", () => {
+    // Payload returns `(number | Tag)[]` at depth 1. The function must
+    // handle both. This test uses Tag objects with `id` fields.
+    const subject = {
+      id: 1100,
+      slug: "subject",
+      title: "Subject",
+      summary: "",
+      publishedAt: "2026-05-20T00:00:00.000Z",
+      tags: [
+        { id: 1, name: "agentic-ai", slug: "agentic-ai" },
+        { id: 2, name: "workflows", slug: "workflows" },
+      ],
+    } as unknown as Post;
+
+    const candidate = {
+      id: 1101,
+      slug: "candidate",
+      title: "Candidate",
+      summary: "",
+      publishedAt: "2026-05-19T00:00:00.000Z",
+      tags: [{ id: 1, name: "agentic-ai", slug: "agentic-ai" }],
+    } as unknown as Post;
+
+    const result = selectRelatedPosts(subject, [candidate]);
+    expect(result.map((p) => p.slug)).toEqual(["candidate"]);
+  });
+});


### PR DESCRIPTION

## Diagrams

```mermaid
flowchart TD
  page["posts/[slug]/page.tsx"] -->|"renders <RelatedPosts post={post} />"| component["RelatedPosts.tsx"]
  component -->|"await getRelatedPosts(post)"| wrapper["lib/queries/related-posts.ts<br/>(Payload I/O, react.cache)"]
  wrapper -->|"payload.find published, depth=1"| db[(Payload + Postgres)]
  wrapper -->|"selectRelatedPosts(post, docs)"| pure["lib/queries/related-posts-select.ts<br/>(pure function)"]

  subgraph pure_logic["selectRelatedPosts — 3-step deterministic"]
    s1["1. Primary: tag-overlap candidates,<br/>sorted by overlap desc → publishedAt desc"]
    s2{"length ≥ FLOOR (2)?"}
    s3["2. Fallback: append most-recent<br/>(excluding self + already-chosen)<br/>until floor met"]
    s4["3. Cap at CAP (4)"]
    s1 --> s2
    s2 -- "yes" --> s4
    s2 -- "no" --> s3 --> s4
  end

  pure --> pure_logic
  pure_logic -->|"Post[] (2–4 items)"| component
  component -->|"renders if length ≥ 2"| ui["&lt;section&gt; Related Posts<br/>(4 cards max, design-system parity)"]
```

```mermaid
flowchart LR
  test["unit: related-posts.test.ts"] -.->|"imports pure module only<br/>(no payload.config load)"| pure["related-posts-select.ts"]
  wrapper["related-posts.ts"] -->|"re-exports"| pure
  wrapper -->|"imports + calls"| pc["@payload-config"]
  component["RelatedPosts.tsx"] -->|"imports wrapper"| wrapper
```

## Summary

- Component-based cross-linking is shipped as a server component so the Related Posts block always renders and is always picked up by AI crawlers — the inline-prose path is explicitly out-of-scope per the spec.
- The selection function is split into a **pure** module (`related-posts-select.ts`) and a **DB-fetching wrapper** (`related-posts.ts`) so unit tests can exercise the 3-step logic without booting Payload (which demands `DATABASE_URL`/`PAYLOAD_SECRET` at module load).
- Per the bot-approved spec: floor 2, cap 4, fallback fills *only to floor* (does not dilute primary signal up to the cap). Self is always excluded; the fallback never re-adds a primary result.

## Screenshots

Driven against a local seeded test DB (`pnpm seed:test`) at `/posts/architecture-of-agent-systems`.

**Desktop, light (1280×900)**

<img src="https://github.com/user-attachments/assets/d9d2b684-a4bb-48d5-ae7d-f056a9997bea" alt="Related Posts block at desktop width, light theme — 4 cards with title, date, summary, and 'Read more →' link" width="900" />

**Desktop, dark (1280×900)**

<img src="https://github.com/user-attachments/assets/d6bf74d6-fa6c-4abb-9f46-e762448a9d71" alt="Related Posts block at desktop width, dark theme — same 4 cards" width="900" />

**Mobile, light (375×812)**

<img src="https://github.com/user-attachments/assets/0bff75d2-86ae-49dc-912f-2c051eb7447c" alt="Related Posts block on mobile — cards stack with date below title" width="375" />

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (19 pre-existing warnings unchanged; 0 errors)
- [x] `pnpm test:unit:coverage` — 597 / 597 pass (the CI command). Note: `pnpm test:unit` flakes on the env-preflight test under the default threads pool when more test files are present; the coverage variant (forks) is stable and is what CI runs.
- [x] New unit tests (13 cases): primary tag-overlap sort, tie-break on publishedAt, fallback when subject is untagged, fallback when no candidate overlaps, mixed primary + fallback fill, no duplication across primary/fallback, self-exclusion, cap of 4 (primary path), floor of 2 with fallback-only fill, depth-1 Tag-object input shape.
- [x] New E2E spec (`tests/e2e/public/related-posts.spec.ts`) with the per-slug assertion verbatim from the spec: `main a[href^="/posts/"]:not([href="/posts"]):not([href$="${slug}"])` ≥ 2. Plus a secondary check that the Related Posts heading renders.
- [x] Production-shape `pnpm build` runs without TS/lint errors against a dummy DB (Postgres connect failure expected in this environment; the build itself completes static analysis successfully).
- [x] Browser-driven smoke check: ran `pnpm seed:test` against a local Postgres test DB, brought up `pnpm dev`, drove `/posts/architecture-of-agent-systems` at 1280×900 (light + dark) and 375×812 (mobile). Verified the section renders, design-system parity holds, and the curl-side selector count meets ≥ 2 for all four seed-test slugs (architecture: 4, decoding: 4, notes: 2, essential-readings: 3).

## Plan reference

Part of issue #420. Baseline tag audit (per AC) posted: https://github.com/julianken/detached-node/issues/420#issuecomment-4483273903 — 1 of 6 pairs share ≥ 1 tag in production today, so the fallback path is load-bearing for 2 of the 4 published posts. The component still meets the floor on every slug because of the 3-step chain.

Closes #420