### PR TITLE
feat(seo): explicit Allow rules for AI crawlers in robots.txt (#417)

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,15 +1,10 @@
 import { MetadataRoute } from "next";
 import { siteUrl } from "@/lib/site-config";
+import { buildRobotsRules } from "@/lib/robots-config";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: [
-      {
-        userAgent: "*",
-        allow: "/",
-        disallow: ["/admin", "/api"],
-      },
-    ],
+    rules: buildRobotsRules(),
     sitemap: `${siteUrl}/sitemap.xml`,
   };
 }

--- a/src/lib/robots-config.ts
+++ b/src/lib/robots-config.ts
@@ -1,0 +1,93 @@
+// src/lib/robots-config.ts
+//
+// Canonical bot list for robots.txt. Each entry becomes a named
+// User-Agent block in the rendered robots.txt with the same access
+// rules as the wildcard fallback (`Allow: /`, `Disallow: /admin`,
+// `Disallow: /api`). Named blocks signal *intent* to AI vendors and
+// search engines, even though the effective access is unchanged from
+// the wildcard.
+//
+// See issue #417 for rationale and the Microsoft Clarity AI-visibility
+// guidance this list draws from.
+
+/**
+ * Paths every crawler — named or wildcard — must avoid.
+ */
+export const DISALLOWED_PATHS = ["/admin", "/api"] as const;
+
+/**
+ * AI grounding and training crawlers. Explicit allow signals that this
+ * site welcomes AI ingestion and citation; flipping any entry to a
+ * disallow later is a clean per-bot opt-out path.
+ */
+export const AI_BOT_USER_AGENTS = [
+  // OpenAI
+  "GPTBot",
+  "ChatGPT-User",
+  "OAI-SearchBot",
+  // Anthropic
+  "ClaudeBot",
+  "anthropic-ai",
+  "Claude-User",
+  "Claude-SearchBot",
+  // Google (AI training surface, distinct from Googlebot search)
+  "Google-Extended",
+  // Perplexity
+  "PerplexityBot",
+  "Perplexity-User",
+  // Common Crawl (feeds many training corpora)
+  "CCBot",
+  // Apple Intelligence
+  "applebot-extended",
+  // Meta AI / Llama
+  "Meta-ExternalAgent",
+  // Amazon AI crawlers
+  "Amazonbot",
+] as const;
+
+/**
+ * Traditional search crawlers. Explicit allow makes the named-block
+ * pattern consistent across AI + search and gives a single place to
+ * adjust per-engine rules if ever needed.
+ */
+export const SEARCH_BOT_USER_AGENTS = [
+  "Googlebot",
+  "Bingbot",
+  "DuckDuckBot",
+] as const;
+
+/**
+ * All named user-agents emitted in robots.txt, in deterministic order
+ * (AI bots first, search bots second). Used by `src/app/robots.ts`.
+ */
+export const NAMED_BOT_USER_AGENTS = [
+  ...AI_BOT_USER_AGENTS,
+  ...SEARCH_BOT_USER_AGENTS,
+] as const;
+
+export type RobotsRule = {
+  userAgent: string;
+  allow: string;
+  disallow: string[];
+};
+
+/**
+ * Build the rules array for `MetadataRoute.Robots`. Each named bot gets
+ * its own block, and a final wildcard block catches any unnamed
+ * crawler. All blocks share the same access rules; the only reason to
+ * name a bot is to signal intent and provide a per-bot flip point.
+ */
+export function buildRobotsRules(): RobotsRule[] {
+  const disallow = [...DISALLOWED_PATHS];
+  const namedRules: RobotsRule[] = NAMED_BOT_USER_AGENTS.map((userAgent) => ({
+    userAgent,
+    allow: "/",
+    disallow,
+  }));
+  const wildcardRule: RobotsRule = {
+    userAgent: "*",
+    allow: "/",
+    disallow,
+  };
+  return [...namedRules, wildcardRule];
+}

--- a/tests/unit/app/robots.test.ts
+++ b/tests/unit/app/robots.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+
+// `siteUrl` calls `assertRequiredEnv` at module load (see
+// `src/lib/site-url.ts`). Stub the env before importing the route
+// module under jsdom — matches the pattern in
+// `tests/unit/app/posts-slug-page.test.ts`.
+process.env.NEXT_PUBLIC_SERVER_URL ||= "http://localhost:3000";
+
+/**
+ * Issue #417: the robots route handler must emit explicit named blocks
+ * for AI + search crawlers plus the existing wildcard fallback, and
+ * preserve the sitemap pointer.
+ *
+ * The structured snapshot lives in
+ * `tests/unit/lib/robots-config.test.ts`; this suite covers the wiring
+ * between the route handler and the config module (sitemap URL, shape
+ * of the returned `MetadataRoute.Robots` object).
+ */
+
+describe("robots route handler", () => {
+  it("returns a MetadataRoute.Robots object with rules + sitemap", async () => {
+    const { default: robots } = await import("@/app/robots");
+    const result = robots();
+    expect(result).toHaveProperty("rules");
+    expect(Array.isArray(result.rules)).toBe(true);
+    expect(result).toHaveProperty("sitemap");
+  });
+
+  it("points the sitemap at <siteUrl>/sitemap.xml", async () => {
+    const { default: robots } = await import("@/app/robots");
+    const { siteUrl } = await import("@/lib/site-config");
+    const result = robots();
+    expect(result.sitemap).toBe(`${siteUrl}/sitemap.xml`);
+  });
+
+  it("delegates rule construction to buildRobotsRules()", async () => {
+    const { default: robots } = await import("@/app/robots");
+    const { buildRobotsRules } = await import("@/lib/robots-config");
+    expect(robots().rules).toEqual(buildRobotsRules());
+  });
+});

--- a/tests/unit/lib/__snapshots__/robots-config.test.ts.snap
+++ b/tests/unit/lib/__snapshots__/robots-config.test.ts.snap
@@ -1,0 +1,150 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`robots-config > matches the named-block snapshot 1`] = `
+[
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "GPTBot",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "ChatGPT-User",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "OAI-SearchBot",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "ClaudeBot",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "anthropic-ai",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "Claude-User",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "Claude-SearchBot",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "Google-Extended",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "PerplexityBot",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "Perplexity-User",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "CCBot",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "applebot-extended",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "Meta-ExternalAgent",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "Amazonbot",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "Googlebot",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "Bingbot",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "DuckDuckBot",
+  },
+  {
+    "allow": "/",
+    "disallow": [
+      "/admin",
+      "/api",
+    ],
+    "userAgent": "*",
+  },
+]
+`;

--- a/tests/unit/lib/robots-config.test.ts
+++ b/tests/unit/lib/robots-config.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import {
+  AI_BOT_USER_AGENTS,
+  DISALLOWED_PATHS,
+  NAMED_BOT_USER_AGENTS,
+  SEARCH_BOT_USER_AGENTS,
+  buildRobotsRules,
+} from "@/lib/robots-config";
+
+/**
+ * Issue #417: explicit Allow/Disallow rules for named AI + search
+ * crawlers. The shape of the rules array is part of our SEO/AI-
+ * discovery contract — adding/removing a bot is intentional, so this
+ * suite tripwires drift in either direction.
+ */
+
+describe("robots-config", () => {
+  it("emits one rule per named bot plus a wildcard fallback", () => {
+    const rules = buildRobotsRules();
+    expect(rules).toHaveLength(NAMED_BOT_USER_AGENTS.length + 1);
+    const last = rules[rules.length - 1];
+    expect(last.userAgent).toBe("*");
+  });
+
+  it("applies the same allow + disallow to every block", () => {
+    const rules = buildRobotsRules();
+    for (const rule of rules) {
+      expect(rule.allow).toBe("/");
+      expect(rule.disallow).toEqual([...DISALLOWED_PATHS]);
+    }
+  });
+
+  it("includes every required AI grounding crawler from issue #417", () => {
+    const userAgents = buildRobotsRules().map((r) => r.userAgent);
+    for (const bot of AI_BOT_USER_AGENTS) {
+      expect(userAgents).toContain(bot);
+    }
+  });
+
+  it("includes every required search crawler from issue #417", () => {
+    const userAgents = buildRobotsRules().map((r) => r.userAgent);
+    for (const bot of SEARCH_BOT_USER_AGENTS) {
+      expect(userAgents).toContain(bot);
+    }
+  });
+
+  it("emits no duplicate user-agents", () => {
+    const userAgents = buildRobotsRules().map((r) => r.userAgent);
+    expect(new Set(userAgents).size).toBe(userAgents.length);
+  });
+
+  // Snapshot of the structured rules. Snapshotting the object (vs the
+  // serialized robots.txt string) tests our intent — adding or removing
+  // a named bot must be an intentional snapshot update. Next.js owns
+  // the string serializer; that path is verified post-deploy via curl.
+  it("matches the named-block snapshot", () => {
+    expect(buildRobotsRules()).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  Crawler[Incoming crawler<br/>User-Agent: X] --> Route[/src/app/robots.ts/]
  Route --> Cfg[src/lib/robots-config.ts<br/>buildRobotsRules]
  Cfg --> Named{X in named<br/>bot list?}
  Named -- yes --> NamedBlock[Allow: /<br/>Disallow: /admin, /api<br/>under explicit UA]
  Named -- no --> Wildcard[Fallback UA: *<br/>Allow: /<br/>Disallow: /admin, /api]
  Route --> Sitemap[Sitemap:<br/>detached-node.dev/sitemap.xml]
```

```mermaid
graph TD
  subgraph "Named blocks rendered into robots.txt"
    AI[AI grounding crawlers<br/>14 UAs]
    Search[Search crawlers<br/>3 UAs]
    Star[Wildcard fallback<br/>UA: *]
  end
  AI --> Out[robots.txt]
  Search --> Out
  Star --> Out
```

## Summary

- Explicit named `User-Agent` blocks replace the single wildcard, signaling intent to AI vendors and giving a clean per-bot flip point if any vendor needs an opt-out later. Effective access is unchanged — every block grants the same `Allow: /` + `Disallow: /admin /api` as the previous wildcard.
- Bot list and rule shape extracted to `src/lib/robots-config.ts` so the policy is testable as a pure unit and lives in lib's coverage zone (vitest excludes `src/app/**` from coverage).
- Three SUGGESTION-tier findings from the bot's spec review (#417 comment) addressed in-PR — see "Bot-finding disposition" below.

## Screenshots

N/A — not UI. Change emits text from a Next.js Metadata Route handler; effects are server-side. Post-deploy verification is `curl -s https://detached-node.dev/robots.txt` (see Test plan).

## Test plan

- [x] `pnpm install --frozen-lockfile` — clean
- [x] `pnpm lint` — 0 errors (19 pre-existing warnings, none in changed files)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 694 / 694 passing (was 685; +9 new tests across 2 new files); 1 snapshot written
- [x] New unit suite `tests/unit/lib/robots-config.test.ts` — covers shape, allow/disallow uniformity, presence of every required UA from issue AC, no-duplicates tripwire, and a structural snapshot of the rules array (snapshot target picked per bot's SUGGESTION 2)
- [x] New route-handler suite `tests/unit/app/robots.test.ts` — covers wiring between the route and the config (sitemap URL points at `<siteUrl>/sitemap.xml`; `rules` delegates to `buildRobotsRules()`). Uses the `process.env.NEXT_PUBLIC_SERVER_URL ||=` stub pattern from `tests/unit/app/posts-slug-page.test.ts`
- [ ] Post-merge: `curl -s https://detached-node.dev/robots.txt` shows each named bot — to be documented as a comment on #417 after Cloud Run deploys

### Bot-finding disposition (from #417 julianken-bot APPROVE review)

| Finding | Disposition |
|---|---|
| **SUGGESTION 1** — AC #5 references a route-handler test convention that doesn't exist | Addressed via **hybrid**: extracted a pure helper `src/lib/robots-config.ts` (bot's Option B) and also added a thin route-handler test at `tests/unit/app/robots.test.ts` that follows the only existing route-handler test pattern (`tests/unit/app/posts-slug-page.test.ts`, env-stub before dynamic import). vitest's `include` glob already covers `tests/unit/**`; the `src/app/**` exclude is for coverage, not for tests. No config change needed. |
| **SUGGESTION 2** — Snapshot target ambiguity (object vs serialized string) | Snapshot targets the **structured `MetadataRoute.Robots`-rules array** as the bot recommended. Rationale documented inline in the test: snapshotting the object tests our intent; Next.js owns the string serializer and that path is verified post-deploy via `curl`. |
| **SUGGESTION 3** — Bot list omissions | **Included** in v1 with brief inline rationale: `Meta-ExternalAgent`, `Amazonbot`, `Claude-User`, `Claude-SearchBot`, `Perplexity-User` (all canonical 2026 UAs; purely additive; matches the issue's "explicit allow" intent). **Deferred** for now: `DuckAssistBot`, `MistralAI-User`, `Google-NotebookLM`, `Google-CloudVertexBot` — revisit when Clarity surfaces them or a vendor publishes their docs. |

## Plan reference

Part of issue #417 — `julianken-bot` APPROVE on the spec, three non-blocking SUGGESTIONs all addressed above. No `docs/plans/` artifact for this single-file change.

Closes #417