### PR TITLE
chore(deps): ignore AI SDK semver-major bumps (keep sketches on v4)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,15 @@ updates:
           - "@types/*"
     labels:
       - "dependencies"
+    ignore:
+      # Keep the agentic-pattern teaching sketches on the AI SDK v4 API they
+      # document. `ai` / `@ai-sdk/*` are typecheck-only devDependencies with no
+      # shipped/runtime impact; the v6 majors break 7 sketches (maxSteps removed,
+      # tool() signature changed) for no benefit. See closed PR #314.
+      - dependency-name: "ai"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@ai-sdk/*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
  A["Dependabot weekly npm scan"] --> B{"ai / @ai-sdk/*<br/>update?"}
  B -->|"patch / minor (within v4 / v1)"| C["propose PR — fine,<br/>v4 API unchanged"]
  B -->|"semver-major (v6 / v3)"| D["IGNORE (new rule)<br/>— would break 7 typecheck sketches"]
  D -.->|"revisit only if sketches<br/>are rewritten to v6"| E["closed PR #314"]
```

## Summary

- **Why:** `ai` / `@ai-sdk/*` are **typecheck-only devDependencies** consumed by `scripts/typecheck-sketches.ts` to compile the agentic-pattern code samples. Those samples deliberately document the AI SDK **v4** API. The v6 majors (PR #314) break 7 sketches — `maxSteps` removed (→ `stopWhen: stepCountIs(n)`) and `tool()` signature changed (`parameters` → `inputSchema`) — for **no shipped/runtime benefit** (they aren't in the app bundle).
- **What:** add a `semver-major` ignore for `ai` and `@ai-sdk/*` to the npm ecosystem in `.github/dependabot.yml`. Patch/minor bumps within v4/v1 still flow normally.
- **Why config and not a comment:** `@dependabot ignore this major version` is unreliable on **grouped** PRs (the ai-sdk group has two packages); it produced no effect on #314. The `ignore` block is the documented, durable mechanism.

## Screenshots

N/A — not UI (CI config only).

## Test plan

- [x] `python3 -c "yaml.safe_load(...)"` — `.github/dependabot.yml` parses; npm `ignore` block present and correctly shaped.
- [x] Scope check: ignore is `version-update:semver-major` only, so patch/minor `ai`/`@ai-sdk` bumps within v4/v1 are unaffected.
- [ ] Behavioral confirmation deferred to Dependabot's next weekly run (it will no longer open the v6 major PR).

## Plan reference

Out of plan — dependency hygiene. Durable follow-up to the closed PR #314 (AI SDK v4→v6 major breaks 7 typecheck-only teaching sketches; maintainer chose to keep the sketches on v4).