### PR TITLE
perf: drop AVIF + raise Cloud Run CPU/mem to fix 5.4s home LCP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
           service: detached-node
           image: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/tech-blog/app:${{ github.sha }}
           region: ${{ vars.GCP_REGION }}
-          flags: '--allow-unauthenticated --min-instances=1 --max-instances=3 --cpu=1 --memory=512Mi --port=8080 --timeout=60s'
+          flags: '--allow-unauthenticated --min-instances=1 --max-instances=3 --cpu=2 --memory=1Gi --port=8080 --timeout=60s'
           env_vars: |
             NODE_ENV=production
             NEXT_PUBLIC_SERVER_URL=${{ vars.NEXT_PUBLIC_SERVER_URL }}

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,7 +13,7 @@ const nextConfig: NextConfig = {
 
   // Image optimization configuration
   images: {
-    formats: ['image/avif', 'image/webp'],
+    formats: ['image/webp'],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
     minimumCacheTTL: 31536000, // 1 year for immutable images


### PR DESCRIPTION
## Diagrams

N/A — config-only change (two lines: `next.config.ts` image formats + `deploy.yml` Cloud Run flags); no architecture or data-flow change to illustrate.

## Summary

Hotfix for a production incident: the home-page LCP is **5,406 ms** (Google "poor" is > 4,000 ms). TTFB is fine (129 ms, prerender cache HIT); the slow element is a featured-post card hero image (`PostCard → ThemeAwareHero`) optimized **on demand** by `/_next/image`. The trace showed a 4,723 ms load with only **12 ms** of download — so ~4.7 s is pure server-side encode wait on a `--cpu=1 --memory=512Mi`, CPU-throttled Cloud Run instance with an ephemeral optimizer cache and no CDN. `images.formats` lists AVIF first, the most CPU-expensive encode, which also starved sibling immutable JS chunks.

Two config changes:

1. **Drop AVIF** — `next.config.ts` `images.formats`: `['image/avif', 'image/webp']` → `['image/webp']`. Sources are already WebP; WebP encodes ~2–4× faster on 1 vCPU, and the larger WebP bytes are irrelevant when download was 12 ms.
2. **Give the origin CPU + memory** — `deploy.yml` Cloud Run flags: `--cpu=1 --memory=512Mi` → `--cpu=2 --memory=1Gi`. **CPU throttling left on** (still grants full CPU during the request, when the encode runs); `--no-cpu-throttling` deliberately **not** added (it only adds 24/7 instance billing for no encode-latency benefit).

Non-goals (unchanged here): no CDN (durable edge-cache tracked in #415), no `--no-cpu-throttling`, and **no JSX/component edits** — the home LCP image already sets `fetchPriority="high"`; this PR does not add `priority`/preload. All other deploy flags (`--allow-unauthenticated`, `--min-instances=1`, `--max-instances=3`, `--port=8080`, `--timeout=60s`) are untouched.

Closes #440

## Screenshots

N/A — not UI. This is a build-config + deploy-flag change with no markup difference.

## Test plan

Local gates run from the worktree:

- `pnpm lint` — **PASS** (0 errors; 19 pre-existing warnings, none from this change).
- `pnpm typecheck` (`tsc --noEmit`) — **PASS**.
- `pnpm test:unit` (`vitest run`) — **PASS** (710/710 tests, 49 files).
- `pnpm build` (`next build`) — **PASS** (exit 0; 67/67 static pages generated, full route table including `/`). Required `NEXT_PUBLIC_SERVER_URL` was supplied locally to satisfy the build-phase env guard (`src/lib/env/required-env.ts`), exactly as CI injects it.
- `pnpm test:e2e` (`playwright test`) — **DEFERRED-CI**: `globalSetup` runs `pnpm seed:test`, which needs a Postgres `DATABASE_URL` not available in this sandbox. The four required **E2E Shard x/4** checks (CI + Mergify-enforced) run on this PR. This is a config-only change with no JSX/behavioral edits, so E2E-exercised markup is unaffected.

**Post-merge verification (to record here after deploy):** re-run a Chrome DevTools trace of `/`; the LCP element is the first featured-post card image (`PostCard → ThemeAwareHero`). Expect LCP well under the prior ~5.4 s (target < ~2.5 s); note before/after.

## Plan reference

Out of plan — prod incident: home-page LCP 5.4s hotfix; durable CDN follow-up #415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
