### PR TITLE
feat(home): editorial redesign + voice cleanup

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from "next";
-import { Card } from "@/components/Card";
+import { Link } from "next-view-transitions";
 import { FadeReveal } from "@/components/FadeReveal";
+import { PostCard } from "@/components/PostCard";
 import { SchemaScript } from "@/components/SchemaScript";
-import { generateWebSiteSchema, generatePersonSchema } from "@/lib/schema";
+import { formatDate } from "@/lib/formatting";
 import { getFeaturedPosts } from "@/lib/queries/posts";
+import { generateWebSiteSchema, generatePersonSchema } from "@/lib/schema";
 import { siteUrl } from "@/lib/site-config";
+import { isMediaObject } from "@/lib/types/media";
 
 // ISR: Revalidate every 30 minutes - featured posts change infrequently
 export const revalidate = 1800;
@@ -20,43 +23,96 @@ export default async function Home() {
 
   return (
     <FadeReveal>
-    <SchemaScript schema={[generateWebSiteSchema(), generatePersonSchema()]} />
-    <div className="flex flex-col gap-16">
-      <section>
-        <h1 className="font-mono text-4xl font-semibold tracking-tight text-text-primary lowercase [text-wrap:balance]">
-          detached<span className="text-accent">-</span>node
-        </h1>
-        <p className="mt-4 max-w-xl text-xl font-medium leading-8 text-text-secondary">
-          a diagnostic analysis of AI-assisted software engineering
-        </p>
-      </section>
+      <SchemaScript schema={[generateWebSiteSchema(), generatePersonSchema()]} />
+      <div className="flex flex-col gap-16">
+        <section>
+          <h1 className="font-mono text-5xl font-semibold tracking-tight text-text-primary lowercase [text-wrap:balance] sm:text-6xl">
+            detached<span className="text-accent">-</span>node
+          </h1>
+          <div className="mt-4 h-px w-12 bg-accent" aria-hidden="true" />
+          <p className="mt-6 max-w-xl text-lg leading-8 text-text-secondary [text-wrap:pretty] sm:text-xl">
+            a diagnostic analysis of AI-assisted software engineering
+          </p>
+        </section>
 
-      <section>
-        <h2 className="font-mono text-xl font-semibold tracking-tight text-text-primary">
-          Latest posts
-        </h2>
-        <div className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {featuredPosts.length > 0 ? (
-            featuredPosts.map((post) => (
-              <Card key={post.id} href={`/posts/${post.slug}`}>
-                <h3 className="font-mono text-base font-semibold text-text-primary [text-wrap:balance]">
-                  {post.title}
-                </h3>
-                <p className="mt-2 text-sm leading-6 text-text-secondary [text-wrap:pretty]">
-                  {post.summary}
+        <section id="latest" className="scroll-mt-24">
+          <div className="flex items-baseline justify-between">
+            <h2 className="font-mono text-xl font-semibold tracking-tight text-text-primary">
+              Latest
+            </h2>
+            <Link
+              href="/posts"
+              className="text-meta font-mono tracking-[0.04em] text-text-secondary hover:text-text-primary focus-ring transition-colors"
+            >
+              All posts →
+            </Link>
+          </div>
+          <div className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {featuredPosts.length > 0 ? (
+              featuredPosts.map((post) => (
+                <PostCard
+                  key={post.id}
+                  title={post.title}
+                  date={formatDate(post.publishedAt)}
+                  summary={post.summary}
+                  href={`/posts/${post.slug}`}
+                  featuredImageLight={
+                    isMediaObject(post.featuredImageLight) ? post.featuredImageLight : null
+                  }
+                  featuredImageDark={
+                    isMediaObject(post.featuredImageDark) ? post.featuredImageDark : null
+                  }
+                  focalPoint={post.focalPoint ?? undefined}
+                  imageAspectRatio="16 / 9"
+                  dateLayout="stacked"
+                />
+              ))
+            ) : (
+              <div className="col-span-full rounded-sm border border-dashed border-border p-8 text-center">
+                <p className="text-sm text-text-tertiary">
+                  No featured posts yet. Check back soon.
                 </p>
-              </Card>
-            ))
-          ) : (
-            <div className="col-span-full rounded-sm border border-dashed border-border p-8 text-center">
-              <p className="text-sm text-text-tertiary">
-                No featured posts yet. Check back soon.
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section>
+          <h2 className="font-mono text-xl font-semibold tracking-tight text-text-primary">
+            Explore
+          </h2>
+          <div className="mt-6 grid gap-6 sm:grid-cols-2">
+            <Link
+              href="/agentic-design-patterns"
+              className="group flex flex-col gap-2 rounded-sm border border-border bg-surface p-6 transition-colors hover:border-border-hover hover:bg-hover-bg focus-ring"
+            >
+              <h3 className="font-mono text-card-title font-semibold tracking-tight text-text-primary">
+                Agentic design patterns
+              </h3>
+              <p className="text-card-summary leading-relaxed text-text-secondary">
+                A reference for designing agentic systems.
               </p>
-            </div>
-          )}
-        </div>
-      </section>
-    </div>
+              <p className="mt-1 text-meta font-medium text-accent group-hover:text-accent-muted transition-colors">
+                Browse the catalog →
+              </p>
+            </Link>
+            <Link
+              href="/about"
+              className="group flex flex-col gap-2 rounded-sm border border-border bg-surface p-6 transition-colors hover:border-border-hover hover:bg-hover-bg focus-ring"
+            >
+              <h3 className="font-mono text-card-title font-semibold tracking-tight text-text-primary">
+                About this site
+              </h3>
+              <p className="text-card-summary leading-relaxed text-text-secondary">
+                What this site is and why it exists.
+              </p>
+              <p className="mt-1 text-meta font-medium text-accent group-hover:text-accent-muted transition-colors">
+                Read more →
+              </p>
+            </Link>
+          </div>
+        </section>
+      </div>
     </FadeReveal>
   );
 }

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -11,6 +11,8 @@ interface PostCardProps {
   featuredImageDark?: Media | null;
   focalPoint?: { x?: number | null; y?: number | null } | null;
   label?: string;
+  imageAspectRatio?: string;
+  dateLayout?: "inline" | "stacked";
 }
 
 export function PostCard({
@@ -22,6 +24,8 @@ export function PostCard({
   featuredImageDark,
   focalPoint,
   label,
+  imageAspectRatio = "4 / 1",
+  dateLayout = "inline",
 }: PostCardProps) {
   return (
     <Link
@@ -42,14 +46,21 @@ export function PostCard({
             className="transition-transform group-hover:scale-105"
             sizes="(max-width: 768px) 100vw, 720px"
             focalPoint={focalPoint}
-            aspectRatio="4 / 1"
+            aspectRatio={imageAspectRatio}
           />
         </div>
       )}
-      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-        <h2 className="font-mono text-card-title font-semibold tracking-tight text-text-primary [text-wrap:balance]">{title}</h2>
-        {date && <span className="text-meta tracking-[0.03em] text-text-tertiary sm:whitespace-nowrap">{date}</span>}
-      </div>
+      {dateLayout === "stacked" ? (
+        <div className="flex flex-col gap-1">
+          {date && <span className="text-meta tracking-[0.03em] text-text-tertiary">{date}</span>}
+          <h2 className="font-mono text-card-title font-semibold tracking-tight text-text-primary [text-wrap:balance]">{title}</h2>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <h2 className="font-mono text-card-title font-semibold tracking-tight text-text-primary [text-wrap:balance]">{title}</h2>
+          {date && <span className="text-meta tracking-[0.03em] text-text-tertiary sm:whitespace-nowrap">{date}</span>}
+        </div>
+      )}
       <p className="mt-2 max-w-prose text-card-summary leading-relaxed text-text-secondary [text-wrap:pretty]">{summary}</p>
       <p className="mt-3 text-meta font-medium text-accent group-hover:text-accent-muted transition-colors">
         Read more →

--- a/src/components/agentic-patterns/HubFilterableContent.tsx
+++ b/src/components/agentic-patterns/HubFilterableContent.tsx
@@ -163,29 +163,16 @@ export function HubFilterableContent({ patterns, layerFiltered = false }: HubFil
         <label htmlFor="hub-search" className="sr-only">
           Search agentic design patterns
         </label>
-        <div className="relative">
-          <input
-            ref={inputRef}
-            id="hub-search"
-            type="search"
-            value={query}
-            onChange={handleChange}
-            aria-label="Search agentic design patterns"
-            aria-describedby="hub-search-hint"
-            placeholder="Search patterns…"
-            className="w-full rounded-sm border border-border bg-surface px-4 py-2.5 pr-16 font-mono text-base text-text-primary placeholder:text-text-tertiary focus-ring"
-          />
-          <kbd
-            aria-hidden="true"
-            className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 rounded-sm border border-border bg-background px-1.5 py-0.5 font-mono text-xs text-text-tertiary"
-          >
-            /
-          </kbd>
-        </div>
-        <p id="hub-search-hint" className="text-xs text-text-tertiary">
-          Press <kbd className="rounded-sm border border-border bg-surface px-1 font-mono text-[0.65rem]">/</kbd>{" "}
-          to focus. Searches name, alternative names, summary, and layer.
-        </p>
+        <input
+          ref={inputRef}
+          id="hub-search"
+          type="search"
+          value={query}
+          onChange={handleChange}
+          aria-label="Search agentic design patterns"
+          placeholder="Search patterns…"
+          className="w-full rounded-sm border border-border bg-surface px-4 py-2.5 font-mono text-base text-text-primary placeholder:text-text-tertiary focus-ring"
+        />
         <p
           role="status"
           aria-live="polite"


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
  subgraph Before
    H1[Hero<br/>wordmark + 1-line tagline]
    L1[Latest<br/>3-up Card grid<br/>title + summary only]
    H1 --> L1
  end
  subgraph After
    H2[Hero<br/>BIG wordmark + accent rule<br/>+ 1-line tagline]
    L2[Latest<br/>3-up PostCard grid<br/>16/9 image + date eyebrow + title + summary<br/>+ All posts link]
    E2[Explore<br/>2-up tile grid<br/>Patterns + About]
    H2 --> L2 --> E2
  end
```

```mermaid
graph LR
  PostCard[PostCard component]
  PostCard -->|defaults<br/>imageAspectRatio=4/1<br/>dateLayout=inline| Posts["/posts page<br/>unchanged"]
  PostCard -->|overrides<br/>imageAspectRatio=16/9<br/>dateLayout=stacked| Home["home page<br/>narrower 3-up cards"]
```

## Summary

- Home page reworked from 2 sections to 3 (Hero, Latest, Explore); the Latest section now reuses `PostCard` from `/posts` so the home and listing surfaces share a visual vocabulary instead of using two different card components.
- `PostCard` gains two optional props (`imageAspectRatio`, `dateLayout`) so the home page can adapt the card to its narrower 3-up layout without forking the component or regressing `/posts`.
- Drive-by on the patterns hub: stripped the `Press / to focus. Searches name, alternative names, summary, and layer.` hint paragraph and the decorative `<kbd>/</kbd>` badge inside the search input. The `/` keydown handler is kept; the UI just no longer advertises it.

## Screenshots

**Home page — desktop (1280)**

| Light | Dark |
| --- | --- |
| <img alt="home, light, desktop" src="https://github.com/user-attachments/assets/43e1cb5c-f477-4cb2-bf68-a634f8a30a2a" /> | <img alt="home, dark, desktop" src="https://github.com/user-attachments/assets/418b2e7d-808a-43dd-b665-eba5bda0ee4d" /> |

**Home page — mobile (390, dark)**

<img width="390" alt="home, dark, mobile" src="https://github.com/user-attachments/assets/c669cfb3-3c31-4aff-8348-7b831161129c" />

**Patterns hub — search input after stripping the `/` badge and hint**

<img alt="patterns hub search" src="https://github.com/user-attachments/assets/f4ca812f-532d-49b8-a0af-84ab9a977293" />

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm lint` — 0 errors (20 pre-existing warnings, none introduced)
- [x] `pnpm vitest run tests/unit/components/PostCard.test.tsx` — 9/9 pass
- [x] Manual dev drive: home page at desktop (1280) + mobile (390) viewports, both light and dark themes; agentic-design-patterns search verified working (typed + `/`-focused)
- [x] `/posts` page rendered to confirm `PostCard` defaults (`imageAspectRatio="4 / 1"`, `dateLayout="inline"`) preserve existing behavior
- [x] CI: lint, tsc, vitest, Next build, bundle size, CodeQL, all 4 E2E shards — all passing as of this edit

## Plan reference

Out of plan — UX polish in response to owner feedback during a working session. Hero treatment, voice register on the Explore tiles, the date/title stacking, and the patterns search hint were all surfaced and fixed interactively; no written plan exists.